### PR TITLE
Fixes error in Framework Import by Resource with optional identity attributes

### DIFF
--- a/internal/provider/framework/importer/parameterized.go
+++ b/internal/provider/framework/importer/parameterized.go
@@ -113,12 +113,10 @@ func MultipleParameterized(ctx context.Context, client AWSClient, request resour
 					return
 				}
 
-				parameterVal := valueAsType(ctx, parameterAttr)
-
-				response.Diagnostics.Append(response.State.SetAttribute(ctx, resourcePath, parameterVal)...)
+				response.Diagnostics.Append(response.State.SetAttribute(ctx, resourcePath, parameterAttr)...)
 
 				if identity := response.Identity; identity != nil {
-					response.Diagnostics.Append(identity.SetAttribute(ctx, identityPath, parameterVal)...)
+					response.Diagnostics.Append(identity.SetAttribute(ctx, identityPath, parameterAttr)...)
 				}
 			}
 		}
@@ -145,28 +143,5 @@ func MultipleParameterized(ctx context.Context, client AWSClient, request resour
 
 	if !identitySpec.IsGlobalResource {
 		setRegionFromStateOrIdentity(ctx, client, request, response)
-	}
-}
-
-func valueAsType(ctx context.Context, v fwattr.Value) any {
-	if v.IsNull() || v.IsUnknown() {
-		return nil
-	}
-
-	switch v.Type(ctx) {
-	case types.StringType:
-		return v.(types.String).ValueString()
-	case types.Float64Type:
-		return v.(types.Float64).ValueFloat64()
-	case types.Int64Type:
-		return v.(types.Int64).ValueInt64()
-	case types.Int32Type:
-		return v.(types.Int32).ValueInt32()
-	case types.NumberType:
-		return v.(types.Number).ValueBigFloat()
-	case types.BoolType:
-		return v.(types.Bool).ValueBool()
-	default:
-		return nil
 	}
 }

--- a/internal/provider/framework/importer/parameterized_test.go
+++ b/internal/provider/framework/importer/parameterized_test.go
@@ -866,6 +866,14 @@ func regionalMultipleParameterizedIdentitySpecWithMappedName(attrNames map[strin
 	return inttypes.RegionalParameterizedIdentity(attrs)
 }
 
+func regionalMultipleParameterizedIdentitySpecWithOptionalValue(attrNames map[string]bool) inttypes.Identity {
+	var attrs []inttypes.IdentityAttribute
+	for attrName, required := range attrNames {
+		attrs = append(attrs, inttypes.StringIdentityAttribute(attrName, required))
+	}
+	return inttypes.RegionalParameterizedIdentity(attrs)
+}
+
 func TestRegionalMutipleParameterized_ByImportID(t *testing.T) {
 	t.Parallel()
 
@@ -1252,6 +1260,26 @@ func TestRegionalMutipleParameterized_ByIdentity(t *testing.T) {
 			expectedRegion: region,
 			expectError:    false,
 		},
+
+		"null value": {
+			identityAttrValues: map[string]string{
+				"name": "a_name",
+			},
+			identitySpec: regionalMultipleParameterizedIdentitySpecWithOptionalValue(map[string]bool{
+				"name": true,
+				"type": false,
+			}),
+			expectedIdentityAttrs: map[string]string{
+				"account_id": accountID,
+				"region":     region,
+				"name":       "a_name",
+			},
+			expectedResourceAttrs: map[string]string{
+				"name": "a_name",
+			},
+			expectedRegion: region,
+			expectError:    false,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -1373,6 +1401,14 @@ func globalMultipleParameterizedIdentitySpecWithMappedName(attrNames map[string]
 		} else {
 			attrs = append(attrs, inttypes.StringIdentityAttributeWithMappedName(identityAttrName, true, resourceAttrName))
 		}
+	}
+	return inttypes.GlobalParameterizedIdentity(attrs)
+}
+
+func globalMultipleParameterizedIdentitySpecWithOptionalValue(attrNames map[string]bool) inttypes.Identity {
+	var attrs []inttypes.IdentityAttribute
+	for attrName, required := range attrNames {
+		attrs = append(attrs, inttypes.StringIdentityAttribute(attrName, required))
 	}
 	return inttypes.GlobalParameterizedIdentity(attrs)
 }
@@ -1681,6 +1717,24 @@ func TestGlobalMutipleParameterized_ByIdentity(t *testing.T) {
 			expectedResourceAttrs: map[string]string{
 				"name": "a_name",
 				"type": "a_type",
+			},
+			expectError: false,
+		},
+
+		"null value": {
+			identityAttrValues: map[string]string{
+				"name": "a_name",
+			},
+			identitySpec: globalMultipleParameterizedIdentitySpecWithOptionalValue(map[string]bool{
+				"name": true,
+				"type": false,
+			}),
+			expectedIdentityAttrs: map[string]string{
+				"account_id": accountID,
+				"name":       "a_name",
+			},
+			expectedResourceAttrs: map[string]string{
+				"name": "a_name",
 			},
 			expectError: false,
 		},

--- a/internal/provider/framework/importer/parameterized_test.go
+++ b/internal/provider/framework/importer/parameterized_test.go
@@ -1249,7 +1249,6 @@ func TestRegionalMutipleParameterized_ByIdentity(t *testing.T) {
 				"name": "a_name",
 				"type": "a_type",
 			},
-			expectedID:     "a_name,a_type",
 			expectedRegion: region,
 			expectError:    false,
 		},
@@ -1595,7 +1594,6 @@ func TestGlobalMutipleParameterized_ByIdentity(t *testing.T) {
 				"type": "a_type",
 			},
 			identitySpec: globalMultipleParameterizedIdentitySpec([]string{"name", "type"}),
-			expectedID:   "a_name,a_type",
 			expectedIdentityAttrs: map[string]string{
 				"account_id": accountID,
 				"name":       "a_name",
@@ -1614,7 +1612,6 @@ func TestGlobalMutipleParameterized_ByIdentity(t *testing.T) {
 				"type":       "a_type",
 			},
 			identitySpec: globalMultipleParameterizedIdentitySpec([]string{"name", "type"}),
-			expectedID:   "a_name,a_type",
 			expectedIdentityAttrs: map[string]string{
 				"account_id": accountID,
 				"name":       "a_name",
@@ -1685,7 +1682,6 @@ func TestGlobalMutipleParameterized_ByIdentity(t *testing.T) {
 				"name": "a_name",
 				"type": "a_type",
 			},
-			expectedID:  "a_name,a_type",
 			expectError: false,
 		},
 	}

--- a/internal/provider/sdkv2/importer/parameterized_test.go
+++ b/internal/provider/sdkv2/importer/parameterized_test.go
@@ -567,6 +567,14 @@ func regionalMultipleParameterizedIdentitySpecWithMappedName(attrNames map[strin
 	return inttypes.RegionalParameterizedIdentity(attrs)
 }
 
+func regionalMultipleParameterizedIdentitySpecWithOptionalValue(attrNames map[string]bool) inttypes.Identity {
+	var attrs []inttypes.IdentityAttribute
+	for attrName, required := range attrNames {
+		attrs = append(attrs, inttypes.StringIdentityAttribute(attrName, required))
+	}
+	return inttypes.RegionalParameterizedIdentity(attrs)
+}
+
 func TestRegionalMutipleParameterized_ByImportID(t *testing.T) {
 	t.Parallel()
 
@@ -763,6 +771,22 @@ func TestRegionalMutipleParameterized_ByIdentity(t *testing.T) {
 			expectedRegion: region,
 			expectError:    false,
 		},
+
+		"null value": {
+			identityAttrs: map[string]string{
+				"name": "a_name",
+			},
+			identitySpec: regionalMultipleParameterizedIdentitySpecWithOptionalValue(map[string]bool{
+				"name": true,
+				"type": false,
+			}),
+			expectedAttrs: map[string]string{
+				"name": "a_name",
+			},
+			expectedID:     "a_name,",
+			expectedRegion: region,
+			expectError:    false,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -846,6 +870,14 @@ func globalMultipleParameterizedIdentitySpecWithMappedName(attrNames map[string]
 		} else {
 			attrs = append(attrs, inttypes.StringIdentityAttributeWithMappedName(identityAttrName, true, resourceAttrName))
 		}
+	}
+	return inttypes.GlobalParameterizedIdentity(attrs)
+}
+
+func globalMultipleParameterizedIdentitySpecWithOptionalValue(attrNames map[string]bool) inttypes.Identity {
+	var attrs []inttypes.IdentityAttribute
+	for attrName, required := range attrNames {
+		attrs = append(attrs, inttypes.StringIdentityAttribute(attrName, required))
 	}
 	return inttypes.GlobalParameterizedIdentity(attrs)
 }
@@ -965,6 +997,21 @@ func TestGlobalMutipleParameterized_ByIdentity(t *testing.T) {
 			},
 			expectError: false,
 		},
+
+		"null value": {
+			identityAttrs: map[string]string{
+				"name": "a_name",
+			},
+			identitySpec: globalMultipleParameterizedIdentitySpecWithOptionalValue(map[string]bool{
+				"name": true,
+				"type": false,
+			}),
+			expectedAttrs: map[string]string{
+				"name": "a_name",
+			},
+			expectedID:  "a_name,",
+			expectError: false,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -1028,7 +1075,7 @@ func (t testImportID) Create(d *schema.ResourceData) string {
 		d.Get("name").(string),
 		d.Get("type").(string),
 	}
-	result, err := flex.FlattenResourceId(idParts, len(idParts), false)
+	result, err := flex.FlattenResourceId(idParts, len(idParts), true)
 	if err != nil {
 		t.t.Fatalf("Creating test Import ID: %s", err)
 	}
@@ -1039,7 +1086,7 @@ func (t testImportID) Create(d *schema.ResourceData) string {
 func (t testImportID) Parse(id string) (string, map[string]any, error) {
 	t.t.Helper()
 
-	parts, err := flex.ExpandResourceId(id, 2, false)
+	parts, err := flex.ExpandResourceId(id, 2, true)
 	if err != nil {
 		t.t.Fatalf("Parsing test Import ID: %s", err)
 	}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes error in Framework Multi-Parameterized importer when optional identity attributes have a `Null` value.

### Output from Smoke Tests
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make smoke-identity

ok  	github.com/hashicorp/terraform-provider-aws/internal/service/batch	231.398s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	107.220s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfrontkeyvaluestore	75.558s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator	97.883s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	165.627s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	407.528s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	119.067s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/osis	990.012s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	203.503s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	203.183s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	246.945s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	208.138s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	71.692s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/shield	7.809s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	68.402s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	158.022s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin	98.069s
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/uxc	36.294s
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>