### PR TITLE
New Resource: aws_sesv2_multi_region_endpoint

### DIFF
--- a/.changelog/49660.txt
+++ b/.changelog/49660.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_sesv2_multi_region_endpoint
+```

--- a/internal/service/sesv2/exports_test.go
+++ b/internal/service/sesv2/exports_test.go
@@ -15,6 +15,7 @@ var (
 	ResourceEmailIdentityFeedbackAttributes  = resourceEmailIdentityFeedbackAttributes
 	ResourceEmailIdentityMailFromAttributes  = resourceEmailIdentityMailFromAttributes
 	ResourceEmailIdentityPolicy              = resourceEmailIdentityPolicy
+	ResourceMultiRegionEndpoint              = newMultiRegionEndpointResource
 	ResourceTenant                           = newTenantResource
 	ResourceTenantResource                   = newTenantResourceAssociationResource
 
@@ -27,6 +28,7 @@ var (
 	FindDedicatedIPPoolByName                        = findDedicatedIPPoolByName
 	FindEmailIdentityByID                            = findEmailIdentityByID
 	FindEmailIdentityPolicyByTwoPartKey              = findEmailIdentityPolicyByTwoPartKey
+	FindMultiRegionEndpointByName                    = findMultiRegionEndpointByName
 	FindTenantByName                                 = findTenantByName
 	FindTenantResourceAssociationByID                = findTenantResourceAssociationByTwoPartKey
 )

--- a/internal/service/sesv2/multi_region_endpoint.go
+++ b/internal/service/sesv2/multi_region_endpoint.go
@@ -49,13 +49,8 @@ func newMultiRegionEndpointResource(_ context.Context) (resource.ResourceWithCon
 	return r, nil
 }
 
-const (
-	ResNameMultiRegionEndpoint = "Multi Region Endpoint"
-)
-
 type multiRegionEndpointResource struct {
 	framework.ResourceWithModel[multiRegionEndpointResourceModel]
-	framework.WithImportByIdentity
 	framework.WithTimeouts
 	framework.WithNoUpdate
 }
@@ -80,6 +75,7 @@ func (r *multiRegionEndpointResource) Schema(ctx context.Context, req resource.S
 				CustomType: fwtypes.NewListNestedObjectTypeOf[detailsModel](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
+					listvalidator.SizeAtLeast(1),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
@@ -87,6 +83,7 @@ func (r *multiRegionEndpointResource) Schema(ctx context.Context, req resource.S
 							CustomType: fwtypes.NewListNestedObjectTypeOf[routeDetailsModel](ctx),
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
+								listvalidator.SizeAtLeast(1),
 							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
@@ -128,22 +125,22 @@ func (r *multiRegionEndpointResource) Create(ctx context.Context, req resource.C
 
 	out, err := conn.CreateMultiRegionEndpoint(ctx, &input)
 	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.String())
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.ValueString())
 		return
 	}
 	if out == nil {
-		smerr.AddError(ctx, &resp.Diagnostics, errors.New("empty output"), smerr.ID, data.EndpointName.String())
+		smerr.AddError(ctx, &resp.Diagnostics, errors.New("empty output"), smerr.ID, data.EndpointName.ValueString())
 		return
 	}
 
 	endpoint, err := waitMultiRegionEndpointCreated(ctx, conn, data.EndpointName.ValueString(), r.CreateTimeout(ctx, data.Timeouts))
 	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.String())
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.ValueString())
 		return
 	}
 	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, endpoint, &data))
 	data.ARN = fwflex.StringValueToFramework(ctx, multiRegionEndpointARN(ctx, r.Meta(), data.EndpointName.ValueString()))
-	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, data))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
 }
 
 func (r *multiRegionEndpointResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -162,7 +159,7 @@ func (r *multiRegionEndpointResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.String())
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.ValueString())
 		return
 	}
 
@@ -190,21 +187,22 @@ func (r *multiRegionEndpointResource) Delete(ctx context.Context, req resource.D
 			return
 		}
 
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.String())
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.ValueString())
 		return
 	}
 
 	_, err = waitMultiRegionEndpointDeleted(ctx, conn, data.EndpointName.ValueString(), r.DeleteTimeout(ctx, data.Timeouts))
 	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.String())
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.ValueString())
 		return
 	}
 }
 
 const (
 	statusCreating = string(awstypes.StatusCreating)
-	statusReady    = string(awstypes.StatusReady)
 	statusDeleting = string(awstypes.StatusDeleting)
+	statusFailed   = string(awstypes.StatusFailed)
+	statusReady    = string(awstypes.StatusReady)
 )
 
 func waitMultiRegionEndpointCreated(ctx context.Context, conn *sesv2.Client, name string, timeout time.Duration) (*sesv2.GetMultiRegionEndpointOutput, error) {
@@ -213,7 +211,6 @@ func waitMultiRegionEndpointCreated(ctx context.Context, conn *sesv2.Client, nam
 		Target:                    []string{statusReady},
 		Refresh:                   statusMultiRegionEndpoint(conn, name),
 		Timeout:                   timeout,
-		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,
 	}
 
@@ -227,7 +224,7 @@ func waitMultiRegionEndpointCreated(ctx context.Context, conn *sesv2.Client, nam
 
 func waitMultiRegionEndpointDeleted(ctx context.Context, conn *sesv2.Client, name string, timeout time.Duration) (*sesv2.GetMultiRegionEndpointOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleting, statusReady},
+		Pending: []string{statusDeleting, statusReady, statusFailed},
 		Target:  []string{},
 		Refresh: statusMultiRegionEndpoint(conn, name),
 		Timeout: timeout,

--- a/internal/service/sesv2/multi_region_endpoint.go
+++ b/internal/service/sesv2/multi_region_endpoint.go
@@ -1,0 +1,373 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sesv2
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/YakDriver/smarterr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	sweepfw "github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource("aws_sesv2_multi_region_endpoint", name="Multi Region Endpoint")
+func newMultiRegionEndpointResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &multiRegionEndpointResource{}
+
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameMultiRegionEndpoint = "Multi Region Endpoint"
+)
+
+type multiRegionEndpointResource struct {
+	framework.ResourceWithModel[multiRegionEndpointResourceModel]
+	framework.WithTimeouts
+	framework.WithNoUpdate
+}
+
+func (r *multiRegionEndpointResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"endpoint_name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"endpoint_id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			names.AttrStatus: schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"routes": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[routeModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrRegion: schema.StringAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+			},
+			"details": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[detailsModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"routes_details": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[routeDetailsModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrRegion: schema.StringAttribute{
+										Required: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.RequiresReplace(),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *multiRegionEndpointResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().SESV2Client(ctx)
+
+	var plan multiRegionEndpointResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	detailsList, d := plan.Details.ToSlice(ctx)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var apiDetails *awstypes.Details
+	if len(detailsList) > 0 {
+		routesDetailsList, d2 := detailsList[0].RoutesDetails.ToSlice(ctx)
+		smerr.AddEnrich(ctx, &resp.Diagnostics, d2)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		rd := make([]awstypes.RouteDetails, len(routesDetailsList))
+		for i, r := range routesDetailsList {
+			rd[i] = awstypes.RouteDetails{
+				Region: fwflex.StringFromFramework(ctx, r.Region),
+			}
+		}
+		apiDetails = &awstypes.Details{RoutesDetails: rd}
+	}
+
+	input := sesv2.CreateMultiRegionEndpointInput{
+		EndpointName: fwflex.StringFromFramework(ctx, plan.EndpointName),
+		Details:      apiDetails,
+	}
+
+	out, err := conn.CreateMultiRegionEndpoint(ctx, &input)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.EndpointName.String())
+		return
+	}
+	if out == nil {
+		smerr.AddError(ctx, &resp.Diagnostics, errors.New("empty output"), smerr.ID, plan.EndpointName.String())
+		return
+	}
+
+	plan.ID = plan.EndpointName
+	plan.EndpointID = fwflex.StringToFramework(ctx, out.EndpointId)
+
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	ep, err := waitMultiRegionEndpointCreated(ctx, conn, plan.EndpointName.ValueString(), createTimeout)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.EndpointName.String())
+		return
+	}
+
+	plan.Status = fwtypes.StringEnumValue(ep.Status)
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
+}
+
+func (r *multiRegionEndpointResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().SESV2Client(ctx)
+
+	var state multiRegionEndpointResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findMultiRegionEndpointByName(ctx, conn, state.ID.ValueString())
+	if retry.NotFound(err) {
+		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		return
+	}
+
+	state.EndpointID = fwflex.StringToFramework(ctx, out.EndpointId)
+	state.EndpointName = fwflex.StringToFramework(ctx, out.EndpointName)
+	state.Status = fwtypes.StringEnumValue(out.Status)
+
+	routes := make([]routeModel, len(out.Routes))
+	for i, r := range out.Routes {
+		routes[i] = routeModel{
+			Region: fwflex.StringToFramework(ctx, r.Region),
+		}
+	}
+	var routesDiags diag.Diagnostics
+	state.Routes, routesDiags = fwtypes.NewListNestedObjectValueOfValueSlice(ctx, routes)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, routesDiags)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
+}
+
+func (r *multiRegionEndpointResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().SESV2Client(ctx)
+
+	var state multiRegionEndpointResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := sesv2.DeleteMultiRegionEndpointInput{
+		EndpointName: state.ID.ValueStringPointer(),
+	}
+
+	_, err := conn.DeleteMultiRegionEndpoint(ctx, &input)
+	if err != nil {
+		if errs.IsA[*awstypes.NotFoundException](err) {
+			return
+		}
+
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		return
+	}
+
+	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
+	_, err = waitMultiRegionEndpointDeleted(ctx, conn, state.ID.ValueString(), deleteTimeout)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		return
+	}
+}
+
+const (
+	statusCreating = string(awstypes.StatusCreating)
+	statusReady    = string(awstypes.StatusReady)
+	statusFailed   = string(awstypes.StatusFailed)
+	statusDeleting = string(awstypes.StatusDeleting)
+)
+
+func waitMultiRegionEndpointCreated(ctx context.Context, conn *sesv2.Client, name string, timeout time.Duration) (*sesv2.GetMultiRegionEndpointOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{statusCreating},
+		Target:                    []string{statusReady},
+		Refresh:                   statusMultiRegionEndpoint(conn, name),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*sesv2.GetMultiRegionEndpointOutput); ok {
+		return out, smarterr.NewError(err)
+	}
+
+	return nil, smarterr.NewError(err)
+}
+
+func waitMultiRegionEndpointDeleted(ctx context.Context, conn *sesv2.Client, name string, timeout time.Duration) (*sesv2.GetMultiRegionEndpointOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{statusDeleting, statusReady},
+		Target:  []string{},
+		Refresh: statusMultiRegionEndpoint(conn, name),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*sesv2.GetMultiRegionEndpointOutput); ok {
+		return out, smarterr.NewError(err)
+	}
+
+	return nil, smarterr.NewError(err)
+}
+
+func statusMultiRegionEndpoint(conn *sesv2.Client, name string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		out, err := findMultiRegionEndpointByName(ctx, conn, name)
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", smarterr.NewError(err)
+		}
+
+		return out, string(out.Status), nil
+	}
+}
+
+func findMultiRegionEndpointByName(ctx context.Context, conn *sesv2.Client, name string) (*sesv2.GetMultiRegionEndpointOutput, error) {
+	input := sesv2.GetMultiRegionEndpointInput{
+		EndpointName: aws.String(name),
+	}
+
+	out, err := conn.GetMultiRegionEndpoint(ctx, &input)
+	if err != nil {
+		if errs.IsA[*awstypes.NotFoundException](err) {
+			return nil, smarterr.NewError(&retry.NotFoundError{
+				LastError: err,
+			})
+		}
+
+		return nil, smarterr.NewError(err)
+	}
+
+	if out == nil {
+		return nil, smarterr.NewError(tfresource.NewEmptyResultError())
+	}
+
+	return out, nil
+}
+
+type multiRegionEndpointResourceModel struct {
+	EndpointID   types.String                                  `tfsdk:"endpoint_id"`
+	EndpointName types.String                                  `tfsdk:"endpoint_name"`
+	Details      fwtypes.ListNestedObjectValueOf[detailsModel] `tfsdk:"details"`
+	Routes       fwtypes.ListNestedObjectValueOf[routeModel]   `tfsdk:"routes"`
+	Status       fwtypes.StringEnum[awstypes.Status]           `tfsdk:"status"`
+	Timeouts     timeouts.Value                                `tfsdk:"timeouts"`
+}
+
+type routeModel struct {
+	Region types.String `tfsdk:"region"`
+}
+
+type detailsModel struct {
+	RoutesDetails fwtypes.ListNestedObjectValueOf[routeDetailsModel] `tfsdk:"routes_details"`
+}
+
+type routeDetailsModel struct {
+	Region types.String `tfsdk:"region"`
+}
+
+func sweepMultiRegionEndpoints(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	input := sesv2.ListMultiRegionEndpointsInput{}
+	conn := client.SESV2Client(ctx)
+	var sweepResources []sweep.Sweepable
+
+	pages := sesv2.NewListMultiRegionEndpointsPaginator(conn, &input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, smarterr.NewError(err)
+		}
+
+		for _, v := range page.MultiRegionEndpoints {
+			sweepResources = append(sweepResources, sweepfw.NewSweepResource(newMultiRegionEndpointResource, client,
+				sweepfw.NewAttribute(names.AttrID, aws.ToString(v.EndpointName))),
+			)
+		}
+	}
+
+	return sweepResources, nil
+}

--- a/internal/service/sesv2/multi_region_endpoint.go
+++ b/internal/service/sesv2/multi_region_endpoint.go
@@ -30,8 +30,6 @@ import (
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
-	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
-	sweepfw "github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -314,26 +312,4 @@ type detailsModel struct {
 
 type routeDetailsModel struct {
 	Region types.String `tfsdk:"region"`
-}
-
-func sweepMultiRegionEndpoints(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
-	input := sesv2.ListMultiRegionEndpointsInput{}
-	conn := client.SESV2Client(ctx)
-	var sweepResources []sweep.Sweepable
-
-	pages := sesv2.NewListMultiRegionEndpointsPaginator(conn, &input)
-	for pages.HasMorePages() {
-		page, err := pages.NextPage(ctx)
-		if err != nil {
-			return nil, smarterr.NewError(err)
-		}
-
-		for _, v := range page.MultiRegionEndpoints {
-			sweepResources = append(sweepResources, sweepfw.NewSweepResource(newMultiRegionEndpointResource, client,
-				sweepfw.NewAttribute(names.AttrID, aws.ToString(v.EndpointName))),
-			)
-		}
-	}
-
-	return sweepResources, nil
 }

--- a/internal/service/sesv2/multi_region_endpoint.go
+++ b/internal/service/sesv2/multi_region_endpoint.go
@@ -6,18 +6,21 @@ package sesv2
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -29,17 +32,21 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	sweepfw "github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @FrameworkResource("aws_sesv2_multi_region_endpoint", name="Multi Region Endpoint")
+// @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
+// @NoImport
 func newMultiRegionEndpointResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &multiRegionEndpointResource{}
 
-	r.SetDefaultCreateTimeout(30 * time.Minute)
-	r.SetDefaultDeleteTimeout(30 * time.Minute)
+	r.SetDefaultCreateTimeout(5 * time.Minute)
+	r.SetDefaultDeleteTimeout(5 * time.Minute)
 
 	return r, nil
 }
@@ -50,6 +57,7 @@ const (
 
 type multiRegionEndpointResource struct {
 	framework.ResourceWithModel[multiRegionEndpointResourceModel]
+	framework.WithImportByIdentity
 	framework.WithTimeouts
 	framework.WithNoUpdate
 }
@@ -57,45 +65,31 @@ type multiRegionEndpointResource struct {
 func (r *multiRegionEndpointResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			names.AttrARN: framework.ARNAttributeComputedOnly(),
 			"endpoint_name": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"endpoint_id": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			names.AttrStatus: schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
+			"endpoint_id":     framework.IDAttribute(),
+			"routes":          framework.ResourceComputedListOfObjectsAttribute[routeModel](ctx),
+			names.AttrTags:    tftags.TagsAttributeForceNew(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
-			"routes": schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[routeModel](ctx),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						names.AttrRegion: schema.StringAttribute{
-							Computed: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
-							},
-						},
-					},
-				},
-			},
 			"details": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[detailsModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
 						"routes_details": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[routeDetailsModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									names.AttrRegion: schema.StringAttribute{
@@ -121,115 +115,75 @@ func (r *multiRegionEndpointResource) Schema(ctx context.Context, req resource.S
 func (r *multiRegionEndpointResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	conn := r.Meta().SESV2Client(ctx)
 
-	var plan multiRegionEndpointResourceModel
-	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	var data multiRegionEndpointResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &data))
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	detailsList, d := plan.Details.ToSlice(ctx)
-	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+	var input sesv2.CreateMultiRegionEndpointInput
+	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Expand(ctx, data, &input))
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	var apiDetails *awstypes.Details
-	if len(detailsList) > 0 {
-		routesDetailsList, d2 := detailsList[0].RoutesDetails.ToSlice(ctx)
-		smerr.AddEnrich(ctx, &resp.Diagnostics, d2)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		rd := make([]awstypes.RouteDetails, len(routesDetailsList))
-		for i, r := range routesDetailsList {
-			rd[i] = awstypes.RouteDetails{
-				Region: fwflex.StringFromFramework(ctx, r.Region),
-			}
-		}
-		apiDetails = &awstypes.Details{RoutesDetails: rd}
-	}
-
-	input := sesv2.CreateMultiRegionEndpointInput{
-		EndpointName: fwflex.StringFromFramework(ctx, plan.EndpointName),
-		Details:      apiDetails,
-	}
+	input.Tags = getTagsIn(ctx)
 
 	out, err := conn.CreateMultiRegionEndpoint(ctx, &input)
 	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.EndpointName.String())
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.String())
 		return
 	}
 	if out == nil {
-		smerr.AddError(ctx, &resp.Diagnostics, errors.New("empty output"), smerr.ID, plan.EndpointName.String())
+		smerr.AddError(ctx, &resp.Diagnostics, errors.New("empty output"), smerr.ID, data.EndpointName.String())
 		return
 	}
 
-	plan.ID = plan.EndpointName
-	plan.EndpointID = fwflex.StringToFramework(ctx, out.EndpointId)
-
-	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
-	ep, err := waitMultiRegionEndpointCreated(ctx, conn, plan.EndpointName.ValueString(), createTimeout)
+	endpoint, err := waitMultiRegionEndpointCreated(ctx, conn, data.EndpointName.ValueString(), r.CreateTimeout(ctx, data.Timeouts))
 	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.EndpointName.String())
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.String())
 		return
 	}
-
-	plan.Status = fwtypes.StringEnumValue(ep.Status)
-
-	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, endpoint, &data))
+	data.ARN = fwflex.StringValueToFramework(ctx, multiRegionEndpointARN(r.Meta(), ctx, data.EndpointName.ValueString()))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, data))
 }
 
 func (r *multiRegionEndpointResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	conn := r.Meta().SESV2Client(ctx)
 
-	var state multiRegionEndpointResourceModel
-	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	var data multiRegionEndpointResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &data))
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	out, err := findMultiRegionEndpointByName(ctx, conn, state.ID.ValueString())
+	out, err := findMultiRegionEndpointByName(ctx, conn, data.EndpointName.ValueString())
 	if retry.NotFound(err) {
 		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		resp.State.RemoveResource(ctx)
 		return
 	}
 	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.String())
 		return
 	}
 
-	state.EndpointID = fwflex.StringToFramework(ctx, out.EndpointId)
-	state.EndpointName = fwflex.StringToFramework(ctx, out.EndpointName)
-	state.Status = fwtypes.StringEnumValue(out.Status)
-
-	routes := make([]routeModel, len(out.Routes))
-	for i, r := range out.Routes {
-		routes[i] = routeModel{
-			Region: fwflex.StringToFramework(ctx, r.Region),
-		}
-	}
-	var routesDiags diag.Diagnostics
-	state.Routes, routesDiags = fwtypes.NewListNestedObjectValueOfValueSlice(ctx, routes)
-	smerr.AddEnrich(ctx, &resp.Diagnostics, routesDiags)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out, &data))
+	data.ARN = fwflex.StringValueToFramework(ctx, multiRegionEndpointARN(r.Meta(), ctx, data.EndpointName.ValueString()))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
 }
 
 func (r *multiRegionEndpointResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	conn := r.Meta().SESV2Client(ctx)
 
-	var state multiRegionEndpointResourceModel
-	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	var data multiRegionEndpointResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &data))
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	input := sesv2.DeleteMultiRegionEndpointInput{
-		EndpointName: state.ID.ValueStringPointer(),
+		EndpointName: data.EndpointName.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteMultiRegionEndpoint(ctx, &input)
@@ -238,14 +192,13 @@ func (r *multiRegionEndpointResource) Delete(ctx context.Context, req resource.D
 			return
 		}
 
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.String())
 		return
 	}
 
-	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
-	_, err = waitMultiRegionEndpointDeleted(ctx, conn, state.ID.ValueString(), deleteTimeout)
+	_, err = waitMultiRegionEndpointDeleted(ctx, conn, data.EndpointName.ValueString(), r.DeleteTimeout(ctx, data.Timeouts))
 	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, data.EndpointName.String())
 		return
 	}
 }
@@ -253,7 +206,6 @@ func (r *multiRegionEndpointResource) Delete(ctx context.Context, req resource.D
 const (
 	statusCreating = string(awstypes.StatusCreating)
 	statusReady    = string(awstypes.StatusReady)
-	statusFailed   = string(awstypes.StatusFailed)
 	statusDeleting = string(awstypes.StatusDeleting)
 )
 
@@ -329,12 +281,26 @@ func findMultiRegionEndpointByName(ctx context.Context, conn *sesv2.Client, name
 	return out, nil
 }
 
+// Helper function to build resource ARN (required to use ListTagsForResource) as the same is not returned by Get/CreateMultiRegionEndpoint
+func multiRegionEndpointARN(meta *conns.AWSClient, ctx context.Context, endpointName string) string {
+	return awsarn.ARN{
+		Partition: meta.Partition(ctx),
+		Service:   "ses",
+		Region:    meta.Region(ctx),
+		AccountID: meta.AccountID(ctx),
+		Resource:  fmt.Sprintf("multi-region-endpoint/%s", endpointName),
+	}.String()
+}
+
 type multiRegionEndpointResourceModel struct {
+	framework.WithRegionModel
+	ARN          types.String                                  `tfsdk:"arn"`
 	EndpointID   types.String                                  `tfsdk:"endpoint_id"`
 	EndpointName types.String                                  `tfsdk:"endpoint_name"`
 	Details      fwtypes.ListNestedObjectValueOf[detailsModel] `tfsdk:"details"`
 	Routes       fwtypes.ListNestedObjectValueOf[routeModel]   `tfsdk:"routes"`
-	Status       fwtypes.StringEnum[awstypes.Status]           `tfsdk:"status"`
+	Tags         tftags.Map                                    `tfsdk:"tags"`
+	TagsAll      tftags.Map                                    `tfsdk:"tags_all"`
 	Timeouts     timeouts.Value                                `tfsdk:"timeouts"`
 }
 

--- a/internal/service/sesv2/multi_region_endpoint.go
+++ b/internal/service/sesv2/multi_region_endpoint.go
@@ -142,7 +142,7 @@ func (r *multiRegionEndpointResource) Create(ctx context.Context, req resource.C
 		return
 	}
 	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, endpoint, &data))
-	data.ARN = fwflex.StringValueToFramework(ctx, multiRegionEndpointARN(r.Meta(), ctx, data.EndpointName.ValueString()))
+	data.ARN = fwflex.StringValueToFramework(ctx, multiRegionEndpointARN(ctx, r.Meta(), data.EndpointName.ValueString()))
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, data))
 }
 
@@ -167,7 +167,7 @@ func (r *multiRegionEndpointResource) Read(ctx context.Context, req resource.Rea
 	}
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out, &data))
-	data.ARN = fwflex.StringValueToFramework(ctx, multiRegionEndpointARN(r.Meta(), ctx, data.EndpointName.ValueString()))
+	data.ARN = fwflex.StringValueToFramework(ctx, multiRegionEndpointARN(ctx, r.Meta(), data.EndpointName.ValueString()))
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &data))
 }
 
@@ -280,7 +280,7 @@ func findMultiRegionEndpointByName(ctx context.Context, conn *sesv2.Client, name
 }
 
 // Helper function to build resource ARN (required to use ListTagsForResource) as the same is not returned by Get/CreateMultiRegionEndpoint
-func multiRegionEndpointARN(meta *conns.AWSClient, ctx context.Context, endpointName string) string {
+func multiRegionEndpointARN(ctx context.Context, meta *conns.AWSClient, endpointName string) string {
 	return awsarn.ARN{
 		Partition: meta.Partition(ctx),
 		Service:   "ses",

--- a/internal/service/sesv2/multi_region_endpoint_test.go
+++ b/internal/service/sesv2/multi_region_endpoint_test.go
@@ -72,7 +72,7 @@ func TestAccSESV2MultiRegionEndpoint_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckMultiRegionEndpointDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMultiRegionEndpointConfig_tags1(rName, acctest.AlternateRegion(), acctest.CtKey1, acctest.CtValue1),
+				Config: testAccMultiRegionEndpointConfig_tags(rName, acctest.AlternateRegion(), acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMultiRegionEndpointExists(ctx, t, resourceName),
 				),
@@ -219,7 +219,7 @@ resource "aws_sesv2_multi_region_endpoint" "test" {
 `, rName, alternateRegion)
 }
 
-func testAccMultiRegionEndpointConfig_tags1(rName, alternateRegion, tagKey1, tagValue1 string) string {
+func testAccMultiRegionEndpointConfig_tags(rName, alternateRegion, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_sesv2_multi_region_endpoint" "test" {
   endpoint_name = %[1]q
@@ -235,23 +235,4 @@ resource "aws_sesv2_multi_region_endpoint" "test" {
   }
 }
 `, rName, alternateRegion, tagKey1, tagValue1)
-}
-
-func testAccMultiRegionEndpointConfig_tags2(rName, alternateRegion, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return fmt.Sprintf(`
-resource "aws_sesv2_multi_region_endpoint" "test" {
-  endpoint_name = %[1]q
-
-  details {
-    routes_details {
-      region = %[2]q
-    }
-  }
-
-  tags = {
-    %[3]q = %[4]q
-    %[5]q = %[6]q
-  }
-}
-`, rName, alternateRegion, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/internal/service/sesv2/multi_region_endpoint_test.go
+++ b/internal/service/sesv2/multi_region_endpoint_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+const (
+	ResNameMultiRegionEndpoint = "Multi Region Endpoint"
+)
+
 func TestAccSESV2MultiRegionEndpoint_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -175,15 +179,15 @@ func testAccCheckMultiRegionEndpointDestroy(ctx context.Context, t *testing.T) r
 				continue
 			}
 
-			_, err := tfsesv2.FindMultiRegionEndpointByName(ctx, conn, rs.Primary.ID)
+			_, err := tfsesv2.FindMultiRegionEndpointByName(ctx, conn, rs.Primary.Attributes["endpoint_name"])
 			if retry.NotFound(err) {
 				return nil
 			}
 			if err != nil {
-				return create.Error(names.SESV2, create.ErrActionCheckingDestroyed, tfsesv2.ResNameMultiRegionEndpoint, rs.Primary.ID, err)
+				return create.Error(names.SESV2, create.ErrActionCheckingDestroyed, ResNameMultiRegionEndpoint, rs.Primary.Attributes["endpoint_name"], err)
 			}
 
-			return create.Error(names.SESV2, create.ErrActionCheckingDestroyed, tfsesv2.ResNameMultiRegionEndpoint, rs.Primary.ID, errors.New("not destroyed"))
+			return create.Error(names.SESV2, create.ErrActionCheckingDestroyed, ResNameMultiRegionEndpoint, rs.Primary.Attributes["endpoint_name"], errors.New("not destroyed"))
 		}
 
 		return nil
@@ -194,7 +198,7 @@ func testAccCheckMultiRegionEndpointExists(ctx context.Context, t *testing.T, na
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
-			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameMultiRegionEndpoint, name, errors.New("not found"))
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, ResNameMultiRegionEndpoint, name, errors.New("not found"))
 		}
 
 		conn := acctest.ProviderMeta(ctx, t).SESV2Client(ctx)

--- a/internal/service/sesv2/multi_region_endpoint_test.go
+++ b/internal/service/sesv2/multi_region_endpoint_test.go
@@ -9,16 +9,17 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
-	"github.com/hashicorp/terraform-provider-aws/names"
-
 	tfsesv2 "github.com/hashicorp/terraform-provider-aws/internal/service/sesv2"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccSESV2MultiRegionEndpoint_basic(t *testing.T) {
@@ -27,32 +28,105 @@ func TestAccSESV2MultiRegionEndpoint_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var multiregionendpoint sesv2.GetMultiRegionEndpointOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sesv2_multi_region_endpoint.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckMultiRegionEndpointDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMultiRegionEndpointConfig_basic(rName),
+				Config: testAccMultiRegionEndpointConfig_basic(rName, acctest.AlternateRegion()),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMultiRegionEndpointExists(ctx, t, resourceName, &multiregionendpoint),
+					testAccCheckMultiRegionEndpointExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "endpoint_id"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "READY"),
+					resource.TestCheckResourceAttr(resourceName, "details.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "details.0.routes_details.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "details.0.routes_details.0.region", acctest.AlternateRegion()),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSESV2MultiRegionEndpoint_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_multi_region_endpoint.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiRegionEndpointDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiRegionEndpointConfig_tags1(rName, acctest.AlternateRegion(), acctest.CtKey1, acctest.CtValue1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMultiRegionEndpointExists(ctx, t, resourceName),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
+						acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),
+					})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSESV2MultiRegionEndpoint_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_multi_region_endpoint.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 3)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiRegionEndpointDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiRegionEndpointConfig_basic(rName, acctest.AlternateRegion()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMultiRegionEndpointExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_name", rName),
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				Config: testAccMultiRegionEndpointConfig_basic(rName, acctest.ThirdRegion()),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMultiRegionEndpointExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_name", rName),
+				),
 			},
 		},
 	})
@@ -64,23 +138,21 @@ func TestAccSESV2MultiRegionEndpoint_disappears(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var multiregionendpoint sesv2.GetMultiRegionEndpointOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_sesv2_multi_region_endpoint.test"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckMultiRegionEndpointDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMultiRegionEndpointConfig_basic(rName),
+				Config: testAccMultiRegionEndpointConfig_basic(rName, acctest.AlternateRegion()),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMultiRegionEndpointExists(ctx, t, resourceName, &multiregionendpoint),
+					testAccCheckMultiRegionEndpointExists(ctx, t, resourceName),
 					acctest.CheckFrameworkResourceDisappears(ctx, t, tfsesv2.ResourceMultiRegionEndpoint, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -118,57 +190,68 @@ func testAccCheckMultiRegionEndpointDestroy(ctx context.Context, t *testing.T) r
 	}
 }
 
-func testAccCheckMultiRegionEndpointExists(ctx context.Context, t *testing.T, name string, multiregionendpoint *sesv2.GetMultiRegionEndpointOutput) resource.TestCheckFunc {
+func testAccCheckMultiRegionEndpointExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameMultiRegionEndpoint, name, errors.New("not found"))
 		}
 
-		if rs.Primary.ID == "" {
-			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameMultiRegionEndpoint, name, errors.New("not set"))
-		}
-
 		conn := acctest.ProviderMeta(ctx, t).SESV2Client(ctx)
 
-		resp, err := tfsesv2.FindMultiRegionEndpointByName(ctx, conn, rs.Primary.ID)
-		if err != nil {
-			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameMultiRegionEndpoint, rs.Primary.ID, err)
-		}
+		_, err := tfsesv2.FindMultiRegionEndpointByName(ctx, conn, rs.Primary.Attributes["endpoint_name"])
 
-		*multiregionendpoint = *resp
-
-		return nil
+		return err
 	}
 }
 
-func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.ProviderMeta(ctx, t).SESV2Client(ctx)
-
-	input := &sesv2.ListMultiRegionEndpointsInput{}
-
-	_, err := conn.ListMultiRegionEndpoints(ctx, input)
-
-	if acctest.PreCheckSkipError(err) {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
-}
-
-func testAccMultiRegionEndpointConfig_basic(rName string) string {
+func testAccMultiRegionEndpointConfig_basic(rName, alternateRegion string) string {
 	return fmt.Sprintf(`
 resource "aws_sesv2_multi_region_endpoint" "test" {
   endpoint_name = %[1]q
 
   details {
     routes_details {
-      region = data.aws_region.secondary.name
+      region = %[2]q
     }
   }
 }
+`, rName, alternateRegion)
+}
 
-data "aws_region" "secondary" {}
-`, rName)
+func testAccMultiRegionEndpointConfig_tags1(rName, alternateRegion, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_multi_region_endpoint" "test" {
+  endpoint_name = %[1]q
+
+  details {
+    routes_details {
+      region = %[2]q
+    }
+  }
+
+  tags = {
+    %[3]q = %[4]q
+  }
+}
+`, rName, alternateRegion, tagKey1, tagValue1)
+}
+
+func testAccMultiRegionEndpointConfig_tags2(rName, alternateRegion, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_multi_region_endpoint" "test" {
+  endpoint_name = %[1]q
+
+  details {
+    routes_details {
+      region = %[2]q
+    }
+  }
+
+  tags = {
+    %[3]q = %[4]q
+    %[5]q = %[6]q
+  }
+}
+`, rName, alternateRegion, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/internal/service/sesv2/multi_region_endpoint_test.go
+++ b/internal/service/sesv2/multi_region_endpoint_test.go
@@ -1,0 +1,174 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package sesv2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/names"
+
+	tfsesv2 "github.com/hashicorp/terraform-provider-aws/internal/service/sesv2"
+)
+
+func TestAccSESV2MultiRegionEndpoint_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var multiregionendpoint sesv2.GetMultiRegionEndpointOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_multi_region_endpoint.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiRegionEndpointDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiRegionEndpointConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMultiRegionEndpointExists(ctx, t, resourceName, &multiregionendpoint),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_id"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "READY"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSESV2MultiRegionEndpoint_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var multiregionendpoint sesv2.GetMultiRegionEndpointOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_multi_region_endpoint.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMultiRegionEndpointDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMultiRegionEndpointConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMultiRegionEndpointExists(ctx, t, resourceName, &multiregionendpoint),
+					acctest.CheckFrameworkResourceDisappears(ctx, t, tfsesv2.ResourceMultiRegionEndpoint, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckMultiRegionEndpointDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.ProviderMeta(ctx, t).SESV2Client(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_sesv2_multi_region_endpoint" {
+				continue
+			}
+
+			_, err := tfsesv2.FindMultiRegionEndpointByName(ctx, conn, rs.Primary.ID)
+			if retry.NotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.SESV2, create.ErrActionCheckingDestroyed, tfsesv2.ResNameMultiRegionEndpoint, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.SESV2, create.ErrActionCheckingDestroyed, tfsesv2.ResNameMultiRegionEndpoint, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMultiRegionEndpointExists(ctx context.Context, t *testing.T, name string, multiregionendpoint *sesv2.GetMultiRegionEndpointOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameMultiRegionEndpoint, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameMultiRegionEndpoint, name, errors.New("not set"))
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).SESV2Client(ctx)
+
+		resp, err := tfsesv2.FindMultiRegionEndpointByName(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameMultiRegionEndpoint, rs.Primary.ID, err)
+		}
+
+		*multiregionendpoint = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.ProviderMeta(ctx, t).SESV2Client(ctx)
+
+	input := &sesv2.ListMultiRegionEndpointsInput{}
+
+	_, err := conn.ListMultiRegionEndpoints(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccMultiRegionEndpointConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_multi_region_endpoint" "test" {
+  endpoint_name = %[1]q
+
+  details {
+    routes_details {
+      region = data.aws_region.secondary.name
+    }
+  }
+}
+
+data "aws_region" "secondary" {}
+`, rName)
+}

--- a/internal/service/sesv2/service_package_gen.go
+++ b/internal/service/sesv2/service_package_gen.go
@@ -36,7 +36,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Factory:  newMultiRegionEndpointResource,
 			TypeName: "aws_sesv2_multi_region_endpoint",
 			Name:     "Multi Region Endpoint",
-			Region:   inttypes.ResourceRegionDefault(),
+			Tags: unique.Make(inttypes.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			}),
+			Region: inttypes.ResourceRegionDefault(),
 		},
 		{
 			Factory:  newTenantResource,

--- a/internal/service/sesv2/service_package_gen.go
+++ b/internal/service/sesv2/service_package_gen.go
@@ -33,6 +33,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newMultiRegionEndpointResource,
+			TypeName: "aws_sesv2_multi_region_endpoint",
+			Name:     "Multi Region Endpoint",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newTenantResource,
 			TypeName: "aws_sesv2_tenant",
 			Name:     "Tenant",

--- a/internal/service/sesv2/sweep.go
+++ b/internal/service/sesv2/sweep.go
@@ -19,6 +19,7 @@ func RegisterSweepers() {
 	awsv2.Register("aws_sesv2_contact_list", sweepContactLists)
 	awsv2.Register("aws_sesv2_multi_region_endpoint", sweepMultiRegionEndpoints)
 	awsv2.Register("aws_sesv2_tenant", sweepTenants)
+	awsv2.Register("aws_sesv2_multi_region_endpoint", sweepMultiRegionEndpoints)
 }
 
 func sweepConfigurationSets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
@@ -87,6 +88,28 @@ func sweepTenants(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepab
 		for _, v := range page.Tenants {
 			sweepResources = append(sweepResources, framework.NewSweepResource(newTenantResource, client,
 				framework.NewAttribute("tenant_name", aws.ToString(v.TenantName))))
+		}
+	}
+
+	return sweepResources, nil
+}
+
+func sweepMultiRegionEndpoints(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	input := sesv2.ListMultiRegionEndpointsInput{}
+	conn := client.SESV2Client(ctx)
+	var sweepResources []sweep.Sweepable
+
+	pages := sesv2.NewListMultiRegionEndpointsPaginator(conn, &input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.MultiRegionEndpoints {
+			sweepResources = append(sweepResources, framework.NewSweepResource(newMultiRegionEndpointResource, client,
+				framework.NewAttribute("endpoint_name", aws.ToString(v.EndpointName))),
+			)
 		}
 	}
 

--- a/internal/service/sesv2/sweep.go
+++ b/internal/service/sesv2/sweep.go
@@ -17,6 +17,7 @@ import (
 func RegisterSweepers() {
 	awsv2.Register("aws_sesv2_configuration_set", sweepConfigurationSets)
 	awsv2.Register("aws_sesv2_contact_list", sweepContactLists)
+	awsv2.Register("aws_sesv2_multi_region_endpoint", sweepMultiRegionEndpoints)
 	awsv2.Register("aws_sesv2_tenant", sweepTenants)
 }
 

--- a/internal/service/sesv2/sweep.go
+++ b/internal/service/sesv2/sweep.go
@@ -19,7 +19,6 @@ func RegisterSweepers() {
 	awsv2.Register("aws_sesv2_contact_list", sweepContactLists)
 	awsv2.Register("aws_sesv2_multi_region_endpoint", sweepMultiRegionEndpoints)
 	awsv2.Register("aws_sesv2_tenant", sweepTenants)
-	awsv2.Register("aws_sesv2_multi_region_endpoint", sweepMultiRegionEndpoints)
 }
 
 func sweepConfigurationSets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {

--- a/website/docs/r/sesv2_multi_region_endpoint.html.markdown
+++ b/website/docs/r/sesv2_multi_region_endpoint.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "SESv2 (Simple Email V2)"
+layout: "aws"
+page_title: "AWS: aws_sesv2_multi_region_endpoint"
+description: |-
+  Manages an AWS SESv2 (Simple Email V2) Multi Region Endpoint.
+---
+
+# Resource: aws_sesv2_multi_region_endpoint
+
+Manages an AWS SESv2 (Simple Email V2) Multi Region Endpoint (global endpoint). Traffic is split equally between the primary region (where the resource is created) and the secondary region specified in the `details` block.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_region" "secondary" {}
+
+resource "aws_sesv2_multi_region_endpoint" "example" {
+  endpoint_name = "example"
+
+  details {
+    routes_details {
+      region = data.aws_region.secondary.name
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `endpoint_name` - (Required, Forces new resource) Name of the multi-region endpoint.
+* `details` - (Required, Forces new resource) Configuration details for the endpoint. See [`details`](#details) below.
+
+### `details`
+
+* `routes_details` - (Required) List of secondary region route configurations. Each entry contains:
+  * `region` - (Required, Forces new resource) Name of the secondary AWS region.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - Name of the multi-region endpoint (same as `endpoint_name`).
+* `endpoint_id` - ID assigned to the multi-region endpoint.
+* `routes` - List of active routes. Each entry contains:
+  * `region` - AWS region name for this route.
+* `status` - Current status of the endpoint. One of `CREATING`, `READY`, `FAILED`, `DELETING`.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `30m`)
+* `delete` - (Default `30m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SESv2 Multi Region Endpoints using the `endpoint_name`. For example:
+
+```terraform
+import {
+  to = aws_sesv2_multi_region_endpoint.example
+  id = "example"
+}
+```
+
+Using `terraform import`, import SESv2 Multi Region Endpoints using the `endpoint_name`. For example:
+
+```console
+% terraform import aws_sesv2_multi_region_endpoint.example example
+```

--- a/website/docs/r/sesv2_multi_region_endpoint.html.markdown
+++ b/website/docs/r/sesv2_multi_region_endpoint.html.markdown
@@ -15,14 +15,13 @@ Manages an AWS SESv2 (Simple Email V2) Multi Region Endpoint (global endpoint). 
 ### Basic Usage
 
 ```terraform
-data "aws_region" "secondary" {}
 
 resource "aws_sesv2_multi_region_endpoint" "example" {
   endpoint_name = "example"
 
   details {
     routes_details {
-      region = data.aws_region.secondary.name
+      region = "example-alternate-region"
     }
   }
 }
@@ -54,22 +53,5 @@ This resource exports the following attributes in addition to the arguments abov
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `30m`)
-* `delete` - (Default `30m`)
-
-## Import
-
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SESv2 Multi Region Endpoints using the `endpoint_name`. For example:
-
-```terraform
-import {
-  to = aws_sesv2_multi_region_endpoint.example
-  id = "example"
-}
-```
-
-Using `terraform import`, import SESv2 Multi Region Endpoints using the `endpoint_name`. For example:
-
-```console
-% terraform import aws_sesv2_multi_region_endpoint.example example
-```
+* `create` - (Default `5m`)
+* `delete` - (Default `5m`)

--- a/website/docs/r/sesv2_multi_region_endpoint.html.markdown
+++ b/website/docs/r/sesv2_multi_region_endpoint.html.markdown
@@ -15,7 +15,6 @@ Manages an AWS SESv2 (Simple Email V2) Multi Region Endpoint (global endpoint). 
 ### Basic Usage
 
 ```terraform
-
 resource "aws_sesv2_multi_region_endpoint" "example" {
   endpoint_name = "example"
 
@@ -31,23 +30,40 @@ resource "aws_sesv2_multi_region_endpoint" "example" {
 
 The following arguments are required:
 
-* `endpoint_name` - (Required, Forces new resource) Name of the multi-region endpoint.
-* `details` - (Required, Forces new resource) Configuration details for the endpoint. See [`details`](#details) below.
+* `details` - (Required) Configuration details for the endpoint. See [`details` Block](#details-block) below.
+* `endpoint_name` - (Required) Name of the multi-region endpoint.
 
-### `details`
+The following arguments are optional:
 
-* `routes_details` - (Required) List of secondary region route configurations. Each entry contains:
-  * `region` - (Required, Forces new resource) Name of the secondary AWS region.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### `details` Block
+
+The `details` block supports:
+
+* `routes_details` - (Required) Secondary region route configuration. See [`routes_details` Block](#routes_details-block) below.
+
+### `routes_details` Block
+
+The `routes_details` block supports:
+
+* `region` - (Required) Name of the secondary AWS region.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - Name of the multi-region endpoint (same as `endpoint_name`).
+* `arn` - ARN of the multi-region endpoint.
 * `endpoint_id` - ID assigned to the multi-region endpoint.
-* `routes` - List of active routes. Each entry contains:
-  * `region` - AWS region name for this route.
-* `status` - Current status of the endpoint. One of `CREATING`, `READY`, `FAILED`, `DELETING`.
+* `routes` - List of active routes. See [`routes`](#routes) below.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+### `routes`
+
+`routes` supports:
+
+* `region` - AWS region name for this route.
 
 ## Timeouts
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds a new resource for `sesv2` global endpoints.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40666 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_CreateMultiRegionEndpoint.html
https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_GetMultiRegionEndpoint.html
https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_DeleteMultiRegionEndpoint.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccSESV2MultiRegionEndpoint_ K=sesv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-sesv2-global-endpoints 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/sesv2/... -v -count 1 -parallel 20 -run='TestAccSESV2MultiRegionEndpoint_'  -timeout 360m -vet=off -buildvcs=false
2026/08/25 02:04:44 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/25 02:04:44 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSESV2MultiRegionEndpoint_basic
=== PAUSE TestAccSESV2MultiRegionEndpoint_basic
=== RUN   TestAccSESV2MultiRegionEndpoint_tags
=== PAUSE TestAccSESV2MultiRegionEndpoint_tags
=== RUN   TestAccSESV2MultiRegionEndpoint_update
=== PAUSE TestAccSESV2MultiRegionEndpoint_update
=== RUN   TestAccSESV2MultiRegionEndpoint_disappears
=== PAUSE TestAccSESV2MultiRegionEndpoint_disappears
=== CONT  TestAccSESV2MultiRegionEndpoint_basic
=== CONT  TestAccSESV2MultiRegionEndpoint_disappears
=== CONT  TestAccSESV2MultiRegionEndpoint_update
=== CONT  TestAccSESV2MultiRegionEndpoint_tags
--- PASS: TestAccSESV2MultiRegionEndpoint_basic (67.45s)
--- PASS: TestAccSESV2MultiRegionEndpoint_disappears (67.83s)
--- PASS: TestAccSESV2MultiRegionEndpoint_tags (78.59s)
--- PASS: TestAccSESV2MultiRegionEndpoint_update (148.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sesv2      153.632s
```
