### PR TITLE
docs: update supported authorizer_types for Bedrock Agent Core gateway

### DIFF
--- a/website/docs/r/bedrockagentcore_gateway.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway.html.markdown
@@ -114,7 +114,7 @@ resource "aws_bedrockagentcore_gateway" "example" {
 
 The following arguments are required:
 
-* `authorizer_type` - (Required) Type of authorizer to use. Valid values: `CUSTOM_JWT`, `AWS_IAM`. When set to `CUSTOM_JWT`, `authorizer_configuration` block is required.
+* `authorizer_type` - (Required) Type of authorizer to use. Valid values: `CUSTOM_JWT`, `AWS_IAM`, `NONE`, `AUTHENTICATE_ONLY`. When set to `CUSTOM_JWT`, `authorizer_configuration` block is required.
 * `name` - (Required) Name of the gateway.
 * `role_arn` - (Required) ARN of the IAM role that the gateway assumes to access AWS services.
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

Update the list of supported `authorizer_types` for the resource [`aws_bedrockagentcore_gateway`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_gateway).
`NONE` and `AUTHENTICATE_ONLY` are missing.

In the comment section of #49648 I demoed that `NONE` is working fine.  Below a successful `terraform apply` for `AUTHENTICATE_ONLY`.


```hcl
terraform apply           
data.aws_iam_policy_document.gateway_assume_role: Reading...
data.aws_iam_policy_document.gateway_assume_role: Read complete after 0s [id=4217861921]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_bedrockagentcore_gateway.example will be created
  + resource "aws_bedrockagentcore_gateway" "example" {
      + authorizer_type           = "AUTHENTICATE_ONLY"
      + description               = "Example AgentCore gateway with no inbound authorization"
      + gateway_arn               = (known after apply)
      + gateway_id                = (known after apply)
      + gateway_url               = (known after apply)
      + name                      = "example-gateway"
      + protocol_type             = "MCP"
      + region                    = "eu-central-1"
      + role_arn                  = (known after apply)
      + tags_all                  = {}
      + workload_identity_details = (known after apply)
    }

  # aws_iam_role.gateway_execution_role will be created
  + resource "aws_iam_role" "gateway_execution_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "bedrock-agentcore.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "example-agentcore-gateway-role"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_iam_role.gateway_execution_role: Creating...
aws_iam_role.gateway_execution_role: Creation complete after 1s [id=example-agentcore-gateway-role]
aws_bedrockagentcore_gateway.example: Creating...
aws_bedrockagentcore_gateway.example: Creation complete after 3s [name=example-gateway]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

### Relations

Closes #49648

### References
- [Terraform provider for AWS - CustomType in resource](https://github.com/hashicorp/terraform-provider-aws/blob/df9bba93f6ee86e14ffd7cfdcb0a6b0de3a2e756/internal/service/bedrockagentcore/gateway.go#L74)
- [AWS Go SDK v2 - AuthorizerType](https://github.com/aws/aws-sdk-go-v2/blob/893faa4621b37ca00e3c99e64bca4483ceb33925/service/bedrockagentcorecontrol/types/enums.go#L132)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.
