### PR TITLE
l/aws_dsql_cluster_policy: new list resource

### DIFF
--- a/.changelog/49676.txt
+++ b/.changelog/49676.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_dsql_cluster_policy
+```

--- a/internal/service/dsql/cluster_policy.go
+++ b/internal/service/dsql/cluster_policy.go
@@ -16,6 +16,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/dsql/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -150,12 +151,16 @@ func (r *clusterPolicyResource) Read(ctx context.Context, request resource.ReadR
 		return
 	}
 
-	smerr.AddEnrich(ctx, &response.Diagnostics, flex.Flatten(ctx, output, &data))
+	smerr.AddEnrich(ctx, &response.Diagnostics, r.flatten(ctx, output, &data))
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *clusterPolicyResource) flatten(ctx context.Context, output *dsql.GetClusterPolicyOutput, data *clusterPolicyResourceModel) diag.Diagnostics {
+	return flex.Flatten(ctx, output, data)
 }
 
 func (r *clusterPolicyResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {

--- a/internal/service/dsql/cluster_policy_list.go
+++ b/internal/service/dsql/cluster_policy_list.go
@@ -1,0 +1,80 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dsql
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dsql"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkListResource("aws_dsql_cluster_policy")
+func newClusterPolicyResourceAsListResource() list.ListResourceWithConfigure {
+	return &clusterPolicyListResource{}
+}
+
+var _ list.ListResource = &clusterPolicyListResource{}
+
+type clusterPolicyListResource struct {
+	clusterPolicyResource
+	framework.WithList
+}
+
+func (l *clusterPolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().DSQLClient(ctx)
+
+	tflog.Info(ctx, "Listing Aurora DSQL Cluster Policies")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		var clusterInput dsql.ListClustersInput
+		for cluster, err := range listClusters(ctx, conn, &clusterInput) {
+			if err != nil {
+				yield(fwdiag.NewListResultErrorDiagnostic(err))
+				return
+			}
+
+			id := aws.ToString(cluster.Identifier)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey(names.AttrIdentifier), id)
+
+			output, err := findClusterPolicyByID(ctx, conn, id)
+			if retry.NotFound(err) {
+				continue
+			}
+			if err != nil {
+				yield(fwdiag.NewListResultErrorDiagnostic(err))
+				return
+			}
+
+			result := request.NewListResult(ctx)
+
+			var data clusterPolicyResourceModel
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
+				data.Identifier = fwflex.StringValueToFramework(ctx, id)
+
+				if request.IncludeResource {
+					result.Diagnostics.Append(l.flatten(ctx, output, &data)...)
+					if result.Diagnostics.HasError() {
+						return
+					}
+				}
+
+				result.DisplayName = id
+			})
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/service/dsql/cluster_policy_list_test.go
+++ b/internal/service/dsql/cluster_policy_list_test.go
@@ -1,0 +1,180 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dsql_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDSQLClusterPolicy_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_dsql_cluster_policy.test[0]"
+	resourceName2 := "aws_dsql_cluster_policy.test[1]"
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
+		CheckDestroy:             testAccCheckClusterPolicyDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ClusterPolicy/list_basic/"),
+				ConfigVariables: config.Variables{
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/ClusterPolicy/list_basic/"),
+				ConfigVariables: config.Variables{
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_dsql_cluster_policy.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_dsql_cluster_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.NotNull()),
+					tfquerycheck.ExpectNoResourceObject("aws_dsql_cluster_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_dsql_cluster_policy.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_dsql_cluster_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.NotNull()),
+					tfquerycheck.ExpectNoResourceObject("aws_dsql_cluster_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDSQLClusterPolicy_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_dsql_cluster_policy.test[0]"
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
+		CheckDestroy:             testAccCheckClusterPolicyDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ClusterPolicy/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrIdentifier), knownvalue.NotNull()),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/ClusterPolicy/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_dsql_cluster_policy.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_dsql_cluster_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.NotNull()),
+					querycheck.ExpectResourceKnownValues("aws_dsql_cluster_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrIdentifier), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPolicy), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("policy_version"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDSQLClusterPolicy_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_dsql_cluster_policy.test[0]"
+	resourceName2 := "aws_dsql_cluster_policy.test[1]"
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ClusterPolicy/list_region_override/"),
+				ConfigVariables: config.Variables{
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/ClusterPolicy/list_region_override/"),
+				ConfigVariables: config.Variables{
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_dsql_cluster_policy.test", identity1.Checks()),
+					tfquerycheck.ExpectIdentityFunc("aws_dsql_cluster_policy.test", identity2.Checks()),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/dsql/service_package_gen.go
+++ b/internal/service/dsql/service_package_gen.go
@@ -72,6 +72,13 @@ func (p *servicePackage) FrameworkListResources(ctx context.Context) iter.Seq[*i
 			Region:   inttypes.ResourceRegionDefault(),
 			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttribute(names.AttrIdentifier, true)),
 		},
+		{
+			Factory:  newClusterPolicyResourceAsListResource,
+			TypeName: "aws_dsql_cluster_policy",
+			Name:     "Cluster Policy",
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttribute(names.AttrIdentifier, true)),
+		},
 	})
 }
 

--- a/internal/service/dsql/testdata/ClusterPolicy/list_basic/main.tf
+++ b/internal/service/dsql/testdata/ClusterPolicy/list_basic/main.tf
@@ -1,0 +1,37 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_dsql_cluster_policy" "test" {
+  count = var.resource_count
+
+  identifier = aws_dsql_cluster.test[count.index].identifier
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCurrentAccountConnect"
+        Effect = "Allow"
+        Principal = {
+          AWS = data.aws_caller_identity.current.account_id
+        }
+        Action = [
+          "dsql:DbConnect",
+        ]
+        Resource = aws_dsql_cluster.test[count.index].arn
+      }
+    ]
+  })
+}
+
+resource "aws_dsql_cluster" "test" {
+  count = var.resource_count
+}
+
+data "aws_caller_identity" "current" {}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/dsql/testdata/ClusterPolicy/list_basic/query.tfquery.hcl
+++ b/internal/service/dsql/testdata/ClusterPolicy/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_dsql_cluster_policy" "test" {
+  provider = aws
+}

--- a/internal/service/dsql/testdata/ClusterPolicy/list_include_resource/main.tf
+++ b/internal/service/dsql/testdata/ClusterPolicy/list_include_resource/main.tf
@@ -1,0 +1,37 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_dsql_cluster_policy" "test" {
+  count = var.resource_count
+
+  identifier = aws_dsql_cluster.test[count.index].identifier
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCurrentAccountConnect"
+        Effect = "Allow"
+        Principal = {
+          AWS = data.aws_caller_identity.current.account_id
+        }
+        Action = [
+          "dsql:DbConnect",
+        ]
+        Resource = aws_dsql_cluster.test[count.index].arn
+      }
+    ]
+  })
+}
+
+resource "aws_dsql_cluster" "test" {
+  count = var.resource_count
+}
+
+data "aws_caller_identity" "current" {}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/dsql/testdata/ClusterPolicy/list_include_resource/query.tfquery.hcl
+++ b/internal/service/dsql/testdata/ClusterPolicy/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_dsql_cluster_policy" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/dsql/testdata/ClusterPolicy/list_region_override/main.tf
+++ b/internal/service/dsql/testdata/ClusterPolicy/list_region_override/main.tf
@@ -1,0 +1,45 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_dsql_cluster_policy" "test" {
+  count = var.resource_count
+
+  identifier = aws_dsql_cluster.test[count.index].identifier
+  region     = var.region
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCurrentAccountConnect"
+        Effect = "Allow"
+        Principal = {
+          AWS = data.aws_caller_identity.current.account_id
+        }
+        Action = [
+          "dsql:DbConnect",
+        ]
+        Resource = aws_dsql_cluster.test[count.index].arn
+      }
+    ]
+  })
+}
+
+resource "aws_dsql_cluster" "test" {
+  count  = var.resource_count
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/dsql/testdata/ClusterPolicy/list_region_override/query.tfquery.hcl
+++ b/internal/service/dsql/testdata/ClusterPolicy/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_dsql_cluster_policy" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/dsql_cluster_policy.html.markdown
+++ b/website/docs/list-resources/dsql_cluster_policy.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "DSQL"
+layout: "aws"
+page_title: "AWS: aws_dsql_cluster_policy"
+description: |-
+  Lists Aurora DSQL Cluster Policy resources.
+---
+
+# List Resource: aws_dsql_cluster_policy
+
+Lists Aurora DSQL Cluster Policy resources.
+
+## Example Usage
+
+```terraform
+list "aws_dsql_cluster_policy" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION


<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds a new list resource, `aws_dsql_cluster_policy`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/47748

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=dsql T=TestAccDSQLClusterPolicy_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-dsql_cluster_policy-autoflex 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/dsql/... -v -count 1 -parallel 20 -run='TestAccDSQLClusterPolicy_'  -timeout 360m -vet=off -buildvcs=false
2026/08/25 13:18:32 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/25 13:18:32 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccDSQLClusterPolicy_basic (124.78s)
--- PASS: TestAccDSQLClusterPolicy_disappears (129.23s)
--- PASS: TestAccDSQLClusterPolicy_List_includeResource (129.76s)
--- PASS: TestAccDSQLClusterPolicy_List_basic (134.18s)
--- PASS: TestAccDSQLClusterPolicy_List_regionOverride (140.49s)
--- PASS: TestAccDSQLClusterPolicy_bypassPolicyLockoutSafetyCheck (147.67s)
--- PASS: TestAccDSQLClusterPolicy_Identity_regionOverride (162.29s)
--- PASS: TestAccDSQLClusterPolicy_Identity_basic (176.37s)
--- PASS: TestAccDSQLClusterPolicy_policy (176.51s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dsql       185.693s
```