### PR TITLE
New Resource: aws_quicksight_spice_capacity_configuration

### DIFF
--- a/.changelog/49697.txt
+++ b/.changelog/49697.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_quicksight_spice_capacity_configuration
+```

--- a/internal/service/quicksight/exports_test.go
+++ b/internal/service/quicksight/exports_test.go
@@ -9,31 +9,32 @@ import (
 
 // Exports for use in tests only.
 var (
-	ResourceAccountSettings      = newAccountSettingsResource
-	ResourceAccountSubscription  = resourceAccountSubscription
-	ResourceAnalysis             = resourceAnalysis
-	ResourceCustomPermissions    = newCustomPermissionsResource
-	ResourceDashboard            = resourceDashboard
-	ResourceDataSet              = resourceDataSet
-	ResourceDataSource           = resourceDataSource
-	ResourceFolder               = resourceFolder
-	ResourceFolderMembership     = newFolderMembershipResource
-	ResourceGroup                = resourceGroup
-	ResourceGroupMembership      = resourceGroupMembership
-	ResourceIAMPolicyAssignment  = newIAMPolicyAssignmentResource
-	ResourceIngestion            = newIngestionResource
-	ResourceIPRestriction        = newIPRestrictionResource
-	ResourceKeyRegistration      = newKeyRegistrationResource
-	ResourceNamespace            = newNamespaceResource
-	ResourceRefreshSchedule      = newRefreshScheduleResource
-	ResourceRoleCustomPermission = newRoleCustomPermissionResource
-	ResourceRoleMembership       = newRoleMembershipResource
-	ResourceTemplate             = resourceTemplate
-	ResourceTemplateAlias        = newTemplateAliasResource
-	ResourceTheme                = resourceTheme
-	ResourceUser                 = resourceUser
-	ResourceUserCustomPermission = newUserCustomPermissionResource
-	ResourceVPCConnection        = newVPCConnectionResource
+	ResourceAccountSettings            = newAccountSettingsResource
+	ResourceAccountSubscription        = resourceAccountSubscription
+	ResourceAnalysis                   = resourceAnalysis
+	ResourceCustomPermissions          = newCustomPermissionsResource
+	ResourceDashboard                  = resourceDashboard
+	ResourceDataSet                    = resourceDataSet
+	ResourceDataSource                 = resourceDataSource
+	ResourceFolder                     = resourceFolder
+	ResourceFolderMembership           = newFolderMembershipResource
+	ResourceGroup                      = resourceGroup
+	ResourceGroupMembership            = resourceGroupMembership
+	ResourceIAMPolicyAssignment        = newIAMPolicyAssignmentResource
+	ResourceIngestion                  = newIngestionResource
+	ResourceIPRestriction              = newIPRestrictionResource
+	ResourceKeyRegistration            = newKeyRegistrationResource
+	ResourceNamespace                  = newNamespaceResource
+	ResourceRefreshSchedule            = newRefreshScheduleResource
+	ResourceRoleCustomPermission       = newRoleCustomPermissionResource
+	ResourceRoleMembership             = newRoleMembershipResource
+	ResourceSPICECapacityConfiguration = newSPICECapacityConfigurationResource
+	ResourceTemplate                   = resourceTemplate
+	ResourceTemplateAlias              = newTemplateAliasResource
+	ResourceTheme                      = resourceTheme
+	ResourceUser                       = resourceUser
+	ResourceUserCustomPermission       = newUserCustomPermissionResource
+	ResourceVPCConnection              = newVPCConnectionResource
 
 	DashboardLatestVersion                 = dashboardLatestVersion
 	DefaultNamespace                       = quicksightschema.DefaultNamespace

--- a/internal/service/quicksight/quicksight_test.go
+++ b/internal/service/quicksight/quicksight_test.go
@@ -51,6 +51,10 @@ func TestAccQuickSight_serial(t *testing.T) {
 			acctest.CtDisappears: testAccRoleMembership_disappears,
 			"role":               testAccRoleMembership_role,
 		},
+		"SPICECapacityConfiguration": {
+			acctest.CtBasic: testAccSPICECapacityConfiguration_basic,
+			"update":        testAccSPICECapacityConfiguration_update,
+		},
 	}
 
 	acctest.RunSerialTests2Levels(t, testCases, 0)

--- a/internal/service/quicksight/service_package_gen.go
+++ b/internal/service/quicksight/service_package_gen.go
@@ -99,6 +99,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 		{
+			Factory:  newSPICECapacityConfigurationResource,
+			TypeName: "aws_quicksight_spice_capacity_configuration",
+			Name:     "SPICE Capacity Configuration",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newTemplateAliasResource,
 			TypeName: "aws_quicksight_template_alias",
 			Name:     "Template Alias",

--- a/internal/service/quicksight/spice_capacity_configuration.go
+++ b/internal/service/quicksight/spice_capacity_configuration.go
@@ -1,0 +1,150 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package quicksight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/quicksight"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	quicksightschema "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_quicksight_spice_capacity_configuration", name="SPICE Capacity Configuration")
+func newSPICECapacityConfigurationResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &spiceCapacityConfigurationResource{}
+
+	return r, nil
+}
+
+type spiceCapacityConfigurationResource struct {
+	framework.ResourceWithModel[spiceCapacityConfigurationResourceModel]
+}
+
+func (r *spiceCapacityConfigurationResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrAWSAccountID: quicksightschema.AWSAccountIDAttribute(),
+			"purchase_mode": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.PurchaseMode](),
+				Optional:   true,
+				Computed:   true,
+				Default:    stringdefault.StaticString(string(awstypes.PurchaseModeManual)),
+			},
+		},
+	}
+}
+
+func (r *spiceCapacityConfigurationResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data spiceCapacityConfigurationResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	if data.AWSAccountID.IsUnknown() {
+		data.AWSAccountID = fwflex.StringValueToFramework(ctx, r.Meta().AccountID(ctx))
+	}
+
+	conn := r.Meta().QuickSightClient(ctx)
+
+	accountID := fwflex.StringValueFromFramework(ctx, data.AWSAccountID)
+	var input quicksight.UpdateSPICECapacityConfigurationInput
+	response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := conn.UpdateSPICECapacityConfiguration(ctx, &input)
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("creating QuickSight SPICE Capacity Configuration (%s)", accountID), err.Error())
+
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, data)...)
+}
+
+// Read is a no-op. QuickSight provides no API to describe the SPICE capacity
+// configuration (purchase mode), so the configured value is retained in state
+// and drift cannot be detected.
+func (r *spiceCapacityConfigurationResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data spiceCapacityConfigurationResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *spiceCapacityConfigurationResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var data spiceCapacityConfigurationResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().QuickSightClient(ctx)
+
+	accountID := fwflex.StringValueFromFramework(ctx, data.AWSAccountID)
+	var input quicksight.UpdateSPICECapacityConfigurationInput
+	response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := conn.UpdateSPICECapacityConfiguration(ctx, &input)
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("updating QuickSight SPICE Capacity Configuration (%s)", accountID), err.Error())
+
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+// Delete resets the purchase mode to MANUAL, the QuickSight default. There is no
+// API to delete the SPICE capacity configuration itself.
+func (r *spiceCapacityConfigurationResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data spiceCapacityConfigurationResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().QuickSightClient(ctx)
+
+	accountID := fwflex.StringValueFromFramework(ctx, data.AWSAccountID)
+	input := quicksight.UpdateSPICECapacityConfigurationInput{
+		AwsAccountId: aws.String(accountID),
+		PurchaseMode: awstypes.PurchaseModeManual,
+	}
+	_, err := conn.UpdateSPICECapacityConfiguration(ctx, &input)
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("deleting QuickSight SPICE Capacity Configuration (%s)", accountID), err.Error())
+
+		return
+	}
+}
+
+func (r *spiceCapacityConfigurationResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrAWSAccountID), request, response)
+}
+
+type spiceCapacityConfigurationResourceModel struct {
+	framework.WithRegionModel
+	AWSAccountID types.String                              `tfsdk:"aws_account_id"`
+	PurchaseMode fwtypes.StringEnum[awstypes.PurchaseMode] `tfsdk:"purchase_mode"`
+}

--- a/internal/service/quicksight/spice_capacity_configuration_test.go
+++ b/internal/service/quicksight/spice_capacity_configuration_test.go
@@ -1,0 +1,108 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package quicksight_test
+
+import (
+	"fmt"
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccSPICECapacityConfiguration_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_quicksight_spice_capacity_configuration.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSPICECapacityConfigurationConfig_basic,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrAWSAccountID), tfknownvalue.AccountID()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("purchase_mode"), knownvalue.StringExact(string(awstypes.PurchaseModeManual))),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrAWSAccountID),
+				ImportStateVerifyIdentifierAttribute: names.AttrAWSAccountID,
+				// The purchase mode cannot be read back from the QuickSight API.
+				ImportStateVerifyIgnore: []string{"purchase_mode"},
+			},
+		},
+	})
+}
+
+func testAccSPICECapacityConfiguration_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_quicksight_spice_capacity_configuration.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSPICECapacityConfigurationConfig_purchaseMode(string(awstypes.PurchaseModeAutoPurchase)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("purchase_mode"), knownvalue.StringExact(string(awstypes.PurchaseModeAutoPurchase))),
+				},
+			},
+			{
+				Config: testAccSPICECapacityConfigurationConfig_purchaseMode(string(awstypes.PurchaseModeManual)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("purchase_mode"), knownvalue.StringExact(string(awstypes.PurchaseModeManual))),
+				},
+			},
+		},
+	})
+}
+
+const testAccSPICECapacityConfigurationConfig_basic = `
+resource "aws_quicksight_spice_capacity_configuration" "test" {}
+`
+
+func testAccSPICECapacityConfigurationConfig_purchaseMode(purchaseMode string) string {
+	return fmt.Sprintf(`
+resource "aws_quicksight_spice_capacity_configuration" "test" {
+  purchase_mode = %[1]q
+}
+`, purchaseMode)
+}

--- a/website/docs/r/quicksight_spice_capacity_configuration.html.markdown
+++ b/website/docs/r/quicksight_spice_capacity_configuration.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "QuickSight"
+layout: "aws"
+page_title: "AWS: aws_quicksight_spice_capacity_configuration"
+description: |-
+  Manages the SPICE capacity purchase mode for a QuickSight account.
+---
+
+# Resource: aws_quicksight_spice_capacity_configuration
+
+Manages the [SPICE](https://docs.aws.amazon.com/quicksight/latest/user/spice.html) capacity purchase mode for a QuickSight account. This controls whether extra SPICE capacity is purchased automatically as needed, or only manually.
+
+~> **Note:** QuickSight does not provide an API to read the current SPICE purchase mode. As a result, this resource is write-only: the configured `purchase_mode` is stored in Terraform state but cannot be refreshed, and changes made outside of Terraform (drift) cannot be detected.
+
+~> **Warning:** Destroying this resource resets the account's SPICE purchase mode to `MANUAL` (the QuickSight default), disabling automatic SPICE capacity purchasing.
+
+## Example Usage
+
+### Automatic SPICE capacity purchasing
+
+```terraform
+resource "aws_quicksight_spice_capacity_configuration" "example" {
+  purchase_mode = "AUTO_PURCHASE"
+}
+```
+
+### Manual SPICE capacity purchasing
+
+```terraform
+resource "aws_quicksight_spice_capacity_configuration" "example" {
+  purchase_mode = "MANUAL"
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `aws_account_id` - (Optional, Forces new resource) AWS account ID. Defaults to automatically determined account ID of the Terraform AWS provider.
+* `purchase_mode` - (Optional) Determines how SPICE capacity can be purchased. Valid values are `MANUAL` (SPICE capacity can only be purchased manually) and `AUTO_PURCHASE` (extra SPICE capacity is automatically purchased on your behalf as needed; SPICE capacity can also still be purchased manually). Defaults to `MANUAL`.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+## Attribute Reference
+
+This resource exports no additional attributes.
+
+## Import
+
+~> **Note:** Because the SPICE purchase mode cannot be read from the QuickSight API, `purchase_mode` is not populated on import and will show a difference on the next plan.
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import QuickSight SPICE capacity configuration using the AWS account ID. For example:
+
+```terraform
+import {
+  to = aws_quicksight_spice_capacity_configuration.example
+  id = "012345678901"
+}
+```
+
+Using `terraform import`, import QuickSight SPICE capacity configuration using the AWS account ID. For example:
+
+```console
+% terraform import aws_quicksight_spice_capacity_configuration.example "012345678901"
+```


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None.

### Description

Adds a new resource, `aws_quicksight_spice_capacity_configuration`, to manage the [SPICE](https://docs.aws.amazon.com/quicksight/latest/user/spice.html) capacity purchase mode for a QuickSight account via the `UpdateSPICECapacityConfiguration` API. The `purchase_mode` argument accepts `MANUAL` (the default) or `AUTO_PURCHASE`.

Notes on design, driven by the API surface (only `UpdateSPICECapacityConfiguration` exists in the SDK — there is no describe/read operation for the purchase mode, and no API to purchase a specific GB amount):

- **Write-only:** QuickSight provides no API to read the current purchase mode, so `Read` is a no-op — the configured value is retained in state and drift cannot be detected. This is documented on the resource page.
- **Delete resets to `MANUAL`:** there is no delete operation for the configuration, so `Delete` writes the QuickSight default (`MANUAL`), disabling automatic purchasing. This is called out with a warning in the docs, mirroring `aws_quicksight_ip_restriction` (which clears rules on delete) and `aws_shield_subscription` (which resets `AutoRenew` on delete).

The original issue also proposed managing SPICE capacity purchases in GB; that is intentionally not implemented because AWS exposes no API for it (console-only).

### Relations

Closes #38996

### References

- https://docs.aws.amazon.com/quicksight/latest/APIReference/API_UpdateSPICECapacityConfiguration.html
- https://docs.aws.amazon.com/quicksight/latest/user/managing-spice-capacity.html#spice-auto-capacity

### Output from Acceptance Testing

Acceptance tests require an AWS account with an active QuickSight subscription, which I do not have available. The tests are included and compile; I was unable to run them against AWS.

```console
% make testacc TESTS='TestAccQuickSight_serial/SPICECapacityConfiguration' PKG=quicksight

(not run — no QuickSight-subscribed test account available)
```
