### PR TITLE
r/aws_rds_cluster: add master_user_authentication_type argument

### DIFF
--- a/.changelog/49670.txt
+++ b/.changelog/49670.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rds_cluster: Add `master_user_authentication_type` argument to support IAM authentication for the master user (RDS for PostgreSQL and Aurora PostgreSQL only)
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -394,6 +394,11 @@ func resourceCluster() *schema.Resource {
 					Optional:     true,
 					RequiredWith: []string{"master_password_wo"},
 				},
+				"master_user_authentication_type": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ValidateDiagFunc: enum.Validate[types.MasterUserAuthenticationType](),
+				},
 				"master_username": {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -736,6 +741,35 @@ func resourceCluster() *schema.Resource {
 				}
 				return nil
 			},
+			func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+				if diff.Get("master_user_authentication_type").(string) != string(types.MasterUserAuthenticationTypeIamDbAuth) {
+					return nil
+				}
+				if _, ok := diff.GetOk("master_password"); ok {
+					return fmt.Errorf(`"master_password" cannot be set when "master_user_authentication_type" is %q`, types.MasterUserAuthenticationTypeIamDbAuth)
+				}
+				if diff.Get("manage_master_user_password").(bool) {
+					return fmt.Errorf(`"manage_master_user_password" cannot be set when "master_user_authentication_type" is %q`, types.MasterUserAuthenticationTypeIamDbAuth)
+				}
+				masterPasswordWO, di := flex.GetWriteOnlyStringValue(diff, cty.GetAttrPath("master_password_wo"))
+				if di.HasError() {
+					return sdkdiag.DiagnosticsError(di)
+				}
+				if masterPasswordWO != "" {
+					return fmt.Errorf(`"master_password_wo" cannot be set when "master_user_authentication_type" is %q`, types.MasterUserAuthenticationTypeIamDbAuth)
+				}
+
+				return nil
+			},
+			func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+				if diff.Get("master_user_authentication_type").(string) != string(types.MasterUserAuthenticationTypeIamDbAuth) {
+					return nil
+				}
+				if !diff.Get("iam_database_authentication_enabled").(bool) {
+					return fmt.Errorf(`"iam_database_authentication_enabled" must be true when "master_user_authentication_type" is %q`, types.MasterUserAuthenticationTypeIamDbAuth)
+				}
+				return nil
+			},
 		),
 	}
 }
@@ -851,6 +885,11 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 
 		if v, ok := d.GetOk("master_user_secret_kms_key_id"); ok {
 			modifyDbClusterInput.MasterUserSecretKmsKeyId = aws.String(v.(string))
+			requiresModifyDbCluster = true
+		}
+
+		if v, ok := d.GetOk("master_user_authentication_type"); ok {
+			modifyDbClusterInput.MasterUserAuthenticationType = types.MasterUserAuthenticationType(v.(string))
 			requiresModifyDbCluster = true
 		}
 
@@ -1121,6 +1160,11 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 			requiresModifyDbCluster = true
 		}
 
+		if v, ok := d.GetOk("master_user_authentication_type"); ok {
+			modifyDbClusterInput.MasterUserAuthenticationType = types.MasterUserAuthenticationType(v.(string))
+			requiresModifyDbCluster = true
+		}
+
 		if v, ok := d.GetOk("monitoring_interval"); ok {
 			input.MonitoringInterval = aws.Int32(int32(v.(int)))
 		}
@@ -1330,6 +1374,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 
 		if v, ok := d.GetOk("master_user_secret_kms_key_id"); ok {
 			input.MasterUserSecretKmsKeyId = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("master_user_authentication_type"); ok {
+			input.MasterUserAuthenticationType = types.MasterUserAuthenticationType(v.(string))
 		}
 
 		if v, ok := d.GetOk("master_username"); ok {
@@ -1677,6 +1725,12 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		if d.HasChange("master_user_secret_kms_key_id") {
 			if v, ok := d.GetOk("master_user_secret_kms_key_id"); ok {
 				input.MasterUserSecretKmsKeyId = aws.String(v.(string))
+			}
+		}
+
+		if d.HasChange("master_user_authentication_type") {
+			if v, ok := d.GetOk("master_user_authentication_type"); ok {
+				input.MasterUserAuthenticationType = types.MasterUserAuthenticationType(v.(string))
 			}
 		}
 
@@ -2403,6 +2457,7 @@ func resourceClusterFlatten(ctx context.Context, conn *rds.Client, dbc *types.DB
 	//
 	// manage_master_user_password
 	// master_password
+	// master_user_authentication_type
 	//
 	// Expose the MasterUserSecret structure as a computed attribute
 	// https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-cluster.html#:~:text=for%20future%20use.-,MasterUserSecret,-%2D%3E%20(structure)

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -53,6 +53,7 @@ func testAccClusterImportStep(n string) resource.TestStep {
 			"manage_master_user_password",
 			"master_password",
 			"master_password_wo",
+			"master_user_authentication_type",
 			"master_user_secret_kms_key_id",
 			"skip_final_snapshot",
 		},
@@ -2126,6 +2127,45 @@ func TestAccRDSCluster_ManagedMasterPassword_convertToManaged(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_resource_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "manage_master_user_password"),
 					resource.TestCheckResourceAttr(resourceName, "manage_master_user_password", acctest.CtTrue),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSCluster_masterUserAuthenticationType(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbCluster types.DBCluster
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_masterUserAuthenticationType(rName, "iam-db-auth"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, tfrds.ClusterEngineAuroraPostgreSQL),
+					resource.TestCheckResourceAttr(resourceName, "master_user_authentication_type", "iam-db-auth"),
+				),
+			},
+			testAccClusterImportStep(resourceName),
+			{
+				Config: testAccClusterConfig_masterUserAuthenticationType(rName, names.AttrPassword),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "master_user_authentication_type", names.AttrPassword),
+				),
+			},
+			{
+				Config: testAccClusterConfig_masterUserAuthenticationType(rName, "iam-db-auth"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "master_user_authentication_type", "iam-db-auth"),
 				),
 			},
 		},
@@ -4392,6 +4432,28 @@ resource "aws_rds_cluster" "test" {
   skip_final_snapshot         = true
 }
 `, rName, tfrds.ClusterEngineAuroraMySQL)
+}
+
+func testAccClusterConfig_masterUserAuthenticationType(rName, authType string) string {
+	// AWS rejects both a master password and a managed master password when
+	// master_user_authentication_type is "iam-db-auth".
+	var masterPassword string
+	if authType != "iam-db-auth" {
+		masterPassword = `master_password                     = "avoid-plaintext-passwords"`
+	}
+
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier = %[1]q
+  database_name      = "test"
+  engine             = %[2]q
+  master_username    = "tfacctest"
+  %[4]s
+  master_user_authentication_type     = %[3]q
+  iam_database_authentication_enabled = true
+  skip_final_snapshot                 = true
+}
+`, rName, tfrds.ClusterEngineAuroraPostgreSQL, authType, masterPassword)
 }
 
 func testAccClusterConfig_managedMasterPasswordKMSKey(rName string) string {

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -27,6 +27,10 @@ Changes to an RDS Cluster can occur when you manually change a parameter, such a
 
 -> **Note:** Write-Only argument `master_password_wo` is available to use in place of `master_password`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments).
 
+~> **Note:** AWS rejects setting `master_user_authentication_type` to `iam-db-auth` together with `master_password` (or `master_password_wo`, or `manage_master_user_password`). Omit the password arguments when using `iam-db-auth`.
+
+~> **Note:** AWS requires `iam_database_authentication_enabled` to be set to `true` when `master_user_authentication_type` is `iam-db-auth`.
+
 ## Example Usage
 
 ### Aurora MySQL 2.x (MySQL 5.7)
@@ -247,6 +251,7 @@ This resource supports the following arguments:
 * `master_password` - (Optional, required unless `manage_master_user_password` is set to true, a `snapshot_identifier`, `replication_source_identifier`, or `master_password_wo` is provided or unless a `global_cluster_identifier` is provided when the cluster is the "secondary" cluster of a global database) Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file. Please refer to the [RDS Naming Constraints](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints). Cannot be set if `manage_master_user_password` is set to `true`.
 * `master_password_wo` (Optional, Write-Only required unless `manage_master_user_password` is set to true, a `snapshot_identifier`, `replication_source_identifier`, or `master_password` is provided or unless a `global_cluster_identifier` is provided when the cluster is the "secondary" cluster of a global database) Password for the master DB user. Note that this may show up in logs. Please refer to the [RDS Naming Constraints](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints). Cannot be set if `manage_master_user_password` is set to `true`.
 * `master_password_wo_version` - (Optional) Used together with `master_password_wo` to trigger an update. Increment this value when an update to the `master_password_wo` is required.
+* `master_user_authentication_type` - (Optional) Authentication type for the master user. Valid values are `password` and `iam-db-auth`. Only valid for RDS for PostgreSQL and Aurora PostgreSQL DB clusters.
 * `master_user_secret_kms_key_id` - (Optional) Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key. To use a KMS key in a different Amazon Web Services account, specify the key ARN or alias ARN. If not specified, the default KMS key for your Amazon Web Services account is used.
 * `master_username` - (Required unless a `snapshot_identifier` or `replication_source_identifier` is provided or unless a `global_cluster_identifier` is provided when the cluster is the "secondary" cluster of a global database) Username for the master DB user. Please refer to the [RDS Naming Constraints](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints). This argument does not support in-place updates and cannot be changed during a restore from snapshot.
 * `monitoring_interval` - (Optional) Interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster. To turn off collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

This adds a new `master_user_authentication_type` argument to `aws_rds_cluster` (`password` / `iam-db-auth`), letting the master user authenticate via IAM instead of a password. 
No new access is granted by this change itself; it exposes an existing RDS API capability. `iam-db-auth` is validated (via `CustomizeDiff`, confirmed against the live RDS API) to be mutually exclusive with `master_password`, `master_password_wo`, and `manage_master_user_password`, and to require `iam_database_authentication_enabled = true`.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds the `master_user_authentication_type` argument to `aws_rds_cluster`, supporting the RDS API's `MasterUserAuthenticationType` parameter (`password` / `iam-db-auth`). 
Only valid for RDS for PostgreSQL and Aurora PostgreSQL DB clusters.

Since `RestoreDBClusterFromSnapshot` and `RestoreDBClusterToPointInTime` don't accept this parameter directly, it's applied via a follow-up `ModifyDBCluster` call in those code paths, matching the existing pattern used for `master_password`/`manage_master_user_password`.

The value isn't returned by `DescribeDBClusters`, so it's treated as a virtual/write-only attribute and excluded from acceptance-test import verification.

Adds plan-time `CustomizeDiff` validation for two constraints confirmed against the live RDS API:

- `iam-db-auth` is incompatible with `master_password`, `master_password_wo`, and `manage_master_user_password`
- `iam-db-auth` requires `iam_database_authentication_enabled` to be `true`

Without this, both combinations passed `plan` and only failed with a raw AWS API error at `apply` time.

### AI Usage
This PR was developed with the assistance of an LLM agent. 
As the human author, I have reviewed and understand every line of the submitted code, including its logic, edge cases, and side effects.
I take full responsibility for this contribution.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- [AWS RDS API Reference: CreateDBCluster - MasterUserAuthenticationType](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBCluster.html)
- [IAM database authentication for MariaDB, MySQL, and PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccRDSCluster_masterUserAuthenticationType PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-rds-cluster-master-user-auth-type-fixes 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_masterUserAuthenticationType'  -timeout 360m -vet=off -buildvcs=false
2026/08/25 21:47:39 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/25 21:47:39 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSCluster_masterUserAuthenticationType
=== PAUSE TestAccRDSCluster_masterUserAuthenticationType
=== CONT  TestAccRDSCluster_masterUserAuthenticationType
--- PASS: TestAccRDSCluster_masterUserAuthenticationType (192.40s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        197.014s
```
