### PR TITLE
New Data Source: aws_elasticache_snapshot

### DIFF
--- a/.changelog/49655.txt
+++ b/.changelog/49655.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_elasticache_snapshot
+```

--- a/internal/service/elasticache/service_package_gen.go
+++ b/internal/service/elasticache/service_package_gen.go
@@ -57,6 +57,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 			Name:     "Service Updates",
 			Region:   inttypes.ResourceRegionDefault(),
 		},
+		{
+			Factory:  newSnapshotDataSource,
+			TypeName: "aws_elasticache_snapshot",
+			Name:     "Snapshot",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
 	}
 }
 

--- a/internal/service/elasticache/snapshot_data_source.go
+++ b/internal/service/elasticache/snapshot_data_source.go
@@ -1,0 +1,276 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_elasticache_snapshot", name="Snapshot")
+func newSnapshotDataSource(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &snapshotDataSource{}, nil
+}
+
+type snapshotDataSource struct {
+	framework.DataSourceWithModel[snapshotDataSourceModel]
+}
+
+func (d *snapshotDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrARN: schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Computed:   true,
+			},
+			names.AttrAutoMinorVersionUpgrade: schema.BoolAttribute{
+				Computed: true,
+			},
+			"automatic_failover": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.AutomaticFailoverStatus](),
+				Computed:   true,
+			},
+			"cache_cluster_create_time": schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
+			"cluster_id": schema.StringAttribute{
+				Required: true,
+			},
+			"data_tiering": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.DataTieringStatus](),
+				Computed:   true,
+			},
+			"durability": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.Durability](),
+				Computed:   true,
+			},
+			names.AttrEngine: schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrEngineVersion: schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrKMSKeyID: schema.StringAttribute{
+				Computed: true,
+			},
+			"maintenance_window": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrMostRecent: schema.BoolAttribute{
+				Optional: true,
+			},
+			"node_snapshots": framework.DataSourceComputedListOfObjectAttribute[nodeSnapshotModel](ctx),
+			"node_type": schema.StringAttribute{
+				Computed: true,
+			},
+			"num_cache_nodes": schema.Int32Attribute{
+				Computed: true,
+			},
+			"num_node_groups": schema.Int32Attribute{
+				Computed: true,
+			},
+			names.AttrParameterGroupName: schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrPort: schema.Int32Attribute{
+				Computed: true,
+			},
+			"preferred_availability_zone": schema.StringAttribute{
+				Computed: true,
+			},
+			"preferred_outpost_arn": schema.StringAttribute{
+				Computed: true,
+			},
+			"replication_group_description": schema.StringAttribute{
+				Computed: true,
+			},
+			"replication_group_id": schema.StringAttribute{
+				Computed: true,
+			},
+			"snapshot_name": schema.StringAttribute{
+				Computed: true,
+			},
+			"snapshot_retention_limit": schema.Int32Attribute{
+				Computed: true,
+			},
+			"snapshot_source": schema.StringAttribute{
+				Computed: true,
+			},
+			"snapshot_window": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrStatus: schema.StringAttribute{
+				Computed: true,
+			},
+			"subnet_group_name": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrTopicARN: schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrVPCID: schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (d *snapshotDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data snapshotDataSourceModel
+	smerr.AddEnrich(ctx, &response.Diagnostics, request.Config.Get(ctx, &data))
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().ElastiCacheClient(ctx)
+
+	clusterID := data.CacheClusterID.ValueString()
+	input := elasticache.DescribeSnapshotsInput{
+		CacheClusterId:      aws.String(clusterID),
+		ShowNodeGroupConfig: aws.Bool(true),
+	}
+
+	snapshots, err := findSnapshots(ctx, conn, &input)
+	if err != nil && !retry.NotFound(err) {
+		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, clusterID)
+		return
+	}
+
+	if len(snapshots) == 0 {
+		smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("no ElastiCache Snapshot found matching cluster ID: %s", clusterID), smerr.ID, clusterID)
+		return
+	}
+
+	if len(snapshots) > 1 && !data.MostRecent.ValueBool() {
+		smerr.AddError(ctx, &response.Diagnostics, fmt.Errorf("multiple ElastiCache Snapshots matched cluster ID %s; set most_recent to true to select the newest", clusterID), smerr.ID, clusterID)
+		return
+	}
+
+	snapshot := mostRecentSnapshot(snapshots)
+
+	smerr.AddEnrich(ctx, &response.Diagnostics, flex.Flatten(ctx, &snapshot, &data), smerr.ID, clusterID)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &response.Diagnostics, response.State.Set(ctx, &data), smerr.ID, clusterID)
+}
+
+type snapshotDataSourceModel struct {
+	framework.WithRegionModel
+	ARN                         fwtypes.ARN                                          `tfsdk:"arn"`
+	AutoMinorVersionUpgrade     types.Bool                                           `tfsdk:"auto_minor_version_upgrade"`
+	AutomaticFailover           fwtypes.StringEnum[awstypes.AutomaticFailoverStatus] `tfsdk:"automatic_failover"`
+	CacheClusterCreateTime      timetypes.RFC3339                                    `tfsdk:"cache_cluster_create_time"`
+	CacheClusterID              types.String                                         `tfsdk:"cluster_id"`
+	CacheNodeType               types.String                                         `tfsdk:"node_type"`
+	CacheParameterGroupName     types.String                                         `tfsdk:"parameter_group_name"`
+	CacheSubnetGroupName        types.String                                         `tfsdk:"subnet_group_name"`
+	DataTiering                 fwtypes.StringEnum[awstypes.DataTieringStatus]       `tfsdk:"data_tiering"`
+	Durability                  fwtypes.StringEnum[awstypes.Durability]              `tfsdk:"durability"`
+	Engine                      types.String                                         `tfsdk:"engine"`
+	EngineVersion               types.String                                         `tfsdk:"engine_version"`
+	KmsKeyID                    types.String                                         `tfsdk:"kms_key_id"`
+	MostRecent                  types.Bool                                           `tfsdk:"most_recent" autoflex:"-"`
+	NodeSnapshots               fwtypes.ListNestedObjectValueOf[nodeSnapshotModel]   `tfsdk:"node_snapshots"`
+	NumCacheNodes               types.Int32                                          `tfsdk:"num_cache_nodes"`
+	NumNodeGroups               types.Int32                                          `tfsdk:"num_node_groups"`
+	Port                        types.Int32                                          `tfsdk:"port"`
+	PreferredAvailabilityZone   types.String                                         `tfsdk:"preferred_availability_zone"`
+	PreferredMaintenanceWindow  types.String                                         `tfsdk:"maintenance_window"`
+	PreferredOutpostARN         types.String                                         `tfsdk:"preferred_outpost_arn"`
+	ReplicationGroupDescription types.String                                         `tfsdk:"replication_group_description"`
+	ReplicationGroupID          types.String                                         `tfsdk:"replication_group_id"`
+	SnapshotName                types.String                                         `tfsdk:"snapshot_name"`
+	SnapshotRetentionLimit      types.Int32                                          `tfsdk:"snapshot_retention_limit"`
+	SnapshotSource              types.String                                         `tfsdk:"snapshot_source"`
+	SnapshotStatus              types.String                                         `tfsdk:"status"`
+	SnapshotWindow              types.String                                         `tfsdk:"snapshot_window"`
+	TopicARN                    types.String                                         `tfsdk:"topic_arn"`
+	VpcID                       types.String                                         `tfsdk:"vpc_id"`
+}
+
+type nodeSnapshotModel struct {
+	CacheClusterID         types.String                                                 `tfsdk:"cache_cluster_id"`
+	CacheNodeCreateTime    timetypes.RFC3339                                            `tfsdk:"cache_node_create_time"`
+	CacheNodeID            types.String                                                 `tfsdk:"cache_node_id"`
+	CacheSize              types.String                                                 `tfsdk:"cache_size"`
+	NodeGroupConfiguration fwtypes.ListNestedObjectValueOf[nodeGroupConfigurationModel] `tfsdk:"node_group_configuration"`
+	NodeGroupID            types.String                                                 `tfsdk:"node_group_id"`
+	SnapshotCreateTime     timetypes.RFC3339                                            `tfsdk:"snapshot_create_time"`
+}
+
+type nodeGroupConfigurationModel struct {
+	NodeGroupID              types.String                      `tfsdk:"node_group_id"`
+	PrimaryAvailabilityZone  types.String                      `tfsdk:"primary_availability_zone"`
+	PrimaryOutpostARN        types.String                      `tfsdk:"primary_outpost_arn"`
+	ReplicaAvailabilityZones fwtypes.ListValueOf[types.String] `tfsdk:"replica_availability_zones"`
+	ReplicaCount             types.Int32                       `tfsdk:"replica_count"`
+	ReplicaOutpostARNs       fwtypes.ListValueOf[types.String] `tfsdk:"replica_outpost_arns"`
+	Slots                    types.String                      `tfsdk:"slots"`
+}
+
+func findSnapshots(ctx context.Context, conn *elasticache.Client, input *elasticache.DescribeSnapshotsInput) ([]awstypes.Snapshot, error) {
+	var output []awstypes.Snapshot
+
+	pages := elasticache.NewDescribeSnapshotsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if errs.IsA[*awstypes.SnapshotNotFoundFault](err) {
+			return nil, &retry.NotFoundError{
+				LastError: err,
+			}
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, page.Snapshots...)
+	}
+
+	return output, nil
+}
+
+// snapshotCreateTime returns the latest node snapshot create time (Snapshot has no top-level one), falling back to the cluster create time.
+func snapshotCreateTime(snapshot awstypes.Snapshot) time.Time {
+	var latest time.Time
+	for _, nodeSnapshot := range snapshot.NodeSnapshots {
+		if t := aws.ToTime(nodeSnapshot.SnapshotCreateTime); t.After(latest) {
+			latest = t
+		}
+	}
+
+	if latest.IsZero() {
+		latest = aws.ToTime(snapshot.CacheClusterCreateTime)
+	}
+
+	return latest
+}
+
+// mostRecentSnapshot returns the newest snapshot by creation time; the caller must ensure the slice is non-empty.
+func mostRecentSnapshot(snapshots []awstypes.Snapshot) awstypes.Snapshot {
+	return slices.MaxFunc(snapshots, func(a, b awstypes.Snapshot) int {
+		return snapshotCreateTime(a).Compare(snapshotCreateTime(b))
+	})
+}

--- a/internal/service/elasticache/snapshot_data_source_test.go
+++ b/internal/service/elasticache/snapshot_data_source_test.go
@@ -1,0 +1,132 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccElastiCacheSnapshotDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	dataSourceName := "data.aws_elasticache_snapshot.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Create the cache cluster first so a snapshot can be taken from it.
+				Config: testAccSnapshotDataSourceConfig_cluster(rName),
+			},
+			{
+				// The provider has no aws_elasticache_snapshot resource, so create the
+				// snapshot out-of-band before reading it through the data source.
+				PreConfig: func() {
+					testAccCreateSnapshot(ctx, t, rName, rName)
+				},
+				Config: testAccSnapshotDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_id", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "snapshot_name", rName),
+					acctest.MatchResourceAttrRegionalARN(ctx, dataSourceName, names.AttrARN, "elasticache", regexache.MustCompile("snapshot:"+rName+"$")),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrEngine, "redis"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "node_type"),
+					resource.TestCheckResourceAttr(dataSourceName, "snapshot_source", "manual"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "node_snapshots.#"),
+				),
+			},
+		},
+	})
+}
+
+// testAccCreateSnapshot creates a snapshot from the cluster via the AWS API, waits for it to become available, and registers cleanup to delete it.
+func testAccCreateSnapshot(ctx context.Context, t *testing.T, clusterID, snapshotName string) {
+	t.Helper()
+
+	conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
+
+	_, err := conn.CreateSnapshot(ctx, &elasticache.CreateSnapshotInput{
+		CacheClusterId: aws.String(clusterID),
+		SnapshotName:   aws.String(snapshotName),
+	})
+	if err != nil {
+		t.Fatalf("creating ElastiCache Snapshot (%s): %s", snapshotName, err)
+	}
+
+	t.Cleanup(func() {
+		// The test context is canceled by the time cleanup runs, so use a non-canceled context.
+		_, err := conn.DeleteSnapshot(context.WithoutCancel(ctx), &elasticache.DeleteSnapshotInput{
+			SnapshotName: aws.String(snapshotName),
+		})
+		if err != nil && !errs.IsA[*awstypes.SnapshotNotFoundFault](err) {
+			t.Logf("deleting ElastiCache Snapshot (%s): %s", snapshotName, err)
+		}
+	})
+
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{"creating"},
+		Target:     []string{"available"},
+		Timeout:    40 * time.Minute,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+		Refresh: func(ctx context.Context) (any, string, error) {
+			output, err := conn.DescribeSnapshots(ctx, &elasticache.DescribeSnapshotsInput{
+				SnapshotName: aws.String(snapshotName),
+			})
+			if err != nil {
+				return nil, "", err
+			}
+			if len(output.Snapshots) == 0 {
+				return nil, "", nil
+			}
+
+			snapshot := output.Snapshots[0]
+			return snapshot, aws.ToString(snapshot.SnapshotStatus), nil
+		},
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		t.Fatalf("waiting for ElastiCache Snapshot (%s) to become available: %s", snapshotName, err)
+	}
+}
+
+func testAccSnapshotDataSourceConfig_cluster(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_cluster" "test" {
+  cluster_id      = %[1]q
+  engine          = "redis"
+  node_type       = "cache.t3.small"
+  num_cache_nodes = 1
+}
+`, rName)
+}
+
+func testAccSnapshotDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccSnapshotDataSourceConfig_cluster(rName), `
+data "aws_elasticache_snapshot" "test" {
+  cluster_id  = aws_elasticache_cluster.test.cluster_id
+  most_recent = true
+}
+`)
+}

--- a/website/docs/d/elasticache_snapshot.html.markdown
+++ b/website/docs/d/elasticache_snapshot.html.markdown
@@ -1,0 +1,92 @@
+---
+subcategory: "ElastiCache"
+layout: "aws"
+page_title: "AWS: aws_elasticache_snapshot"
+description: |-
+  Provides information about an ElastiCache Snapshot for a cache cluster.
+---
+
+# Data Source: aws_elasticache_snapshot
+
+Provides information about an ElastiCache Snapshot taken from a cache cluster.
+
+Use this data source to discover a snapshot for a given cache cluster so it can be referenced
+elsewhere in a configuration, for example to recreate an `aws_elasticache_cluster` from its most
+recent snapshot. Discovery works even after the source cluster has been deleted, because snapshot
+metadata persists.
+
+~> **Note:** This data source looks up snapshots by `cluster_id` (the `CacheClusterId` filter of
+the `DescribeSnapshots` API), so it returns only snapshots taken from a cache cluster. Snapshots
+taken from a replication group are not returned; for those, `replication_group_id` is empty.
+
+## Example Usage
+
+```terraform
+data "aws_elasticache_snapshot" "latest" {
+  cluster_id  = "example-cluster"
+  most_recent = true
+}
+
+resource "aws_elasticache_cluster" "example" {
+  cluster_id      = "example-cluster"
+  engine          = "redis"
+  node_type       = "cache.t3.small"
+  num_cache_nodes = 1
+  snapshot_name   = data.aws_elasticache_snapshot.latest.snapshot_name
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `cluster_id` - (Required) User-supplied identifier of the source cache cluster whose snapshots are described.
+* `most_recent` - (Optional) If more than one snapshot matches, return the most recent one. Defaults to `false`, in which case matching more than one snapshot is an error.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the snapshot.
+* `auto_minor_version_upgrade` - Whether minor version engine upgrades are applied automatically to the source cluster.
+* `automatic_failover` - Status of automatic failover for the source replication group.
+* `cache_cluster_create_time` - Date and time when the source cluster was created.
+* `data_tiering` - Whether data tiering is enabled.
+* `durability` - Durability setting of the cluster when the snapshot was taken.
+* `engine` - Name of the cache engine used by the source cluster.
+* `engine_version` - Version of the cache engine used by the source cluster.
+* `kms_key_id` - ID of the KMS key used to encrypt the snapshot.
+* `maintenance_window` - Weekly time range during which maintenance on the source cluster is performed.
+* `node_snapshots` - List of the cache nodes in the source cluster. Each element exports the following:
+    * `cache_cluster_id` - Unique identifier for the source cluster.
+    * `cache_node_create_time` - Date and time when the cache node was created in the source cluster.
+    * `cache_node_id` - Cache node identifier for the node in the source cluster.
+    * `cache_size` - Size of the cache on the source cache node.
+    * `node_group_configuration` - Configuration for the source node group (shard). Each element exports the following:
+        * `node_group_id` - Identifier for the node group (shard).
+        * `primary_availability_zone` - Availability Zone where the primary node of this node group is launched.
+        * `primary_outpost_arn` - Outpost ARN of the primary node.
+        * `replica_availability_zones` - List of Availability Zones used for the read replicas.
+        * `replica_count` - Number of read replica nodes in this node group (shard).
+        * `replica_outpost_arns` - List of Outpost ARNs of the node replicas.
+        * `slots` - Keyspace for this node group (shard), in the format `startkey-endkey`.
+    * `node_group_id` - Unique identifier for the source node group (shard).
+    * `snapshot_create_time` - Date and time when the source node's metadata and cache data set was obtained for the snapshot.
+* `node_type` - Compute and memory capacity of the nodes in the source cluster.
+* `num_cache_nodes` - Number of cache nodes in the source cluster.
+* `num_node_groups` - Number of node groups (shards) in the snapshot.
+* `parameter_group_name` - Cache parameter group associated with the source cluster.
+* `port` - Port number used by each cache node in the source cluster.
+* `preferred_availability_zone` - Availability Zone in which the source cluster is located.
+* `preferred_outpost_arn` - ARN of the preferred Outpost.
+* `replication_group_description` - Description of the source replication group. Empty for cluster snapshots.
+* `replication_group_id` - Identifier of the source replication group. Empty for cluster snapshots.
+* `snapshot_name` - Name of the snapshot.
+* `snapshot_retention_limit` - Number of days for which ElastiCache retains automatic snapshots before deleting them.
+* `snapshot_source` - Whether the snapshot is from an automatic backup (`automated`) or was created manually (`manual`).
+* `snapshot_window` - Daily time range during which ElastiCache takes daily snapshots of the source cluster.
+* `status` - Status of the snapshot.
+* `subnet_group_name` - Cache subnet group associated with the source cluster.
+* `topic_arn` - ARN of the topic used by the source cluster for publishing notifications.
+* `vpc_id` - VPC in which the source cluster exists.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds a new `aws_elasticache_snapshot` data source that discovers an existing ElastiCache cache-cluster snapshot via the `DescribeSnapshots` API, resolving it by `cluster_id` (with `most_recent` to pick the newest when several exist) and exposing its metadata, most importantly `snapshot_name` for feeding into `aws_elasticache_cluster.snapshot_name` to recreate a cluster from its own snapshot. 
It is scoped to the `CacheClusterId` filter so replication-group snapshots are never returned (though `replication_group_id` is still exposed, empty for cluster snapshots), exposes nested `node_snapshots`/`node_group_configuration`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28984

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheSnapshotDataSource
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-elasticahe-snapshot-datasource 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheSnapshotDataSource'  -timeout 360m -vet=off -buildvcs=false
2026/08/24 10:07:43 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/24 10:07:43 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheSnapshotDataSource_basic
=== PAUSE TestAccElastiCacheSnapshotDataSource_basic
=== CONT  TestAccElastiCacheSnapshotDataSource_basic
--- PASS: TestAccElastiCacheSnapshotDataSource_basic (637.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        643.480s
```

### AI Usage Disclosure
Implemented with the help of an LLM agent (Kiro); I have reviewed and
understand all of the changes.