### PR TITLE
r/aws_savingsplan_savings_plan: mark `purchase_time` as `Optional` and `Computed`

### DIFF
--- a/.changelog/49679.txt
+++ b/.changelog/49679.txt
@@ -4,4 +4,3 @@ resource/aws_savingsplan_savings_plan: Mark `purchase_time` as `Optional` and `C
 ```release-note:bug
 resource/aws_savingsplan_savings_plan: Because we cannot easily test this functionality, it is best effort and we ask for community help in testing
 ```
-```

--- a/.changelog/49679.txt
+++ b/.changelog/49679.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_savingsplan_savings_plan: Mark `purchase_time` as `Optional` and `Computed`
+```
+```release-note:bug
+resource/aws_savingsplan_savings_plan: Because we cannot easily test this functionality, it is best effort and we ask for community help in testing
+```
+```

--- a/internal/service/savingsplans/savings_plan.go
+++ b/internal/service/savingsplans/savings_plan.go
@@ -115,9 +115,11 @@ func (r *savingsPlanResource) Schema(ctx context.Context, req resource.SchemaReq
 			"purchase_time": schema.StringAttribute{
 				CustomType:  timetypes.RFC3339Type{},
 				Optional:    true,
+				Computed:    true,
 				Description: "The time at which to purchase the Savings Plan, in UTC format (YYYY-MM-DDTHH:MM:SSZ).",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"recurring_payment_amount": schema.StringAttribute{


### PR DESCRIPTION




<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
When omitted AWS purchases the plan immediately, and returns the purchase timestamp accordingly. To allow for immediate creation of savings plans, and import of existing plans where purchase time is not future dated, this argument is now marked as both optional and computed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/47519#issuecomment-4274273494



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Acceptance tests cannot be run for this resource, so we ask for community help in validating the behavior of this change.
