### PR TITLE
Prefix allocations for Direct Connect virtual interfaces

### DIFF
--- a/.changelog/49711.txt
+++ b/.changelog/49711.txt
@@ -1,0 +1,31 @@
+```release-note:enhancement
+resource/aws_dx_connection: Add `prefix_pool_size_ipv4`, `prefix_pool_size_ipv6`, `prefix_pool_unallocated_count_ipv4`, and `prefix_pool_unallocated_count_ipv6` attributes
+```
+
+```release-note:enhancement
+resource/aws_dx_private_virtual_interface: Add `prefix_pool_allocated_count_ipv4` and `prefix_pool_allocated_count_ipv6` arguments
+```
+
+```release-note:enhancement
+resource/aws_dx_transit_virtual_interface: Add `prefix_pool_allocated_count_ipv4` and `prefix_pool_allocated_count_ipv6` arguments
+```
+
+```release-note:enhancement
+resource/aws_dx_hosted_private_virtual_interface: Add `prefix_pool_allocated_count_ipv4` and `prefix_pool_allocated_count_ipv6` attributes
+```
+
+```release-note:enhancement
+resource/aws_dx_hosted_transit_virtual_interface: Add `prefix_pool_allocated_count_ipv4` and `prefix_pool_allocated_count_ipv6` attributes
+```
+
+```release-note:enhancement
+resource/aws_dx_hosted_private_virtual_interface_accepter: Add `prefix_pool_allocated_count_ipv4` and `prefix_pool_allocated_count_ipv6` arguments
+```
+
+```release-note:enhancement
+resource/aws_dx_hosted_transit_virtual_interface_accepter: Add `prefix_pool_allocated_count_ipv4` and `prefix_pool_allocated_count_ipv6` arguments
+```
+
+```release-note:enhancement
+data-source/aws_dx_connection: Add `prefix_pool_size_ipv4`, `prefix_pool_size_ipv6`, `prefix_pool_unallocated_count_ipv4`, and `prefix_pool_unallocated_count_ipv6` attributes
+```

--- a/internal/service/directconnect/connection.go
+++ b/internal/service/directconnect/connection.go
@@ -217,6 +217,22 @@ func resourceConnection() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"prefix_pool_size_ipv4": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"prefix_pool_size_ipv6": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"prefix_pool_unallocated_count_ipv4": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"prefix_pool_unallocated_count_ipv6": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
 				names.AttrProviderName: {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -306,6 +322,10 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta an
 	d.Set(names.AttrOwnerAccountID, connection.OwnerAccount)
 	d.Set("partner_name", connection.PartnerName)
 	d.Set("port_encryption_status", connection.PortEncryptionStatus)
+	d.Set("prefix_pool_size_ipv4", connection.PrefixPoolSizeIpv4)
+	d.Set("prefix_pool_size_ipv6", connection.PrefixPoolSizeIpv6)
+	d.Set("prefix_pool_unallocated_count_ipv4", connection.PrefixPoolUnallocatedCountIpv4)
+	d.Set("prefix_pool_unallocated_count_ipv6", connection.PrefixPoolUnallocatedCountIpv6)
 	d.Set(names.AttrProviderName, connection.ProviderName)
 	if !d.IsNewResource() && !d.Get("request_macsec").(bool) {
 		d.Set("request_macsec", aws.Bool(false))

--- a/internal/service/directconnect/connection_data_source.go
+++ b/internal/service/directconnect/connection_data_source.go
@@ -61,6 +61,22 @@ func dataSourceConnection() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+				"prefix_pool_size_ipv4": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"prefix_pool_size_ipv6": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"prefix_pool_unallocated_count_ipv4": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"prefix_pool_unallocated_count_ipv6": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
 				names.AttrProviderName: {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -107,6 +123,10 @@ func dataSourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set(names.AttrState, connection.ConnectionState)
 	d.Set(names.AttrOwnerAccountID, connection.OwnerAccount)
 	d.Set("partner_name", connection.PartnerName)
+	d.Set("prefix_pool_size_ipv4", connection.PrefixPoolSizeIpv4)
+	d.Set("prefix_pool_size_ipv6", connection.PrefixPoolSizeIpv6)
+	d.Set("prefix_pool_unallocated_count_ipv4", connection.PrefixPoolUnallocatedCountIpv4)
+	d.Set("prefix_pool_unallocated_count_ipv6", connection.PrefixPoolUnallocatedCountIpv6)
 	d.Set(names.AttrProviderName, connection.ProviderName)
 	d.Set("vlan_id", connection.Vlan)
 

--- a/internal/service/directconnect/hosted_private_virtual_interface.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface.go
@@ -102,6 +102,14 @@ func resourceHostedPrivateVirtualInterface() *schema.Resource {
 					Required: true,
 					ForceNew: true,
 				},
+				"prefix_pool_allocated_count_ipv4": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"prefix_pool_allocated_count_ipv6": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
 				names.AttrOwnerAccountID: {
 					Type:         schema.TypeString,
 					Required:     true,
@@ -207,6 +215,8 @@ func resourceHostedPrivateVirtualInterfaceRead(ctx context.Context, d *schema.Re
 	d.Set("mtu", vif.Mtu)
 	d.Set(names.AttrName, vif.VirtualInterfaceName)
 	d.Set(names.AttrOwnerAccountID, vif.OwnerAccount)
+	d.Set("prefix_pool_allocated_count_ipv4", vif.PrefixPoolAllocatedCountIpv4)
+	d.Set("prefix_pool_allocated_count_ipv6", vif.PrefixPoolAllocatedCountIpv6)
 	d.Set("vlan", vif.Vlan)
 
 	return diags

--- a/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
@@ -17,6 +17,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -49,6 +50,18 @@ func resourceHostedPrivateVirtualInterfaceAccepter() *schema.Resource {
 					Optional:     true,
 					ForceNew:     true,
 					ExactlyOneOf: []string{"dx_gateway_id", "vpn_gateway_id"},
+				},
+				"prefix_pool_allocated_count_ipv4": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 1000),
+				},
+				"prefix_pool_allocated_count_ipv6": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 1000),
 				},
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -140,6 +153,8 @@ func resourceHostedPrivateVirtualInterfaceAccepterRead(ctx context.Context, d *s
 	}
 
 	d.Set("dx_gateway_id", vif.DirectConnectGatewayId)
+	d.Set("prefix_pool_allocated_count_ipv4", vif.PrefixPoolAllocatedCountIpv4)
+	d.Set("prefix_pool_allocated_count_ipv6", vif.PrefixPoolAllocatedCountIpv6)
 	d.Set("virtual_interface_id", vif.VirtualInterfaceId)
 	d.Set("vpn_gateway_id", vif.VirtualGatewayId)
 

--- a/internal/service/directconnect/hosted_transit_virtual_interface.go
+++ b/internal/service/directconnect/hosted_transit_virtual_interface.go
@@ -102,6 +102,14 @@ func resourceHostedTransitVirtualInterface() *schema.Resource {
 					Required: true,
 					ForceNew: true,
 				},
+				"prefix_pool_allocated_count_ipv4": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"prefix_pool_allocated_count_ipv6": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
 				names.AttrOwnerAccountID: {
 					Type:         schema.TypeString,
 					Required:     true,
@@ -203,6 +211,8 @@ func resourceHostedTransitVirtualInterfaceRead(ctx context.Context, d *schema.Re
 	d.Set("mtu", vif.Mtu)
 	d.Set(names.AttrName, vif.VirtualInterfaceName)
 	d.Set(names.AttrOwnerAccountID, vif.OwnerAccount)
+	d.Set("prefix_pool_allocated_count_ipv4", vif.PrefixPoolAllocatedCountIpv4)
+	d.Set("prefix_pool_allocated_count_ipv6", vif.PrefixPoolAllocatedCountIpv6)
 	d.Set("vlan", vif.Vlan)
 
 	return diags

--- a/internal/service/directconnect/hosted_transit_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_transit_virtual_interface_accepter.go
@@ -17,6 +17,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/directconnect/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -48,6 +49,18 @@ func resourceHostedTransitVirtualInterfaceAccepter() *schema.Resource {
 					Type:     schema.TypeString,
 					Required: true,
 					ForceNew: true,
+				},
+				"prefix_pool_allocated_count_ipv4": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 1000),
+				},
+				"prefix_pool_allocated_count_ipv6": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 1000),
 				},
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -126,6 +139,8 @@ func resourceHostedTransitVirtualInterfaceAccepterRead(ctx context.Context, d *s
 	}
 
 	d.Set("dx_gateway_id", vif.DirectConnectGatewayId)
+	d.Set("prefix_pool_allocated_count_ipv4", vif.PrefixPoolAllocatedCountIpv4)
+	d.Set("prefix_pool_allocated_count_ipv6", vif.PrefixPoolAllocatedCountIpv6)
 	d.Set("virtual_interface_id", vif.VirtualInterfaceId)
 
 	return diags

--- a/internal/service/directconnect/private_virtual_interface.go
+++ b/internal/service/directconnect/private_virtual_interface.go
@@ -106,6 +106,18 @@ func resourcePrivateVirtualInterface() *schema.Resource {
 					Required: true,
 					ForceNew: true,
 				},
+				"prefix_pool_allocated_count_ipv4": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 1000),
+				},
+				"prefix_pool_allocated_count_ipv6": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 1000),
+				},
 				"sitelink_enabled": {
 					Type:     schema.TypeBool,
 					Optional: true,
@@ -170,6 +182,14 @@ func resourcePrivateVirtualInterfaceCreate(ctx context.Context, d *schema.Resour
 		input.NewPrivateVirtualInterface.DirectConnectGatewayId = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("prefix_pool_allocated_count_ipv4"); ok {
+		input.NewPrivateVirtualInterface.PrefixPoolAllocatedCountIpv4 = aws.Int32(int32(v.(int)))
+	}
+
+	if v, ok := d.GetOk("prefix_pool_allocated_count_ipv6"); ok {
+		input.NewPrivateVirtualInterface.PrefixPoolAllocatedCountIpv6 = aws.Int32(int32(v.(int)))
+	}
+
 	if v, ok := d.GetOk("vpn_gateway_id"); ok {
 		input.NewPrivateVirtualInterface.VirtualGatewayId = aws.String(v.(string))
 	}
@@ -227,6 +247,8 @@ func resourcePrivateVirtualInterfaceRead(ctx context.Context, d *schema.Resource
 	d.Set("jumbo_frame_capable", vif.JumboFrameCapable)
 	d.Set("mtu", vif.Mtu)
 	d.Set(names.AttrName, vif.VirtualInterfaceName)
+	d.Set("prefix_pool_allocated_count_ipv4", vif.PrefixPoolAllocatedCountIpv4)
+	d.Set("prefix_pool_allocated_count_ipv6", vif.PrefixPoolAllocatedCountIpv6)
 	d.Set("sitelink_enabled", vif.SiteLinkEnabled)
 	d.Set("vlan", vif.Vlan)
 	d.Set("vpn_gateway_id", vif.VirtualGatewayId)

--- a/internal/service/directconnect/transit_virtual_interface.go
+++ b/internal/service/directconnect/transit_virtual_interface.go
@@ -105,6 +105,18 @@ func resourceTransitVirtualInterface() *schema.Resource {
 					Required: true,
 					ForceNew: true,
 				},
+				"prefix_pool_allocated_count_ipv4": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 1000),
+				},
+				"prefix_pool_allocated_count_ipv6": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 1000),
+				},
 				"sitelink_enabled": {
 					Type:     schema.TypeBool,
 					Optional: true,
@@ -160,6 +172,14 @@ func resourceTransitVirtualInterfaceCreate(ctx context.Context, d *schema.Resour
 		input.NewTransitVirtualInterface.CustomerAddress = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("prefix_pool_allocated_count_ipv4"); ok {
+		input.NewTransitVirtualInterface.PrefixPoolAllocatedCountIpv4 = aws.Int32(int32(v.(int)))
+	}
+
+	if v, ok := d.GetOk("prefix_pool_allocated_count_ipv6"); ok {
+		input.NewTransitVirtualInterface.PrefixPoolAllocatedCountIpv6 = aws.Int32(int32(v.(int)))
+	}
+
 	output, err := conn.CreateTransitVirtualInterface(ctx, input)
 
 	if err != nil {
@@ -213,6 +233,8 @@ func resourceTransitVirtualInterfaceRead(ctx context.Context, d *schema.Resource
 	d.Set("jumbo_frame_capable", vif.JumboFrameCapable)
 	d.Set("mtu", vif.Mtu)
 	d.Set(names.AttrName, vif.VirtualInterfaceName)
+	d.Set("prefix_pool_allocated_count_ipv4", vif.PrefixPoolAllocatedCountIpv4)
+	d.Set("prefix_pool_allocated_count_ipv6", vif.PrefixPoolAllocatedCountIpv6)
 	d.Set("sitelink_enabled", vif.SiteLinkEnabled)
 	d.Set("vlan", vif.Vlan)
 

--- a/internal/service/directconnect/vif.go
+++ b/internal/service/directconnect/vif.go
@@ -52,7 +52,7 @@ func virtualInterfaceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		}
 	}
 
-	if d.HasChange("prefix_pool_allocated_count_ipv4") || d.HasChange("prefix_pool_allocated_count_ipv6") {
+	if d.HasChanges("prefix_pool_allocated_count_ipv4", "prefix_pool_allocated_count_ipv6") {
 		input := &directconnect.UpdateVirtualInterfaceAttributesInput{
 			VirtualInterfaceId: aws.String(d.Id()),
 		}

--- a/internal/service/directconnect/vif.go
+++ b/internal/service/directconnect/vif.go
@@ -52,6 +52,26 @@ func virtualInterfaceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		}
 	}
 
+	if d.HasChange("prefix_pool_allocated_count_ipv4") || d.HasChange("prefix_pool_allocated_count_ipv6") {
+		input := &directconnect.UpdateVirtualInterfaceAttributesInput{
+			VirtualInterfaceId: aws.String(d.Id()),
+		}
+
+		if d.HasChange("prefix_pool_allocated_count_ipv4") {
+			input.PrefixPoolAllocatedCountIpv4 = aws.Int32(int32(d.Get("prefix_pool_allocated_count_ipv4").(int)))
+		}
+
+		if d.HasChange("prefix_pool_allocated_count_ipv6") {
+			input.PrefixPoolAllocatedCountIpv6 = aws.Int32(int32(d.Get("prefix_pool_allocated_count_ipv6").(int)))
+		}
+
+		_, err := conn.UpdateVirtualInterfaceAttributes(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Direct Connect Virtual Interface (%s) prefix pool allocation: %s", d.Id(), err)
+		}
+	}
+
 	return diags
 }
 

--- a/website/docs/d/dx_connection.html.markdown
+++ b/website/docs/d/dx_connection.html.markdown
@@ -36,6 +36,10 @@ This data source exports the following attributes in addition to the arguments a
 * `location` - AWS Direct Connect location where the connection is located.
 * `owner_account_id` - ID of the AWS account that owns the connection.
 * `partner_name` - The name of the AWS Direct Connect service provider associated with the connection.
+* `prefix_pool_size_ipv4` - The total number of inbound IPv4 route prefixes that can be allocated across the virtual interfaces on the connection.
+* `prefix_pool_size_ipv6` - The total number of inbound IPv6 route prefixes that can be allocated across the virtual interfaces on the connection.
+* `prefix_pool_unallocated_count_ipv4` - The number of inbound IPv4 route prefixes in the connection prefix pool not yet allocated to a virtual interface.
+* `prefix_pool_unallocated_count_ipv6` - The number of inbound IPv6 route prefixes in the connection prefix pool not yet allocated to a virtual interface.
 * `provider_name` - Name of the service provider associated with the connection.
 * `state` - State of the connection.
 * `tags` - Map of tags for the resource.

--- a/website/docs/r/dx_connection.html.markdown
+++ b/website/docs/r/dx_connection.html.markdown
@@ -77,6 +77,10 @@ This resource exports the following attributes in addition to the arguments abov
 * `owner_account_id` - The ID of the AWS account that owns the connection.
 * `partner_name` - The name of the AWS Direct Connect service provider associated with the connection.
 * `port_encryption_status` - The MAC Security (MACsec) port link status of the connection.
+* `prefix_pool_size_ipv4` - The total number of inbound IPv4 route prefixes that can be allocated across the virtual interfaces on the connection.
+* `prefix_pool_size_ipv6` - The total number of inbound IPv6 route prefixes that can be allocated across the virtual interfaces on the connection.
+* `prefix_pool_unallocated_count_ipv4` - The number of inbound IPv4 route prefixes in the connection prefix pool not yet allocated to a virtual interface.
+* `prefix_pool_unallocated_count_ipv6` - The number of inbound IPv6 route prefixes in the connection prefix pool not yet allocated to a virtual interface.
 * `state` - State of the connection. See [CreateConnection](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_CreateConnection.html#API_CreateConnection_ResponseSyntax) for list of possible state values.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `vlan_id` - The VLAN ID.

--- a/website/docs/r/dx_hosted_private_virtual_interface.html.markdown
+++ b/website/docs/r/dx_hosted_private_virtual_interface.html.markdown
@@ -48,6 +48,8 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - The ARN of the virtual interface.
 * `jumbo_frame_capable` - Indicates whether jumbo frames (9001 MTU) are supported.
 * `aws_device` - The Direct Connect endpoint on which the virtual interface terminates.
+* `prefix_pool_allocated_count_ipv4` - The number of inbound IPv4 route prefixes allocated to the virtual interface.
+* `prefix_pool_allocated_count_ipv6` - The number of inbound IPv6 route prefixes allocated to the virtual interface.
 
 ## Timeouts
 

--- a/website/docs/r/dx_hosted_private_virtual_interface_accepter.html.markdown
+++ b/website/docs/r/dx_hosted_private_virtual_interface_accepter.html.markdown
@@ -66,6 +66,8 @@ This resource supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `virtual_interface_id` - (Required) The ID of the Direct Connect virtual interface to accept.
 * `dx_gateway_id` - (Optional) The ID of the Direct Connect gateway to which to connect the virtual interface.
+* `prefix_pool_allocated_count_ipv4` - (Optional) The number of inbound IPv4 route prefixes to allocate to the virtual interface. Valid values are `0` to `1000`. If not specified, AWS applies the default allocation of `100`.
+* `prefix_pool_allocated_count_ipv6` - (Optional) The number of inbound IPv6 route prefixes to allocate to the virtual interface. Valid values are `0` to `1000`. If not specified, AWS applies the default allocation of `100`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpn_gateway_id` - (Optional) The ID of the [virtual private gateway](vpn_gateway.html) to which to connect the virtual interface.
 

--- a/website/docs/r/dx_hosted_transit_virtual_interface.html.markdown
+++ b/website/docs/r/dx_hosted_transit_virtual_interface.html.markdown
@@ -49,6 +49,8 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - The ARN of the virtual interface.
 * `aws_device` - The Direct Connect endpoint on which the virtual interface terminates.
 * `jumbo_frame_capable` - Indicates whether jumbo frames (8500 MTU) are supported.
+* `prefix_pool_allocated_count_ipv4` - The number of inbound IPv4 route prefixes allocated to the virtual interface.
+* `prefix_pool_allocated_count_ipv6` - The number of inbound IPv6 route prefixes allocated to the virtual interface.
 
 ## Timeouts
 

--- a/website/docs/r/dx_hosted_transit_virtual_interface_accepter.html.markdown
+++ b/website/docs/r/dx_hosted_transit_virtual_interface_accepter.html.markdown
@@ -71,6 +71,8 @@ This resource supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `dx_gateway_id` - (Required) The ID of the [Direct Connect gateway](dx_gateway.html) to which to connect the virtual interface.
 * `virtual_interface_id` - (Required) The ID of the Direct Connect virtual interface to accept.
+* `prefix_pool_allocated_count_ipv4` - (Optional) The number of inbound IPv4 route prefixes to allocate to the virtual interface. Valid values are `0` to `1000`. If not specified, AWS applies the default allocation of `100`.
+* `prefix_pool_allocated_count_ipv6` - (Optional) The number of inbound IPv6 route prefixes to allocate to the virtual interface. Valid values are `0` to `1000`. If not specified, AWS applies the default allocation of `100`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference

--- a/website/docs/r/dx_private_virtual_interface.html.markdown
+++ b/website/docs/r/dx_private_virtual_interface.html.markdown
@@ -40,6 +40,8 @@ This resource supports the following arguments:
 * `dx_gateway_id` - (Optional) The ID of the Direct Connect gateway to which to connect the virtual interface.
 * `mtu` - (Optional) The maximum transmission unit (MTU) is the size, in bytes, of the largest permissible packet that can be passed over the connection.
 The MTU of a virtual private interface can be either `1500` or `9001` (jumbo frames). Default is `1500`.
+* `prefix_pool_allocated_count_ipv4` - (Optional) The number of inbound IPv4 route prefixes to allocate to the virtual interface. Valid values are `0` to `1000`. If not specified, AWS applies the default allocation of `100`.
+* `prefix_pool_allocated_count_ipv6` - (Optional) The number of inbound IPv6 route prefixes to allocate to the virtual interface. Valid values are `0` to `1000`. If not specified, AWS applies the default allocation of `100`.
 * `sitelink_enabled` - (Optional) Indicates whether to enable or disable SiteLink.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpn_gateway_id` - (Optional) The ID of the [virtual private gateway](vpn_gateway.html) to which to connect the virtual interface.

--- a/website/docs/r/dx_transit_virtual_interface.html.markdown
+++ b/website/docs/r/dx_transit_virtual_interface.html.markdown
@@ -47,6 +47,8 @@ This resource supports the following arguments:
 * `customer_address` - (Optional) The IPv4 CIDR destination address to which Amazon should send traffic. Required for IPv4 BGP peers.
 * `mtu` - (Optional) The maximum transmission unit (MTU) is the size, in bytes, of the largest permissible packet that can be passed over the connection.
 The MTU of a virtual transit interface can be either `1500` or `8500` (jumbo frames). Default is `1500`.
+* `prefix_pool_allocated_count_ipv4` - (Optional) The number of inbound IPv4 route prefixes to allocate to the virtual interface. Valid values are `0` to `1000`. If not specified, AWS applies the default allocation of `100`.
+* `prefix_pool_allocated_count_ipv6` - (Optional) The number of inbound IPv6 route prefixes to allocate to the virtual interface. Valid values are `0` to `1000`. If not specified, AWS applies the default allocation of `100`.
 * `sitelink_enabled` - (Optional) Indicates whether to enable or disable SiteLink.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Implement new parameters for inbound route-prefix allocations for private and transit virtual interfaces (VIFs)

```hcl
resource "aws_dx_transit_virtual_interface" "this" {
  name           = "my-dx"
  connection_id  = aws_dx_connection.this.id
  dx_gateway_id  = aws_dx_gateway.this.id
  address_family = "ipv4"
  bgp_asn        = 65001
  vlan           = 100

  # new parameters
  prefix_pool_allocated_count_ipv4 = 1000
  prefix_pool_allocated_count_ipv6 = 123
}
```
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49608

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

[AWS Direct Connect introduces inbound prefix controls and higher prefix scale](https://aws.amazon.com/about-aws/whats-new/2026/08/aws-direct-connect-new-prefix-controls/)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% ❯ AWS_REGION=us-west-2 DX_CONNECTION_ID=dxcon-fhbshvrc make testacc TESTS=TestAccDirectConnectTransit PKG=directconnect
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 dx-allocate-prefixes 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/directconnect/... -v -count 1 -parallel 20 -run='TestAccDirectConnectTransit'  -timeout 360m -vet=off -buildvcs=false
2026/08/27 11:51:56 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/27 11:51:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDirectConnectTransitVirtualInterface_serial
=== PAUSE TestAccDirectConnectTransitVirtualInterface_serial
=== CONT  TestAccDirectConnectTransitVirtualInterface_serial
=== RUN   TestAccDirectConnectTransitVirtualInterface_serial/basic
=== RUN   TestAccDirectConnectTransitVirtualInterface_serial/bgpASNLong
    transit_virtual_interface_test.go:366: skipping test; environment variable DX_GATEWAY_ID must be set
=== RUN   TestAccDirectConnectTransitVirtualInterface_serial/tags
=== RUN   TestAccDirectConnectTransitVirtualInterface_serial/sitelink
--- PASS: TestAccDirectConnectTransitVirtualInterface_serial (2440.09s)
    --- PASS: TestAccDirectConnectTransitVirtualInterface_serial/basic (900.90s)
    --- SKIP: TestAccDirectConnectTransitVirtualInterface_serial/bgpASNLong (0.00s)
    --- PASS: TestAccDirectConnectTransitVirtualInterface_serial/tags (603.40s)
    --- PASS: TestAccDirectConnectTransitVirtualInterface_serial/sitelink (935.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/directconnect      2447.731s
...
```

I've been trying for hours, but the tests take ages. Also the location for the `connection` test has no free ports.