### PR TITLE
l/`aws_ecr_lifecycle_policy`: New List Resource

### DIFF
--- a/.changelog/49696.txt
+++ b/.changelog/49696.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_ecr_lifecycle_policy
+```

--- a/internal/service/ecr/lifecycle_policy.go
+++ b/internal/service/ecr/lifecycle_policy.go
@@ -111,12 +111,20 @@ func resourceLifecyclePolicyRead(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "reading ECR Lifecycle Policy (%s): %s", d.Id(), err)
 	}
 
-	if equivalent, err := equivalentLifecyclePolicyJSON(d.Get(names.AttrPolicy).(string), aws.ToString(output.LifecyclePolicyText)); err != nil {
+	if err := resourceLifecyclePolicyFlatten(d, output); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
+	}
+
+	return diags
+}
+
+func resourceLifecyclePolicyFlatten(d *schema.ResourceData, output *ecr.GetLifecyclePolicyOutput) error {
+	if equivalent, err := equivalentLifecyclePolicyJSON(d.Get(names.AttrPolicy).(string), aws.ToString(output.LifecyclePolicyText)); err != nil {
+		return err
 	} else if !equivalent {
 		policyToSet, err := structure.NormalizeJsonString(aws.ToString(output.LifecyclePolicyText))
 		if err != nil {
-			return sdkdiag.AppendFromErr(diags, err)
+			return err
 		}
 
 		d.Set(names.AttrPolicy, policyToSet)
@@ -125,7 +133,7 @@ func resourceLifecyclePolicyRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("registry_id", output.RegistryId)
 	d.Set("repository", output.RepositoryName)
 
-	return diags
+	return nil
 }
 
 func resourceLifecyclePolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/ecr/lifecycle_policy_list.go
+++ b/internal/service/ecr/lifecycle_policy_list.go
@@ -36,12 +36,6 @@ type lifecyclePolicyListResourceModel struct {
 }
 
 func (l *lifecyclePolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query lifecyclePolicyListResourceModel
-	if diags := request.Config.Get(ctx, &query); diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
 	conn := l.Meta().ECRClient(ctx)
 
 	tflog.Info(ctx, "Listing ECR lifecycle policies")

--- a/internal/service/ecr/lifecycle_policy_list.go
+++ b/internal/service/ecr/lifecycle_policy_list.go
@@ -1,0 +1,100 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ecr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+)
+
+// @SDKListResource("aws_ecr_lifecycle_policy")
+func newLifecyclePolicyResourceAsListResource() inttypes.ListResourceForSDK {
+	l := lifecyclePolicyListResource{}
+	l.SetResourceSchema(resourceLifecyclePolicy())
+	return &l
+}
+
+var _ list.ListResource = &lifecyclePolicyListResource{}
+
+type lifecyclePolicyListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+type lifecyclePolicyListResourceModel struct {
+	framework.WithRegionModel
+}
+
+func (l *lifecyclePolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	var query lifecyclePolicyListResourceModel
+	if diags := request.Config.Get(ctx, &query); diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	conn := l.Meta().ECRClient(ctx)
+
+	tflog.Info(ctx, "Listing ECR lifecycle policies")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := &ecr.DescribeRepositoriesInput{}
+
+		for repository, err := range listRepositories(ctx, conn, input) {
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(err)
+				yield(result)
+				return
+			}
+
+			repositoryName := aws.ToString(repository.RepositoryName)
+			ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("repository"), repositoryName)
+
+			output, err := findLifecyclePolicyByRepositoryName(ctx, conn, repositoryName)
+			if retry.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("reading ECR Lifecycle Policy (%s): %w", repositoryName, err))
+				yield(result)
+				return
+			}
+
+			result := request.NewListResult(ctx)
+
+			rd := l.ResourceData()
+			rd.SetId(repositoryName)
+			rd.Set("repository", repositoryName)
+
+			if request.IncludeResource {
+				if err := resourceLifecyclePolicyFlatten(rd, output); err != nil {
+					result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("flattening ECR Lifecycle Policy (%s): %w", repositoryName, err))
+					yield(result)
+					return
+				}
+			}
+
+			result.DisplayName = repositoryName
+
+			l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+			if result.Diagnostics.HasError() {
+				yield(result)
+				return
+			}
+
+			if !yield(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/service/ecr/lifecycle_policy_list.go
+++ b/internal/service/ecr/lifecycle_policy_list.go
@@ -31,10 +31,6 @@ type lifecyclePolicyListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type lifecyclePolicyListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *lifecyclePolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ECRClient(ctx)
 

--- a/internal/service/ecr/lifecycle_policy_list_test.go
+++ b/internal/service/ecr/lifecycle_policy_list_test.go
@@ -28,8 +28,8 @@ func TestAccECRLifecyclePolicy_List_basic(t *testing.T) {
 	resourceName2 := "aws_ecr_lifecycle_policy.test[1]"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	repositoryName1 := tfstatecheck.StateValue()
-	repositoryName2 := tfstatecheck.StateValue()
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -48,8 +48,8 @@ func TestAccECRLifecyclePolicy_List_basic(t *testing.T) {
 					"resource_count": config.IntegerVariable(2),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					repositoryName1.GetStateValue(resourceName1, tfjsonpath.New("repository")),
-					repositoryName2.GetStateValue(resourceName2, tfjsonpath.New("repository")),
+					identity1.GetIdentity(resourceName1),
+					identity2.GetIdentity(resourceName2),
 				},
 			},
 
@@ -62,16 +62,13 @@ func TestAccECRLifecyclePolicy_List_basic(t *testing.T) {
 					"resource_count": config.IntegerVariable(2),
 				},
 				QueryResultChecks: []querycheck.QueryResultCheck{
-					querycheck.ExpectIdentity("aws_ecr_lifecycle_policy.test", map[string]knownvalue.Check{
-						names.AttrAccountID: tfknownvalue.AccountID(),
-						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
-						"repository":        repositoryName1.ValueCheck(),
-					}),
-					querycheck.ExpectIdentity("aws_ecr_lifecycle_policy.test", map[string]knownvalue.Check{
-						names.AttrAccountID: tfknownvalue.AccountID(),
-						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
-						"repository":        repositoryName2.ValueCheck(),
-					}),
+					tfquerycheck.ExpectIdentityFunc("aws_ecr_lifecycle_policy.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ecr_lifecycle_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					tfquerycheck.ExpectNoResourceObject("aws_ecr_lifecycle_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_ecr_lifecycle_policy.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ecr_lifecycle_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), knownvalue.StringExact(rName+"-1")),
+					tfquerycheck.ExpectNoResourceObject("aws_ecr_lifecycle_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
 				},
 			},
 		},
@@ -83,6 +80,7 @@ func TestAccECRLifecyclePolicy_List_includeResource(t *testing.T) {
 
 	resourceName1 := "aws_ecr_lifecycle_policy.test[0]"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	policyDocument := `{"rules":[{"rulePriority":1,"description":"Expire images older than 14 days","selection":{"tagStatus":"untagged","countType":"sinceImagePushed","countUnit":"days","countNumber":14},"action":{"type":"expire"}}]}`
 
 	identity1 := tfstatecheck.Identity()
 
@@ -123,7 +121,7 @@ func TestAccECRLifecyclePolicy_List_includeResource(t *testing.T) {
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.StringExact(rName+"-0")),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("repository"), knownvalue.StringExact(rName+"-0")),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New("registry_id"), tfknownvalue.AccountID()),
-						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPolicy), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPolicy), tfknownvalue.JSONNoDiff(policyDocument)),
 					}),
 				},
 			},

--- a/internal/service/ecr/lifecycle_policy_list_test.go
+++ b/internal/service/ecr/lifecycle_policy_list_test.go
@@ -1,0 +1,186 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ecr_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccECRLifecyclePolicy_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ecr_lifecycle_policy.test[0]"
+	resourceName2 := "aws_ecr_lifecycle_policy.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	repositoryName1 := tfstatecheck.StateValue()
+	repositoryName2 := tfstatecheck.StateValue()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		CheckDestroy:             testAccCheckLifecyclePolicyDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/LifecyclePolicy/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					repositoryName1.GetStateValue(resourceName1, tfjsonpath.New("repository")),
+					repositoryName2.GetStateValue(resourceName2, tfjsonpath.New("repository")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/LifecyclePolicy/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("aws_ecr_lifecycle_policy.test", map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+						"repository":        repositoryName1.ValueCheck(),
+					}),
+					querycheck.ExpectIdentity("aws_ecr_lifecycle_policy.test", map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+						"repository":        repositoryName2.ValueCheck(),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccECRLifecyclePolicy_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ecr_lifecycle_policy.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		CheckDestroy:             testAccCheckLifecyclePolicyDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/LifecyclePolicy/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/LifecyclePolicy/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_ecr_lifecycle_policy.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_ecr_lifecycle_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), knownvalue.StringExact(rName+"-0")),
+					querycheck.ExpectResourceKnownValues("aws_ecr_lifecycle_policy.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("repository"), knownvalue.StringExact(rName+"-0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("registry_id"), tfknownvalue.AccountID()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrPolicy), knownvalue.NotNull()),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccECRLifecyclePolicy_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_ecr_lifecycle_policy.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	repositoryName1 := tfstatecheck.StateValue()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		CheckDestroy:             testAccCheckLifecyclePolicyDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/LifecyclePolicy/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					repositoryName1.GetStateValue(resourceName1, tfjsonpath.New("repository")),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/LifecyclePolicy/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("aws_ecr_lifecycle_policy.test", map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.AlternateRegion()),
+						"repository":        repositoryName1.ValueCheck(),
+					}),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/ecr/service_package_gen.go
+++ b/internal/service/ecr/service_package_gen.go
@@ -182,6 +182,13 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageSDKListResource] {
 	return slices.Values([]*inttypes.ServicePackageSDKListResource{
 		{
+			Factory:  newLifecyclePolicyResourceAsListResource,
+			TypeName: "aws_ecr_lifecycle_policy",
+			Name:     "Lifecycle Policy",
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttribute("repository", true)),
+		},
+		{
 			Factory:  repositoryResourceAsListResource,
 			TypeName: "aws_ecr_repository",
 			Name:     "Repository",

--- a/internal/service/ecr/testdata/LifecyclePolicy/list_basic/main.tf
+++ b/internal/service/ecr/testdata/LifecyclePolicy/list_basic/main.tf
@@ -1,0 +1,42 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ecr_lifecycle_policy" "test" {
+  count = var.resource_count
+
+  repository = aws_ecr_repository.test[count.index].name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Expire images older than 14 days"
+      selection = {
+        tagStatus   = "untagged"
+        countType   = "sinceImagePushed"
+        countUnit   = "days"
+        countNumber = 14
+      }
+      action = {
+        type = "expire"
+      }
+    }]
+  })
+}
+
+resource "aws_ecr_repository" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/ecr/testdata/LifecyclePolicy/list_basic/query.tfquery.hcl
+++ b/internal/service/ecr/testdata/LifecyclePolicy/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ecr_lifecycle_policy" "test" {
+  provider = aws
+}

--- a/internal/service/ecr/testdata/LifecyclePolicy/list_include_resource/main.tf
+++ b/internal/service/ecr/testdata/LifecyclePolicy/list_include_resource/main.tf
@@ -1,0 +1,42 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ecr_lifecycle_policy" "test" {
+  count = var.resource_count
+
+  repository = aws_ecr_repository.test[count.index].name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Expire images older than 14 days"
+      selection = {
+        tagStatus   = "untagged"
+        countType   = "sinceImagePushed"
+        countUnit   = "days"
+        countNumber = 14
+      }
+      action = {
+        type = "expire"
+      }
+    }]
+  })
+}
+
+resource "aws_ecr_repository" "test" {
+  count = var.resource_count
+
+  name = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/ecr/testdata/LifecyclePolicy/list_include_resource/query.tfquery.hcl
+++ b/internal/service/ecr/testdata/LifecyclePolicy/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ecr_lifecycle_policy" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/ecr/testdata/LifecyclePolicy/list_region_override/main.tf
+++ b/internal/service/ecr/testdata/LifecyclePolicy/list_region_override/main.tf
@@ -1,0 +1,50 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_ecr_lifecycle_policy" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  repository = aws_ecr_repository.test[count.index].name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Expire images older than 14 days"
+      selection = {
+        tagStatus   = "untagged"
+        countType   = "sinceImagePushed"
+        countUnit   = "days"
+        countNumber = 14
+      }
+      action = {
+        type = "expire"
+      }
+    }]
+  })
+}
+
+resource "aws_ecr_repository" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  name = "${var.rName}-${count.index}"
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/ecr/testdata/LifecyclePolicy/list_region_override/query.tfquery.hcl
+++ b/internal/service/ecr/testdata/LifecyclePolicy/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_ecr_lifecycle_policy" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/ecr_lifecycle_policy.html.markdown
+++ b/website/docs/list-resources/ecr_lifecycle_policy.html.markdown
@@ -1,0 +1,26 @@
+---
+subcategory: "ECR (Elastic Container Registry)"
+layout: "aws"
+page_title: "AWS: aws_ecr_lifecycle_policy"
+description: |-
+  Lists ECR (Elastic Container Registry) Lifecycle Policy resources.
+---
+
+# List Resource: aws_ecr_lifecycle_policy
+
+Lists ECR (Elastic Container Registry) Lifecycle Policy resources.
+Only repositories with an attached lifecycle policy are returned.
+
+## Example Usage
+
+```terraform
+list "aws_ecr_lifecycle_policy" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

### Description

l/aws_ecr_lifecycle_policy: New List Resource

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/47005
Closes https://github.com/hashicorp/terraform-provider-aws/issues/48580

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

#### List

```console
make t K=ecr T=TestAccECRLifecyclePolicy_List_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-list-resource-aws_ecr_lifecycle_policy 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRLifecyclePolicy_List_'  -timeout 360m -vet=off -buildvcs=false
2026/08/26 18:37:50 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/26 18:37:50 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECRLifecyclePolicy_List_basic
=== PAUSE TestAccECRLifecyclePolicy_List_basic
=== RUN   TestAccECRLifecyclePolicy_List_includeResource
=== PAUSE TestAccECRLifecyclePolicy_List_includeResource
=== RUN   TestAccECRLifecyclePolicy_List_regionOverride
=== PAUSE TestAccECRLifecyclePolicy_List_regionOverride
=== CONT  TestAccECRLifecyclePolicy_List_basic
=== CONT  TestAccECRLifecyclePolicy_List_regionOverride
=== CONT  TestAccECRLifecyclePolicy_List_includeResource
--- PASS: TestAccECRLifecyclePolicy_List_regionOverride (31.79s)
--- PASS: TestAccECRLifecyclePolicy_List_basic (32.07s)
--- PASS: TestAccECRLifecyclePolicy_List_includeResource (32.22s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        40.865s
```

#### Overall

```console
make t K=ecr T=TestAccECRLifecyclePolicy_     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-list-resource-aws_ecr_lifecycle_policy 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRLifecyclePolicy_'  -timeout 360m -vet=off -buildvcs=false
2026/08/26 18:59:14 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/26 18:59:14 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECRLifecyclePolicy_Identity_basic
=== PAUSE TestAccECRLifecyclePolicy_Identity_basic
=== RUN   TestAccECRLifecyclePolicy_Identity_regionOverride
=== PAUSE TestAccECRLifecyclePolicy_Identity_regionOverride
=== RUN   TestAccECRLifecyclePolicy_Identity_ExistingResource_basic
=== PAUSE TestAccECRLifecyclePolicy_Identity_ExistingResource_basic
=== RUN   TestAccECRLifecyclePolicy_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccECRLifecyclePolicy_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccECRLifecyclePolicy_List_basic
=== PAUSE TestAccECRLifecyclePolicy_List_basic
=== RUN   TestAccECRLifecyclePolicy_List_includeResource
=== PAUSE TestAccECRLifecyclePolicy_List_includeResource
=== RUN   TestAccECRLifecyclePolicy_List_regionOverride
=== PAUSE TestAccECRLifecyclePolicy_List_regionOverride
=== RUN   TestAccECRLifecyclePolicy_basic
=== PAUSE TestAccECRLifecyclePolicy_basic
=== RUN   TestAccECRLifecyclePolicy_disappears
=== PAUSE TestAccECRLifecyclePolicy_disappears
=== RUN   TestAccECRLifecyclePolicy_ignoreEquivalent
=== PAUSE TestAccECRLifecyclePolicy_ignoreEquivalent
=== RUN   TestAccECRLifecyclePolicy_detectDiff
=== PAUSE TestAccECRLifecyclePolicy_detectDiff
=== RUN   TestAccECRLifecyclePolicy_detectTagPatternListDiff
=== PAUSE TestAccECRLifecyclePolicy_detectTagPatternListDiff
=== RUN   TestAccECRLifecyclePolicy_storageClass
=== PAUSE TestAccECRLifecyclePolicy_storageClass
=== CONT  TestAccECRLifecyclePolicy_Identity_basic
=== CONT  TestAccECRLifecyclePolicy_basic
=== CONT  TestAccECRLifecyclePolicy_detectDiff
=== CONT  TestAccECRLifecyclePolicy_storageClass
=== CONT  TestAccECRLifecyclePolicy_List_basic
=== CONT  TestAccECRLifecyclePolicy_detectTagPatternListDiff
=== CONT  TestAccECRLifecyclePolicy_Identity_ExistingResource_basic
=== CONT  TestAccECRLifecyclePolicy_ignoreEquivalent
=== CONT  TestAccECRLifecyclePolicy_disappears
=== CONT  TestAccECRLifecyclePolicy_List_regionOverride
=== CONT  TestAccECRLifecyclePolicy_Identity_regionOverride
=== CONT  TestAccECRLifecyclePolicy_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccECRLifecyclePolicy_List_includeResource
--- PASS: TestAccECRLifecyclePolicy_disappears (42.04s)
--- PASS: TestAccECRLifecyclePolicy_List_basic (42.32s)
--- PASS: TestAccECRLifecyclePolicy_List_regionOverride (43.13s)
--- PASS: TestAccECRLifecyclePolicy_List_includeResource (45.41s)
--- PASS: TestAccECRLifecyclePolicy_storageClass (48.46s)
--- PASS: TestAccECRLifecyclePolicy_basic (49.34s)
--- PASS: TestAccECRLifecyclePolicy_ignoreEquivalent (54.97s)
--- PASS: TestAccECRLifecyclePolicy_detectDiff (58.83s)
--- PASS: TestAccECRLifecyclePolicy_detectTagPatternListDiff (58.91s)
--- PASS: TestAccECRLifecyclePolicy_Identity_regionOverride (62.04s)
--- PASS: TestAccECRLifecyclePolicy_Identity_basic (62.80s)
--- PASS: TestAccECRLifecyclePolicy_Identity_ExistingResource_noRefreshNoChange (75.21s)
--- PASS: TestAccECRLifecyclePolicy_Identity_ExistingResource_basic (84.31s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        92.329s
```
