### PR TITLE
dynamodb_table: Show correct diff when GSI changes with updates

### DIFF
--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -247,7 +247,7 @@ func resourceTable() *schema.Resource {
 							},
 						},
 					},
-					Set: sdkv2.SimpleSchemaSetFunc(names.AttrName),
+					// Set: sdkv2.SimpleSchemaSetFunc(names.AttrName),
 				},
 				"global_table_witness": {
 					Type:     schema.TypeList,

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -229,6 +230,7 @@ func resourceTable() *schema.Resource {
 							"range_key": {
 								Type:             schema.TypeString,
 								Optional:         true,
+								Computed:         true,
 								Deprecated:       "range_key is deprecated. Use key_schema instead.",
 								ValidateDiagFunc: verify.WarnStringIsNotEmpty,
 							},
@@ -245,6 +247,7 @@ func resourceTable() *schema.Resource {
 							},
 						},
 					},
+					Set: sdkv2.SimpleSchemaSetFunc(names.AttrName),
 				},
 				"global_table_witness": {
 					Type:     schema.TypeList,
@@ -3696,73 +3699,91 @@ func customDiffGlobalSecondaryIndex(_ context.Context, diff *schema.ResourceDiff
 	planGSI := planRaw.GetAttr("global_secondary_index")
 	plan := collectGSI(planGSI)
 
-	// Adding or removing GSIs
-	if len(plan) != len(state) {
-		return nil
-	}
-
-	// GSI name mismatch
-	for name := range state {
-		if _, ok := plan[name]; !ok {
-			return nil
+	// Group changed keys by GSI element hash
+	keysByHash := make(map[string][]string)
+	for _, key := range diff.GetChangedKeysPrefix("global_secondary_index") {
+		parts := strings.Split(key, ".")
+		if len(parts) >= 2 && parts[1] != "#" {
+			hash := parts[1]
+			keysByHash[hash] = append(keysByHash[hash], key)
 		}
 	}
 
-	for name, vState := range state {
-		vPlan := plan[name]
+	for hash := range keysByHash {
+		nameKey := fmt.Sprintf("global_secondary_index.%s.%s", hash, names.AttrName)
+		gsiName, ok := diff.Get(nameKey).(string)
+		if !ok || gsiName == "" {
+			continue
+		}
 
-		for attrName := range vState.Type().AttributeTypes() {
-			s := vState.GetAttr(attrName)
-			p := vPlan.GetAttr(attrName)
-			switch attrName {
-			case "hash_key":
-				if p.IsNull() && !s.IsNull() && vPlan.GetAttr("key_schema").LengthInt() > 0 {
-					// "key_schema" is set
-					continue // change to "key_schema" will be caught by equality test
-				}
-				if !ctyValueLegacyEquals(s, p) {
-					return nil
-				}
-
-			case "range_key":
-				if p.IsNull() && !s.IsNull() && vPlan.GetAttr("key_schema").LengthInt() > 0 {
-					// "key_schema" is set
-					continue // change to "key_schema" will be caught by equality test
-				}
-				if !ctyValueLegacyEquals(s, p) {
-					return nil
-				}
-
-			case "key_schema":
-				// key_schema is a block nested list, so the zero-value is an empty list
-				if p.LengthInt() == 0 && s.LengthInt() > 0 {
-					// "hash_key" is set
-					continue // change to "hash_key" will be caught by equality test
-				}
-				if !ctyValueLegacyEquals(s, p) {
-					return nil
-				}
-
-			case "warm_throughput":
-				// AWS automatically sets warm_throughput
-				// values for on-demand tables, but these should not cause diffs when
-				// the user hasn't explicitly configured warm_throughput.
-				if p.IsNull() || (p.IsKnown() && p.LengthInt() == 0) {
-					continue
-				}
-				if !ctyValueLegacyEquals(s, p) {
-					return nil
-				}
-
-			default:
-				if !ctyValueLegacyEquals(s, p) {
-					return nil
+		vState, existsInState := state[gsiName]
+		vPlan, existsInPlan := plan[gsiName]
+		if existsInState && existsInPlan {
+			if !gsiHasFunctionalChanges(vState, vPlan) {
+				for _, attr := range []string{"hash_key", "range_key", "key_schema", "read_capacity", "write_capacity", "warm_throughput"} {
+					key := fmt.Sprintf("global_secondary_index.%s.%s", hash, attr)
+					if err := diff.Clear(key); err != nil {
+						return err
+					}
 				}
 			}
 		}
 	}
 
-	return diff.Clear("global_secondary_index")
+	return nil
+}
+
+func gsiHasFunctionalChanges(vState, vPlan cty.Value) bool {
+	for attrName := range vState.Type().AttributeTypes() {
+		s := vState.GetAttr(attrName)
+		p := vPlan.GetAttr(attrName)
+		switch attrName {
+		case "hash_key":
+			if p.IsNull() && !s.IsNull() && vPlan.GetAttr("key_schema").LengthInt() > 0 {
+				// "key_schema" is set
+				continue
+			}
+			if !ctyValueLegacyEquals(s, p) {
+				return true
+			}
+
+		case "range_key":
+			if p.IsNull() && !s.IsNull() && vPlan.GetAttr("key_schema").LengthInt() > 0 {
+				// "key_schema" is set
+				continue
+			}
+			if !ctyValueLegacyEquals(s, p) {
+				return true
+			}
+
+		case "key_schema":
+			// key_schema is a block nested list, so the zero-value is an empty list
+			if p.LengthInt() == 0 && s.LengthInt() > 0 {
+				// "hash_key" is set
+				continue
+			}
+			if !ctyValueLegacyEquals(s, p) {
+				return true
+			}
+
+		case "warm_throughput":
+			// AWS automatically sets warm_throughput
+			// values for on-demand tables, but these should not cause diffs when
+			// the user hasn't explicitly configured warm_throughput.
+			if p.IsNull() || (p.IsKnown() && p.LengthInt() == 0) {
+				continue
+			}
+			if !ctyValueLegacyEquals(s, p) {
+				return true
+			}
+
+		default:
+			if !ctyValueLegacyEquals(s, p) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func collectGSI(gsi cty.Value) map[string]cty.Value {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

GSI changes on `aws_dynamodb_table` can often show additional changes in the plan that are not applied. For example, adding or removing a GSI can show that all keys are changed.

```terraform
  # aws_dynamodb_table.test will be updated in-place
  ~ resource "aws_dynamodb_table" "test" {
        id                          = "gsi-regression-test-2"
        name                        = "gsi-regression-test-2"
        tags                        = {}
        # (14 unchanged attributes hidden)

      - global_secondary_index {
          - hash_key           = "gsi1pk" -> null
          - name               = "gsi1" -> null
          - non_key_attributes = [] -> null
          - projection_type    = "ALL" -> null
          - range_key          = "gsi1sk" -> null
          - read_capacity      = 0 -> null
          - write_capacity     = 0 -> null

          - key_schema {
              - attribute_name = "gsi1pk" -> null
              - key_type       = "HASH" -> null
            }
          - key_schema {
              - attribute_name = "gsi1sk" -> null
              - key_type       = "RANGE" -> null
            }
        }
      - global_secondary_index {
          - hash_key           = "gsi2pk" -> null
          - name               = "gsi2" -> null
          - non_key_attributes = [] -> null
          - projection_type    = "ALL" -> null
          - range_key          = "gsi2sk" -> null
          - read_capacity      = 0 -> null
          - write_capacity     = 0 -> null

          - key_schema {
              - attribute_name = "gsi2pk" -> null
              - key_type       = "HASH" -> null
            }
          - key_schema {
              - attribute_name = "gsi2sk" -> null
              - key_type       = "RANGE" -> null
            }
        }
      - global_secondary_index {
          - hash_key           = "gsi3pk" -> null
          - name               = "gsi3" -> null
          - non_key_attributes = [] -> null
          - projection_type    = "ALL" -> null
          - range_key          = "gsi3sk" -> null
          - read_capacity      = 0 -> null
          - write_capacity     = 0 -> null

          - key_schema {
              - attribute_name = "gsi3pk" -> null
              - key_type       = "HASH" -> null
            }
          - key_schema {
              - attribute_name = "gsi3sk" -> null
              - key_type       = "RANGE" -> null
            }
        }
      + global_secondary_index {
          + hash_key           = (known after apply)
          + name               = "gsi1"
          + non_key_attributes = []
          + projection_type    = "ALL"
          + read_capacity      = (known after apply)
          + write_capacity     = (known after apply)
            # (1 unchanged attribute hidden)

          + key_schema {
              + attribute_name = "gsi1pk"
              + key_type       = "HASH"
            }
          + key_schema {
              + attribute_name = "gsi1sk"
              + key_type       = "RANGE"
            }

          + warm_throughput (known after apply)
        }
      + global_secondary_index {
          + hash_key           = (known after apply)
          + name               = "gsi3"
          + non_key_attributes = []
          + projection_type    = "ALL"
          + read_capacity      = (known after apply)
          + write_capacity     = (known after apply)
            # (1 unchanged attribute hidden)

          + key_schema {
              + attribute_name = "gsi3pk"
              + key_type       = "HASH"
            }
          + key_schema {
              + attribute_name = "gsi3sk"
              + key_type       = "RANGE"
            }

          + warm_throughput (known after apply)
        }

        # (10 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
