### PR TITLE
r/aws_observabilityadmin_centralization_rule_for_organization: add tag_propagation_configuration

### DIFF
--- a/.changelog/49656.txt
+++ b/.changelog/49656.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_observabilityadmin_centralization_rule_for_organization: Add `tag_propagation_configuration` configuration block to `rule.destination.destination_logs_configuration`, and `tag_propagation_status` and `tag_propagation_failure_reason` attributes
+```

--- a/internal/service/observabilityadmin/centralization_rule_for_organization.go
+++ b/internal/service/observabilityadmin/centralization_rule_for_organization.go
@@ -72,6 +72,18 @@ func (r *centralizationRuleForOrganizationResource) Schema(ctx context.Context, 
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"tag_propagation_failure_reason": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"tag_propagation_status": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
@@ -178,6 +190,24 @@ func (r *centralizationRuleForOrganizationResource) Schema(ctx context.Context, 
 															names.AttrKMSKeyARN: schema.StringAttribute{
 																CustomType: fwtypes.ARNType,
 																Optional:   true,
+															},
+														},
+													},
+												},
+												"tag_propagation_configuration": schema.ListNestedBlock{
+													CustomType: fwtypes.NewListNestedObjectTypeOf[tagPropagationConfigurationModel](ctx),
+													Validators: []validator.List{
+														listvalidator.SizeAtMost(1),
+													},
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															"destination_role_arn": schema.StringAttribute{
+																CustomType: fwtypes.ARNType,
+																Required:   true,
+															},
+															"tag_conflict_resolution_strategy": schema.StringAttribute{
+																Optional:   true,
+																CustomType: fwtypes.StringEnumType[awstypes.TagConflictResolutionStrategy](),
 															},
 														},
 													},
@@ -529,12 +559,14 @@ func waitCentralizationRuleForOrganizationHealthy(ctx context.Context, conn *obs
 
 type centralizationRuleForOrganizationResourceModel struct {
 	framework.WithRegionModel
-	Rule     fwtypes.ListNestedObjectValueOf[centralizationRuleModel] `tfsdk:"rule"`
-	RuleARN  types.String                                             `tfsdk:"rule_arn"`
-	RuleName types.String                                             `tfsdk:"rule_name"`
-	Tags     tftags.Map                                               `tfsdk:"tags"`
-	TagsAll  tftags.Map                                               `tfsdk:"tags_all"`
-	Timeouts timeouts.Value                                           `tfsdk:"timeouts"`
+	Rule                        fwtypes.ListNestedObjectValueOf[centralizationRuleModel] `tfsdk:"rule"`
+	RuleARN                     types.String                                             `tfsdk:"rule_arn"`
+	RuleName                    types.String                                             `tfsdk:"rule_name"`
+	TagPropagationFailureReason types.String                                             `tfsdk:"tag_propagation_failure_reason"`
+	TagPropagationStatus        types.String                                             `tfsdk:"tag_propagation_status"`
+	Tags                        tftags.Map                                               `tfsdk:"tags"`
+	TagsAll                     tftags.Map                                               `tfsdk:"tags_all"`
+	Timeouts                    timeouts.Value                                           `tfsdk:"timeouts"`
 }
 
 type centralizationRuleModel struct {
@@ -560,6 +592,12 @@ type destinationLogsConfigurationModel struct {
 	BackupConfiguration         fwtypes.ListNestedObjectValueOf[logsBackupConfigurationModel]     `tfsdk:"backup_configuration"`
 	LogGroupNameConfiguration   fwtypes.ListNestedObjectValueOf[logGroupNameConfigurationModel]   `tfsdk:"log_group_name_configuration"`
 	LogsEncryptionConfiguration fwtypes.ListNestedObjectValueOf[logsEncryptionConfigurationModel] `tfsdk:"logs_encryption_configuration"`
+	TagPropagationConfiguration fwtypes.ListNestedObjectValueOf[tagPropagationConfigurationModel] `tfsdk:"tag_propagation_configuration"`
+}
+
+type tagPropagationConfigurationModel struct {
+	DestinationRoleARN            fwtypes.ARN                                                `tfsdk:"destination_role_arn"`
+	TagConflictResolutionStrategy fwtypes.StringEnum[awstypes.TagConflictResolutionStrategy] `tfsdk:"tag_conflict_resolution_strategy"`
 }
 
 type sourceLogsConfigurationModel struct {

--- a/internal/service/observabilityadmin/centralization_rule_for_organization_test.go
+++ b/internal/service/observabilityadmin/centralization_rule_for_organization_test.go
@@ -206,7 +206,8 @@ func TestAccObservabilityAdminCentralizationRuleForOrganization_update(t *testin
 								"logs_encryption_configuration": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectPartial(map[string]knownvalue.Check{
 									"encryption_strategy": tfknownvalue.StringExact(awstypes.EncryptionStrategyAwsOwned),
 								})}),
-								"log_group_name_configuration": knownvalue.ListSizeExact(0),
+								"log_group_name_configuration":  knownvalue.ListSizeExact(0),
+								"tag_propagation_configuration": knownvalue.ListSizeExact(0),
 							})}),
 							names.AttrRegion: knownvalue.StringExact(endpoints.EuWest1RegionID),
 						})}),
@@ -286,6 +287,72 @@ func TestAccObservabilityAdminCentralizationRuleForOrganization_encryptionScope(
 							AtMapKey("logs_encryption_configuration").AtSliceIndex(0).
 							AtMapKey("encryption_scope"),
 						tfknownvalue.StringExact(awstypes.EncryptionScopeEncryptedSourceOnly)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccObservabilityAdminCentralizationRuleForOrganization_tagPropagation(t *testing.T) {
+	ctx := acctest.Context(t)
+	var rule observabilityadmin.GetCentralizationRuleForOrganizationOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_observabilityadmin_centralization_rule_for_organization.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			acctest.PreCheckIAMServiceLinkedRole(ctx, t, "/aws-service-role/observabilityadmin.amazonaws.com")
+			acctest.PreCheckOrganizationsEnabledServicePrincipal(ctx, t, "observabilityadmin.amazonaws.com")
+			acctest.PreCheckIAMServiceLinkedRole(ctx, t, "/aws-service-role/logs-centralization.observabilityadmin.amazonaws.com")
+			acctest.PreCheckPartition(t, endpoints.AwsPartitionID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ObservabilityAdminServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCentralizationRuleForOrganizationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCentralizationRuleForOrganizationConfig_tagPropagation(rName, acctest.Region(), string(awstypes.TagConflictResolutionStrategyInSync)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCentralizationRuleForOrganizationExists(ctx, t, resourceName, &rule),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName,
+						tfjsonpath.New(names.AttrRule).AtSliceIndex(0).
+							AtMapKey(names.AttrDestination).AtSliceIndex(0).
+							AtMapKey("destination_logs_configuration").AtSliceIndex(0).
+							AtMapKey("tag_propagation_configuration").AtSliceIndex(0).
+							AtMapKey("tag_conflict_resolution_strategy"),
+						tfknownvalue.StringExact(awstypes.TagConflictResolutionStrategyInSync)),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "rule_name"),
+				ImportStateVerifyIdentifierAttribute: "rule_name",
+			},
+			{
+				Config: testAccCentralizationRuleForOrganizationConfig_tagPropagation(rName, acctest.Region(), string(awstypes.TagConflictResolutionStrategyAddOnly)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCentralizationRuleForOrganizationExists(ctx, t, resourceName, &rule),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName,
+						tfjsonpath.New(names.AttrRule).AtSliceIndex(0).
+							AtMapKey(names.AttrDestination).AtSliceIndex(0).
+							AtMapKey("destination_logs_configuration").AtSliceIndex(0).
+							AtMapKey("tag_propagation_configuration").AtSliceIndex(0).
+							AtMapKey("tag_conflict_resolution_strategy"),
+						tfknownvalue.StringExact(awstypes.TagConflictResolutionStrategyAddOnly)),
 				},
 			},
 		},
@@ -615,6 +682,62 @@ resource "aws_observabilityadmin_centralization_rule_for_organization" "test" {
   }
 }
 `, rName, dstRegion, bkupRegion, acctest.ListOfStrings(srcRegions...))
+}
+
+func testAccCentralizationRuleForOrganizationConfig_tagPropagation(rName, region, tagConflictResolutionStrategy string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_organizations_organization" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "logs.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_observabilityadmin_centralization_rule_for_organization" "test" {
+  rule_name = %[1]q
+
+  rule {
+    destination {
+      region  = %[2]q
+      account = data.aws_caller_identity.current.account_id
+
+      destination_logs_configuration {
+        logs_encryption_configuration {
+          encryption_strategy = "AWS_OWNED"
+        }
+
+        log_group_name_configuration {
+          log_group_name_pattern = "/central/$${source.accountId}/$${source.region}/$${source.logGroup}"
+        }
+
+        tag_propagation_configuration {
+          destination_role_arn             = aws_iam_role.test.arn
+          tag_conflict_resolution_strategy = %[3]q
+        }
+      }
+    }
+
+    source {
+      regions = [%[2]q]
+      scope   = "OrganizationId = '${data.aws_organizations_organization.current.id}'"
+
+      source_logs_configuration {
+        encrypted_log_group_strategy = "ALLOW"
+        log_group_selection_criteria = "LogGroupName LIKE '/aws/lambda%%'"
+      }
+    }
+  }
+}
+`, rName, region, tagConflictResolutionStrategy)
 }
 
 func testAccCentralizationRuleForOrganizationConfig_encryptionScope(rName, encryptionScope, region string) string {

--- a/website/docs/r/observabilityadmin_centralization_rule_for_organization.html.markdown
+++ b/website/docs/r/observabilityadmin_centralization_rule_for_organization.html.markdown
@@ -192,6 +192,7 @@ The following arguments are optional:
 * `backup_configuration` - (Optional) Configuration block for backup settings. See [`backup_configuration`](#backup_configuration) below.
 * `log_group_name_configuration` - (Optional) Configuration block for a naming pattern for destination log groups created during centralization. See [`log_group_name_configuration`](#log_group_name_configuration) below.
 * `logs_encryption_configuration` - (Optional) Configuration block for logs encryption settings. See [`logs_encryption_configuration`](#logs_encryption_configuration) below.
+* `tag_propagation_configuration` - (Optional) Configuration block for propagating source resource tags to centralized destination log groups. See [`tag_propagation_configuration`](#tag_propagation_configuration) below.
 
 ##### backup_configuration
 
@@ -208,6 +209,11 @@ The following arguments are optional:
 * `encryption_conflict_resolution_strategy` - (Optional) Strategy for resolving encryption conflicts. Valid values: `ALLOW`, `SKIP`.
 * `encryption_scope` - (Optional) Determines which newly created destination log groups are encrypted with `kms_key_arn` when `encryption_strategy` is `CUSTOMER_MANAGED`. Valid values: `ENCRYPTED_SOURCE_ONLY` (default), `NEW_DESTINATION_LOG_GROUPS`. Not valid when `encryption_strategy` is `AWS_OWNED`.
 * `kms_key_arn` - (Optional) ARN of the KMS key to use for encryption when `encryption_strategy` is `CUSTOMER_MANAGED`.
+
+##### tag_propagation_configuration
+
+* `destination_role_arn` - (Required) ARN of the IAM role that the service assumes to propagate source resource tags to centralized destination log groups.
+* `tag_conflict_resolution_strategy` - (Optional) Strategy for resolving tag conflicts when propagating tags to destination log groups. Valid values: `IN_SYNC`, `ADD_ONLY`, `UPDATE_SYNC`.
 
 #### destination_metrics_configuration
 
@@ -239,6 +245,8 @@ The following arguments are optional:
 This resource exports the following attributes in addition to the arguments above:
 
 * `rule_arn` - ARN of the centralization rule.
+* `tag_propagation_status` - Health status of tag propagation for the rule (for example, `Healthy` or `Unhealthy`). Independent of the overall rule health.
+* `tag_propagation_failure_reason` - Reason tag propagation is unhealthy, when applicable (for example, `RoleNotAssumable` or `RoleLacksPermissions`).
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts


### PR DESCRIPTION
### Description

Adds tag propagation support to `aws_observabilityadmin_centralization_rule_for_organization`.

A new `tag_propagation_configuration` block on
`rule.destination.destination_logs_configuration` lets a centralization rule propagate
source resource tags to the centralized destination log groups:

- `destination_role_arn` - (Required) IAM role the service assumes to propagate tags.
- `tag_conflict_resolution_strategy` - (Optional) `IN_SYNC` | `ADD_ONLY` | `UPDATE_SYNC`.

It also exposes the two read-only tag-propagation health attributes returned by
`GetCentralizationRuleForOrganization`:

- `tag_propagation_status` (`Healthy` | `Unhealthy`)
- `tag_propagation_failure_reason` (`RoleNotAssumable` | `RoleLacksPermissions`)

These are modeled as Computed plain strings (not enums) so future service-side values do
not break `plan`/`refresh`. AutoFlex maps the write block; the resource's existing
read-back on create populates the Computed attributes.

### References

* `aws-sdk-go-v2/service/observabilityadmin` `TagPropagationConfiguration`, `TagPropagationStatus`, `TagPropagationFailureReason`
* [Announcement](https://aws.amazon.com/about-aws/whats-new/2026/08/amazon-cloudwatch-centralization-tag-propogation/)

### Output from Acceptance Testing

Full `TestAccObservabilityAdminCentralizationRuleForOrganization*` suite (9 tests) against a
real AWS Organizations management account:

```console
$ make testacc PKG=observabilityadmin TESTS=TestAccObservabilityAdminCentralizationRuleForOrganization

--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_disappears (42.71s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_metricsConfiguration (48.20s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_basic (54.50s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_tagPropagation (78.37s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_encryptionScope (81.84s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_tags (88.50s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_dataSourceSelectionCriteria (274.04s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_destinationLogGroupNameConfiguration (274.09s)
--- PASS: TestAccObservabilityAdminCentralizationRuleForOrganization_update (278.71s)
PASS
```

Note: when `tag_propagation_configuration` is set, the API requires a
`log_group_name_configuration` whose pattern contains the `${source.logGroup}`,
`${source.accountId}`, and `${source.region}` macros; the acceptance test reflects this.
