### PR TITLE
New PlanModifier: `tfsetplanmodifier.RequiresReplaceIfElementsDeleted`

### DIFF
--- a/internal/framework/flex/set.go
+++ b/internal/framework/flex/set.go
@@ -5,6 +5,7 @@ package flex
 
 import (
 	"context"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -32,18 +33,10 @@ func DiffSets(ctx context.Context, a, b types.Set) types.Set {
 
 	var diff []attr.Value
 	for _, av := range aElems {
-		inB := false
-		for _, bv := range bElems {
-			if av.Equal(bv) {
-				inB = true
-				break
-			}
-		}
-		if !inB {
+		if inB := slices.ContainsFunc(bElems, av.Equal); !inB {
 			diff = append(diff, av)
 		}
 	}
-
 	if diff == nil {
 		diff = []attr.Value{}
 	}

--- a/internal/framework/flex/set.go
+++ b/internal/framework/flex/set.go
@@ -14,6 +14,43 @@ import (
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 )
 
+// DiffSets returns the set difference a\b: elements present in a but absent in b.
+// Neither a nor b may be Unknown. A Null value is treated as an empty set.
+// The returned set uses the element type of a.
+func DiffSets(ctx context.Context, a, b types.Set) types.Set {
+	elemType := a.ElementType(ctx)
+
+	aElems := a.Elements()
+	if len(aElems) == 0 {
+		return types.SetValueMust(elemType, []attr.Value{})
+	}
+
+	bElems := b.Elements()
+	if len(bElems) == 0 {
+		return types.SetValueMust(elemType, aElems)
+	}
+
+	var diff []attr.Value
+	for _, av := range aElems {
+		inB := false
+		for _, bv := range bElems {
+			if av.Equal(bv) {
+				inB = true
+				break
+			}
+		}
+		if !inB {
+			diff = append(diff, av)
+		}
+	}
+
+	if diff == nil {
+		diff = []attr.Value{}
+	}
+
+	return types.SetValueMust(elemType, diff)
+}
+
 func ExpandFrameworkStringValueSet(ctx context.Context, v basetypes.SetValuable) inttypes.Set[string] {
 	return ExpandFrameworkStringyValueSet[string](ctx, v)
 }

--- a/internal/framework/flex/set_test.go
+++ b/internal/framework/flex/set_test.go
@@ -14,6 +14,106 @@ import (
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 )
 
+func TestDiffSets(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		a, b     types.Set
+		expected types.Set
+	}
+	tests := map[string]testCase{
+		"both null treated as empty": {
+			a:        types.SetNull(types.StringType),
+			b:        types.SetNull(types.StringType),
+			expected: types.SetValueMust(types.StringType, []attr.Value{}),
+		},
+		"a null b non-empty": {
+			a: types.SetNull(types.StringType),
+			b: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("x"),
+			}),
+			expected: types.SetValueMust(types.StringType, []attr.Value{}),
+		},
+		"a non-empty b null": {
+			a: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("x"),
+				types.StringValue("y"),
+			}),
+			b:        types.SetNull(types.StringType),
+			expected: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("x"), types.StringValue("y")}),
+		},
+		"disjoint sets": {
+			a: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("a"),
+				types.StringValue("b"),
+			}),
+			b: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("c"),
+				types.StringValue("d"),
+			}),
+			expected: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("a"),
+				types.StringValue("b"),
+			}),
+		},
+		"a subset of b": {
+			a: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("a"),
+				types.StringValue("b"),
+			}),
+			b: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("a"),
+				types.StringValue("b"),
+				types.StringValue("c"),
+			}),
+			expected: types.SetValueMust(types.StringType, []attr.Value{}),
+		},
+		"partial overlap": {
+			a: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("a"),
+				types.StringValue("b"),
+				types.StringValue("c"),
+			}),
+			b: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("b"),
+				types.StringValue("d"),
+			}),
+			expected: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("a"),
+				types.StringValue("c"),
+			}),
+		},
+		"equal sets": {
+			a: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("a"),
+				types.StringValue("b"),
+			}),
+			b: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("a"),
+				types.StringValue("b"),
+			}),
+			expected: types.SetValueMust(types.StringType, []attr.Value{}),
+		},
+		"both empty": {
+			a:        types.SetValueMust(types.StringType, []attr.Value{}),
+			b:        types.SetValueMust(types.StringType, []attr.Value{}),
+			expected: types.SetValueMust(types.StringType, []attr.Value{}),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.DiffSets(context.Background(), test.a, test.b)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestExpandFrameworkStringValueSet(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/planmodifiers/listplanmodifier/requires_replace_if_emptied.go
+++ b/internal/framework/planmodifiers/listplanmodifier/requires_replace_if_emptied.go
@@ -11,7 +11,7 @@ import (
 	fwplanmodifiers "github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers"
 )
 
-// RequiresReplaceIfEmptied returns a plan modifier requires resource replacement if:
+// RequiresReplaceIfEmptied returns a plan modifier that requires resource replacement if:
 //   - The resource is planned for update.
 //   - The plan and state values are not equal.
 //   - The state value is a non-empty list.

--- a/internal/framework/planmodifiers/setplanmodifier/requires_replace_if_elements_deleted.go
+++ b/internal/framework/planmodifiers/setplanmodifier/requires_replace_if_elements_deleted.go
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package setplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+// RequiresReplaceIfElementsDeleted returns a plan modifier that requires resource replacement if:
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The state value contains elements that are not present in the plan value.
+var RequiresReplaceIfElementsDeleted planmodifier.Set = setplanmodifier.RequiresReplaceIf(func(ctx context.Context, request planmodifier.SetRequest, response *setplanmodifier.RequiresReplaceIfFuncResponse) {
+	// Do nothing if there is an unknown planned value.
+	if request.PlanValue.IsUnknown() {
+		return
+	}
+
+	if diff := fwflex.DiffSets(ctx, request.StateValue, request.PlanValue); diff.Length(fwtypes.CollectionLengthUnhandledAsZero) > 0 {
+		response.RequiresReplace = true
+	}
+}, requiresReplaceIfElementsDeletedDescription, requiresReplaceIfElementsDeletedDescription)
+
+const requiresReplaceIfElementsDeletedDescription = `If the previous value of this attribute contains elements that are not present in the planned value, Terraform will destroy and recreate the resource.`

--- a/internal/framework/planmodifiers/setplanmodifier/requires_replace_if_elements_deleted_test.go
+++ b/internal/framework/planmodifiers/setplanmodifier/requires_replace_if_elements_deleted_test.go
@@ -1,0 +1,213 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package setplanmodifier_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	tfsetplanmodifier "github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/setplanmodifier"
+)
+
+func TestRequiresReplaceIfElementsDeleted(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		request  planmodifier.SetRequest
+		expected planmodifier.SetResponse
+	}
+
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"value": schema.SetAttribute{
+				ElementType: types.StringType,
+			},
+		},
+	}
+	nullState := tfsdk.State{
+		Schema: testSchema,
+		Raw: tftypes.NewValue(
+			testSchema.Type().TerraformType(t.Context()),
+			nil,
+		),
+	}
+	testPlan := func(value types.Set) tfsdk.Plan {
+		tfValue, err := value.ToTerraformValue(t.Context())
+
+		if err != nil {
+			panic("ToTerraformValue error: " + err.Error())
+		}
+
+		return tfsdk.Plan{
+			Schema: testSchema,
+			Raw: tftypes.NewValue(
+				testSchema.Type().TerraformType(t.Context()),
+				map[string]tftypes.Value{
+					"value": tfValue,
+				},
+			),
+		}
+	}
+	testState := func(value types.Set) tfsdk.State {
+		tfValue, err := value.ToTerraformValue(t.Context())
+
+		if err != nil {
+			panic("ToTerraformValue error: " + err.Error())
+		}
+
+		return tfsdk.State{
+			Schema: testSchema,
+			Raw: tftypes.NewValue(
+				testSchema.Type().TerraformType(t.Context()),
+				map[string]tftypes.Value{
+					"value": tfValue,
+				},
+			),
+		}
+	}
+	emptyValue := types.SetValueMust(types.StringType, []attr.Value{})
+	oldValue := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("old-value1"), types.StringValue("old-value2")})
+	newValueNoChange := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("old-value2"), types.StringValue("old-value1")})
+	newValueAdd := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("old-value1"), types.StringValue("old-value2"), types.StringValue("new-value")})
+	newValueAddAndDel := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("old-value1"), types.StringValue("new-value")})
+	newValueDel := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("old-value2")})
+
+	tests := map[string]testCase{
+		"unknown value on update": {
+			request: planmodifier.SetRequest{
+				State:      testState(oldValue),
+				StateValue: oldValue,
+				Plan:       testPlan(types.SetUnknown(types.StringType)),
+				PlanValue:  types.SetUnknown(types.StringType),
+			},
+			expected: planmodifier.SetResponse{
+				PlanValue: types.SetUnknown(types.StringType),
+			},
+		},
+		"empty value on create": {
+			request: planmodifier.SetRequest{
+				State:      nullState,
+				StateValue: types.SetNull(types.StringType),
+				Plan:       testPlan(emptyValue),
+				PlanValue:  emptyValue,
+			},
+			expected: planmodifier.SetResponse{
+				PlanValue: emptyValue,
+			},
+		},
+		"non-empty value to empty value on update": {
+			request: planmodifier.SetRequest{
+				State:      testState(oldValue),
+				StateValue: oldValue,
+				Plan:       testPlan(emptyValue),
+				PlanValue:  emptyValue,
+			},
+			expected: planmodifier.SetResponse{
+				PlanValue:       emptyValue,
+				RequiresReplace: true,
+			},
+		},
+		"non-empty value to null value on update": {
+			request: planmodifier.SetRequest{
+				State:      testState(oldValue),
+				StateValue: oldValue,
+				Plan:       testPlan(types.SetNull(types.StringType)),
+				PlanValue:  types.SetNull(types.StringType),
+			},
+			expected: planmodifier.SetResponse{
+				PlanValue:       types.SetNull(types.StringType),
+				RequiresReplace: true,
+			},
+		},
+		"non-empty value to same non-empty value on update": {
+			request: planmodifier.SetRequest{
+				State:      testState(oldValue),
+				StateValue: oldValue,
+				Plan:       testPlan(oldValue),
+				PlanValue:  oldValue,
+			},
+			expected: planmodifier.SetResponse{
+				PlanValue: oldValue,
+			},
+		},
+		"non-empty value to same reordered non-empty value on update": {
+			request: planmodifier.SetRequest{
+				State:      testState(oldValue),
+				StateValue: oldValue,
+				Plan:       testPlan(newValueNoChange),
+				PlanValue:  newValueNoChange,
+			},
+			expected: planmodifier.SetResponse{
+				PlanValue: newValueNoChange,
+			},
+		},
+		"empty value to non-empty value on update": {
+			request: planmodifier.SetRequest{
+				State:      testState(emptyValue),
+				StateValue: emptyValue,
+				Plan:       testPlan(newValueAdd),
+				PlanValue:  newValueAdd,
+			},
+			expected: planmodifier.SetResponse{
+				PlanValue: newValueAdd,
+			},
+		},
+		"non-empty value to non-empty value with addition on update": {
+			request: planmodifier.SetRequest{
+				State:      testState(oldValue),
+				StateValue: oldValue,
+				Plan:       testPlan(newValueAdd),
+				PlanValue:  newValueAdd,
+			},
+			expected: planmodifier.SetResponse{
+				PlanValue: newValueAdd,
+			},
+		},
+		"non-empty value to non-empty value with addition and deletion on update": {
+			request: planmodifier.SetRequest{
+				State:      testState(oldValue),
+				StateValue: oldValue,
+				Plan:       testPlan(newValueAddAndDel),
+				PlanValue:  newValueAddAndDel,
+			},
+			expected: planmodifier.SetResponse{
+				PlanValue:       newValueAddAndDel,
+				RequiresReplace: true,
+			},
+		},
+		"non-empty value to non-empty value with deletion on update": {
+			request: planmodifier.SetRequest{
+				State:      testState(oldValue),
+				StateValue: oldValue,
+				Plan:       testPlan(newValueDel),
+				PlanValue:  newValueDel,
+			},
+			expected: planmodifier.SetResponse{
+				PlanValue:       newValueDel,
+				RequiresReplace: true,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			response := planmodifier.SetResponse{
+				PlanValue: test.request.PlanValue,
+			}
+			tfsetplanmodifier.RequiresReplaceIfElementsDeleted.PlanModifySet(t.Context(), test.request, &response)
+
+			if diff := cmp.Diff(test.expected, response); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds a new `PlanModifier` for sets, `RequiresReplaceIfElementsDeleted`, which forces resource replacement if any elements are removed from a set.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Required for https://github.com/hashicorp/terraform-provider-aws/pull/48877.