### PR TITLE
resource/aws_iam_policy_attachment: Removes `aws_iam_group` from test

### DIFF
--- a/internal/service/iam/testdata/PolicyAttachment/basic/main_gen.tf
+++ b/internal/service/iam/testdata/PolicyAttachment/basic/main_gen.tf
@@ -3,7 +3,6 @@
 
 resource "aws_iam_policy_attachment" "test" {
   name       = var.rName
-  groups     = aws_iam_group.test[*].name
   roles      = aws_iam_role.test[*].name
   policy_arn = aws_iam_policy.test.arn
 }
@@ -26,11 +25,6 @@ resource "aws_iam_policy" "test" {
   ]
 }
 EOF
-}
-
-resource "aws_iam_group" "test" {
-  count = 2
-  name  = format("${var.rName}-%d", count.index + 1)
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/iam/testdata/PolicyAttachment/basic_v6.52.0/main_gen.tf
+++ b/internal/service/iam/testdata/PolicyAttachment/basic_v6.52.0/main_gen.tf
@@ -3,7 +3,6 @@
 
 resource "aws_iam_policy_attachment" "test" {
   name       = var.rName
-  groups     = aws_iam_group.test[*].name
   roles      = aws_iam_role.test[*].name
   policy_arn = aws_iam_policy.test.arn
 }
@@ -26,11 +25,6 @@ resource "aws_iam_policy" "test" {
   ]
 }
 EOF
-}
-
-resource "aws_iam_group" "test" {
-  count = 2
-  name  = format("${var.rName}-%d", count.index + 1)
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/iam/testdata/tmpl/policy_attachment_basic.gtpl
+++ b/internal/service/iam/testdata/tmpl/policy_attachment_basic.gtpl
@@ -1,6 +1,5 @@
 resource "aws_iam_policy_attachment" "test" {
   name       = var.rName
-  groups     = aws_iam_group.test[*].name
   roles      = aws_iam_role.test[*].name
   policy_arn = aws_iam_policy.test.arn
 }
@@ -23,11 +22,6 @@ resource "aws_iam_policy" "test" {
   ]
 }
 EOF
-}
-
-resource "aws_iam_group" "test" {
-  count = 2
-  name  = format("${var.rName}-%d", count.index + 1)
 }
 
 resource "aws_iam_role" "test" {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Removes `aws_iam_group` from `aws_iam_policy_attachment` test to avoid permissions restrictions

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>