### PR TITLE
r/aws_appautoscaling_policy: Retry read after create on empty result

### DIFF
--- a/.changelog/49694.txt
+++ b/.changelog/49694.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appautoscaling_policy: Retry the read following resource creation, fixing intermittent `empty result` errors caused by Application Auto Scaling eventual consistency
+```

--- a/internal/service/appautoscaling/exports_test.go
+++ b/internal/service/appautoscaling/exports_test.go
@@ -15,4 +15,6 @@ var (
 
 	PolicyParseImportID = policyParseImportID
 	TargetParseImportID = targetParseImportID
+
+	PolicyReadRetryable = policyReadRetryable
 )

--- a/internal/service/appautoscaling/policy.go
+++ b/internal/service/appautoscaling/policy.go
@@ -560,9 +560,9 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppAutoScalingClient(ctx)
 
-	output, err := tfresource.RetryWhenIsA[*awstypes.ScalingPolicy, *awstypes.FailedResourceAccessException](ctx, propagationTimeout, func(ctx context.Context) (*awstypes.ScalingPolicy, error) {
+	output, err := tfresource.RetryWhen(ctx, propagationTimeout, func(ctx context.Context) (*awstypes.ScalingPolicy, error) {
 		return findScalingPolicyByFourPartKey(ctx, conn, d.Get(names.AttrName).(string), d.Get("service_namespace").(string), d.Get(names.AttrResourceID).(string), d.Get("scalable_dimension").(string))
-	})
+	}, policyReadRetryable(d.IsNewResource()))
 
 	if retry.NotFound(err) && !d.IsNewResource() {
 		log.Printf("[WARN] Application Auto Scaling Scaling Policy (%s) not found, removing from state", d.Id())
@@ -605,6 +605,21 @@ func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	return diags
+}
+
+// policyReadRetryable retries a scaling policy read while the policy is being created.
+func policyReadRetryable(isNewResource bool) tfresource.Retryable {
+	return func(err error) (bool, error) {
+		if errs.IsA[*awstypes.FailedResourceAccessException](err) {
+			return true, err
+		}
+
+		if isNewResource && retry.NotFound(err) {
+			return true, err
+		}
+
+		return false, err
+	}
 }
 
 func findScalingPolicyByFourPartKey(ctx context.Context, conn *applicationautoscaling.Client, name, serviceNamespace, resourceID, scalableDimension string) (*awstypes.ScalingPolicy, error) {

--- a/internal/service/appautoscaling/policy_test.go
+++ b/internal/service/appautoscaling/policy_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfappautoscaling "github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -98,6 +99,59 @@ func TestPolicyParseImportID(t *testing.T) {
 		if !reflect.DeepEqual(tc.expected, idParts) {
 			t.Errorf("tfappautoscaling.PolicyParseImportID(%q): expected %q, but got %q", tc.input, strings.Join(tc.expected, "/"), strings.Join(idParts, "/"))
 		}
+	}
+}
+
+func TestPolicyReadRetryable(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		err           error
+		isNewResource bool
+		expected      bool
+	}{
+		"empty result while creating": {
+			err:           tfresource.NewEmptyResultError(),
+			isNewResource: true,
+			expected:      true,
+		},
+		"empty result after creating": {
+			err:           tfresource.NewEmptyResultError(),
+			isNewResource: false,
+			expected:      false,
+		},
+		"failed resource access while creating": {
+			err:           &awstypes.FailedResourceAccessException{},
+			isNewResource: true,
+			expected:      true,
+		},
+		"failed resource access after creating": {
+			err:           &awstypes.FailedResourceAccessException{},
+			isNewResource: false,
+			expected:      true,
+		},
+		"validation error while creating": {
+			err:           &awstypes.ValidationException{},
+			isNewResource: true,
+			expected:      false,
+		},
+		"no error": {
+			err:           nil,
+			isNewResource: true,
+			expected:      false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, _ := tfappautoscaling.PolicyReadRetryable(testCase.isNewResource)(testCase.err)
+
+			if got != testCase.expected {
+				t.Errorf("got %t, expected %t", got, testCase.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
`aws_appautoscaling_policy` reads the policy back immediately after `PutScalingPolicy`.
Application Auto Scaling is eventually consistent, so `DescribeScalingPolicies` can return
`200` with an empty list for a policy that was just created. `resourcePolicyRead` only
retries `FailedResourceAccessException`, and the graceful not-found branch is guarded by
`!d.IsNewResource()`, so the apply fails:

```
Error: reading Application Auto Scaling Scaling Policy (example-policy): empty result
```

This was fixed once in #11222 (2019). 244bcbbe ("r/aws_appautoscaling_policy: Tidy up.", #34934) replaced the retry loop with `tfresource.RetryWhenAWSErrCodeEquals` and dropped that case. 

32772b3a (SDK v2 migration) narrowed it to `RetryWhenIsA[*awstypes.FailedResourceAccessException]`.

This restores it by moving the read's retry decision into `policyReadRetryable`, which
retries `FailedResourceAccessException` as before plus not-found while the resource is new.

The race is timing-dependent and not reproducible on demand, so the added unit test covers
the retry predicate rather than the race itself.

LLM-assisted.

### Relations
Closes #49649

### References
* #10549 - original report
* #11222 - the 2019 fix that added the retry
* 244bcbbe (#34934) - removal
* 32772b3a - SDK v2 migration narrowing the retry to `FailedResourceAccessException`


### Output from Acceptance Testing
I need help running this from a maintainer 🙏 
```
git remote add ryanjclark https://github.com/ryanjclark/terraform-provider-aws.git
git fetch ryanjclark b-aws_appautoscaling_policy-read-retry
git checkout -t ryanjclark/b-aws_appautoscaling_policy-read-retry
make testacc TESTS=TestAccAppAutoScalingPolicy_ PKG=appautoscaling
```