### PR TITLE
resource/aws_s3_account_public_access_block: Handle eventual consistency on create

### DIFF
--- a/.changelog/49687.txt
+++ b/.changelog/49687.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_account_public_access_block: Fixes eventual consistency issue on creation
+```

--- a/internal/service/s3control/account_public_access_block.go
+++ b/internal/service/s3control/account_public_access_block.go
@@ -100,9 +100,12 @@ func resourceAccountPublicAccessBlockCreate(ctx context.Context, d *schema.Resou
 
 	d.SetId(accountID)
 
-	_, err = tfresource.RetryWhenNotFound(ctx, s3PropagationTimeout, func(ctx context.Context) (any, error) {
+	const (
+		inARow = 2
+	)
+	_, err = retry.Op(func(ctx context.Context) (any, error) {
 		return findPublicAccessBlockByAccountID(ctx, conn, d.Id())
-	})
+	}).UntilFoundN(inARow)(ctx, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for S3 Account Public Access Block (%s) create: %s", d.Id(), err)


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Handles eventual consistency on create by waiting for the resource to be present for two consecutive requests.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3control TESTS=TestAccS3ControlAccountPublicAccessBlock_serial

--- PASS: TestAccS3ControlAccountPublicAccessBlock_serial (707.42s)
    --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock (707.42s)
        --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/DataSourceBasic (62.00s)
        --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/Identity (184.05s)
            --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/Identity/basic (29.05s)
            --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/Identity/ExistingResource (108.61s)
            --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/Identity/ExistingResourceNoRefresh (41.38s)
        --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/basic (49.98s)
        --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/BlockPublicPolicy (70.87s)
        --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/RestrictPublicBuckets (83.72s)
        --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/disappears (22.13s)
        --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/AccountId (39.07s)
        --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/BlockPublicAcls (115.91s)
        --- PASS: TestAccS3ControlAccountPublicAccessBlock_serial/PublicAccessBlock/IgnorePublicAcls (79.70s)
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>