### PR TITLE
r/aws_opensearch_domain: add software_update_options.use_latest_service_software_for_blue_green

### DIFF
--- a/.changelog/49683.txt
+++ b/.changelog/49683.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_opensearch_domain: Add `software_update_options.use_latest_service_software_for_blue_green` argument
+```
+
+```release-note:enhancement
+data-source/aws_opensearch_domain: Add `software_update_options.use_latest_service_software_for_blue_green` attribute
+```

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -794,6 +794,11 @@ func resourceDomain() *schema.Resource {
 								Optional: true,
 								Computed: true,
 							},
+							"use_latest_service_software_for_blue_green": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
 						},
 					},
 				},

--- a/internal/service/opensearch/domain_data_source.go
+++ b/internal/service/opensearch/domain_data_source.go
@@ -485,6 +485,10 @@ func dataSourceDomain() *schema.Resource {
 								Type:     schema.TypeBool,
 								Computed: true,
 							},
+							"use_latest_service_software_for_blue_green": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
 						},
 					},
 				},

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -2527,6 +2527,7 @@ func TestAccOpenSearchDomain_softwareUpdateOptions(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, t, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "software_update_options.0.auto_software_update_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "software_update_options.0.use_latest_service_software_for_blue_green", acctest.CtFalse),
 				),
 			},
 			{
@@ -2534,6 +2535,7 @@ func TestAccOpenSearchDomain_softwareUpdateOptions(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, t, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "software_update_options.0.auto_software_update_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "software_update_options.0.use_latest_service_software_for_blue_green", acctest.CtTrue),
 				),
 			},
 		},
@@ -4912,7 +4914,8 @@ resource "aws_opensearch_domain" "test" {
   }
 
   software_update_options {
-    auto_software_update_enabled = %[2]t
+    auto_software_update_enabled               = %[2]t
+    use_latest_service_software_for_blue_green = %[2]t
   }
 }
 `, rName, option)

--- a/internal/service/opensearch/flex.go
+++ b/internal/service/opensearch/flex.go
@@ -237,6 +237,9 @@ func expandSoftwareUpdateOptions(in []any) *awstypes.SoftwareUpdateOptions {
 	if v, ok := m["auto_software_update_enabled"].(bool); ok {
 		out.AutoSoftwareUpdateEnabled = aws.Bool(v)
 	}
+	if v, ok := m["use_latest_service_software_for_blue_green"].(bool); ok {
+		out.UseLatestServiceSoftwareForBlueGreen = aws.Bool(v)
+	}
 
 	return &out
 }
@@ -247,7 +250,8 @@ func flattenSoftwareUpdateOptions(softwareUpdateOptions *awstypes.SoftwareUpdate
 	}
 
 	m := map[string]any{
-		"auto_software_update_enabled": aws.ToBool(softwareUpdateOptions.AutoSoftwareUpdateEnabled),
+		"auto_software_update_enabled":               aws.ToBool(softwareUpdateOptions.AutoSoftwareUpdateEnabled),
+		"use_latest_service_software_for_blue_green": aws.ToBool(softwareUpdateOptions.UseLatestServiceSoftwareForBlueGreen),
 	}
 
 	return []any{m}

--- a/website/docs/d/opensearch_domain.html.markdown
+++ b/website/docs/d/opensearch_domain.html.markdown
@@ -121,6 +121,7 @@ This data source exports the following attributes in addition to the arguments a
     * `automated_snapshot_start_hour` - Hour during which the service takes an automated daily snapshot of the indices in the domain.
 * `software_update_options` - Software update options for the domain
     * `auto_software_update_enabled` - Enabled or disabled.
+    * `use_latest_service_software_for_blue_green` - Whether the domain uses the latest available service software during a blue/green deployment.
 * `tags` - Tags assigned to the domain.
 * `vpc_options` - VPC Options for private OpenSearch domains.
     * `availability_zones` - Availability zones used by the domain.

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -489,6 +489,7 @@ AWS documentation: [Amazon Cognito Authentication for Dashboard](https://docs.aw
 ### software_update_options
 
 * `auto_software_update_enabled` - (Optional) Whether automatic service software updates are enabled for the domain. Defaults to `false`.
+* `use_latest_service_software_for_blue_green` - (Optional) Whether the domain should use the latest available service software during a blue/green deployment. When enabled, the domain automatically uses the latest available service software when a blue/green deployment is triggered. Defaults to `false`.
 
 ### vpc_options
 

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -489,7 +489,7 @@ AWS documentation: [Amazon Cognito Authentication for Dashboard](https://docs.aw
 ### software_update_options
 
 * `auto_software_update_enabled` - (Optional) Whether automatic service software updates are enabled for the domain. Defaults to `false`.
-* `use_latest_service_software_for_blue_green` - (Optional) Whether the domain should use the latest available service software during a blue/green deployment. When enabled, the domain automatically uses the latest available service software when a blue/green deployment is triggered. Defaults to `false`.
+* `use_latest_service_software_for_blue_green` - (Optional) Whether the domain should use the latest available service software during a blue/green deployment. When enabled, the domain automatically uses the latest available service software when a blue/green deployment is triggered. If not set, the AWS service default applies.
 
 ### vpc_options
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Adds support for `use_latest_service_software_for_blue_green` within the `software_update_options` block of the `aws_opensearch_domain` resource and data source.

When enabled, the OpenSearch domain automatically uses the latest available service software during a blue/green deployment, rather than the currently pinned service software version. The property is already supported by the AWS API (`SoftwareUpdateOptions.UseLatestServiceSoftwareForBlueGreen`) but was not exposed by the provider. It is optional and defaults to `false`, so existing configurations are unaffected.

Changes:
- `resource/aws_opensearch_domain`: new `software_update_options.use_latest_service_software_for_blue_green` argument (Optional, Computed), wired through `expandSoftwareUpdateOptions`/`flattenSoftwareUpdateOptions`.
- `data-source/aws_opensearch_domain`: corresponding computed attribute.
- Documentation and CHANGELOG updated.
- Extended `TestAccOpenSearchDomain_softwareUpdateOptions` to cover the new attribute.

### Relations

Closes #49684

### References

- AWS SDK for Go v2 `opensearch` types: `SoftwareUpdateOptions.UseLatestServiceSoftwareForBlueGreen`
- CloudFormation: `AWS::OpenSearchService::Domain` `SoftwareUpdateOptions.UseLatestServiceSoftwareForBlueGreen`

### Output from Acceptance Testing

<!-- Acceptance tests deploy a real OpenSearch domain (~15-20 min, incurs cost). To be run before merge. -->

```console
% make testacc TESTS=TestAccOpenSearchDomain_softwareUpdateOptions PKG=opensearch

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-opensearch-use-latest-service-software-blue-green 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain_softwareUpdateOptions'  -timeout 360m -vet=off -buildvcs=false
2026/08/26 02:23:23 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/26 02:23:23 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccOpenSearchDomain_softwareUpdateOptions
=== PAUSE TestAccOpenSearchDomain_softwareUpdateOptions
=== CONT  TestAccOpenSearchDomain_softwareUpdateOptions
--- PASS: TestAccOpenSearchDomain_softwareUpdateOptions (2011.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 2018.167s

```
