### PR TITLE
r/aws_savingsplan_savings_plan: mark `queued` as a target state during creation

### DIFF
--- a/.changelog/49678.txt
+++ b/.changelog/49678.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_savingsplan_savings_plan: Treat `queued` as a target state during creation
+```
+```release-note:bug
+resource/aws_savingsplan_savings_plan: Because we cannot easily test this functionality, it is best effort and we ask for community help in testing
+```

--- a/internal/service/savingsplans/savings_plan.go
+++ b/internal/service/savingsplans/savings_plan.go
@@ -313,8 +313,8 @@ func (r *savingsPlanResource) ImportState(ctx context.Context, req resource.Impo
 
 func waitSavingsPlanCreated(ctx context.Context, conn *savingsplans.Client, id string, timeout time.Duration) (*awstypes.SavingsPlan, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.SavingsPlanStatePaymentPending, awstypes.SavingsPlanStateQueued),
-		Target:  enum.Slice(awstypes.SavingsPlanStateActive),
+		Pending: enum.Slice(awstypes.SavingsPlanStatePaymentPending),
+		Target:  enum.Slice(awstypes.SavingsPlanStateQueued, awstypes.SavingsPlanStateActive),
 		Refresh: statusSavingsPlan(conn, id),
 		Timeout: timeout,
 	}


### PR DESCRIPTION



<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This will allow future-dated savings plans to be created without the operation timing out while waiting for an `active` state that will never arrive.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #47519


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Acceptance tests cannot be run for this resource, so we ask for community help in validating the behavior of this change.

