### PR TITLE
feat(eks): Add pod_gc_controller_config to kube_controller_manager_config

### DIFF
--- a/.changelog/49725.txt
+++ b/.changelog/49725.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_cluster: Add `pod_gc_controller_config` argument to the `kube_controller_manager_config` configuration block
+```

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -313,6 +313,21 @@ func resourceCluster() *schema.Resource {
 									},
 								},
 							},
+							"pod_gc_controller_config": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Computed: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"terminated_pod_gc_threshold": {
+											Type:     schema.TypeInt,
+											Optional: true,
+											Computed: true,
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -1561,6 +1576,29 @@ func expandKubeControllerManagerConfigRequest(tfList []any) *types.KubeControlle
 		apiObject.HorizontalPodAutoscalerControllerConfig = expandHorizontalPodAutoscalerControllerConfigRequest(v)
 	}
 
+	if v, ok := tfMap["pod_gc_controller_config"].([]any); ok && len(v) > 0 {
+		apiObject.PodGcControllerConfig = expandPodGcControllerConfigRequest(v)
+	}
+
+	return apiObject
+}
+
+func expandPodGcControllerConfigRequest(tfList []any) *types.PodGcControllerConfigRequest {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	apiObject := &types.PodGcControllerConfigRequest{}
+
+	if v, ok := tfMap["terminated_pod_gc_threshold"].(int); ok && v != 0 {
+		apiObject.TerminatedPodGcThreshold = aws.Int32(int32(v))
+	}
+
 	return apiObject
 }
 
@@ -2150,6 +2188,10 @@ func flattenKubeControllerManagerConfigResponse(apiObject *types.KubeControllerM
 		tfMap["horizontal_pod_autoscaler_controller_config"] = flattenHorizontalPodAutoscalerControllerConfigResponse(apiObject.HorizontalPodAutoscalerControllerConfig)
 	}
 
+	if apiObject.PodGcControllerConfig != nil {
+		tfMap["pod_gc_controller_config"] = flattenPodGcControllerConfigResponse(apiObject.PodGcControllerConfig)
+	}
+
 	return []any{tfMap}
 }
 
@@ -2162,6 +2204,20 @@ func flattenHorizontalPodAutoscalerControllerConfigResponse(apiObject *types.Hor
 
 	if apiObject.HorizontalPodAutoscalerSyncPeriod != nil {
 		tfMap["horizontal_pod_autoscaler_sync_period"] = aws.ToString(apiObject.HorizontalPodAutoscalerSyncPeriod)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenPodGcControllerConfigResponse(apiObject *types.PodGcControllerConfigResponse) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if apiObject.TerminatedPodGcThreshold != nil {
+		tfMap["terminated_pod_gc_threshold"] = aws.ToInt32(apiObject.TerminatedPodGcThreshold)
 	}
 
 	return []any{tfMap}

--- a/internal/service/eks/cluster_data_source_test.go
+++ b/internal/service/eks/cluster_data_source_test.go
@@ -338,7 +338,7 @@ data "aws_eks_cluster" "test" {
 }
 
 func testAccClusterDataSourceConfig_kubeControllerManagerConfig(rName string) string {
-	return acctest.ConfigCompose(testAccClusterConfig_kubeControllerManagerConfig(rName, "10s"), `
+	return acctest.ConfigCompose(testAccClusterConfig_kubeControllerManagerConfig(rName, "10s", 12500), `
 data "aws_eks_cluster" "test" {
   name = aws_eks_cluster.test.name
 }

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -1959,7 +1959,7 @@ func TestAccEKSCluster_kubeControllerManagerConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "10s"),
+				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "10s", 12500),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 				),
@@ -1973,6 +1973,9 @@ func TestAccEKSCluster_kubeControllerManagerConfig(t *testing.T) {
 						"horizontal_pod_autoscaler_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"horizontal_pod_autoscaler_sync_period": knownvalue.StringExact("10s"),
 						})}),
+						"pod_gc_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"terminated_pod_gc_threshold": knownvalue.Int64Exact(12500),
+						})}),
 					})})),
 				},
 			},
@@ -1983,7 +1986,7 @@ func TestAccEKSCluster_kubeControllerManagerConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"bootstrap_self_managed_addons"},
 			},
 			{
-				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "13s"),
+				Config: testAccClusterConfig_kubeControllerManagerConfig(rName, "13s", 10000),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 				),
@@ -1996,6 +1999,9 @@ func TestAccEKSCluster_kubeControllerManagerConfig(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("kube_controller_manager_config"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"horizontal_pod_autoscaler_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"horizontal_pod_autoscaler_sync_period": knownvalue.StringExact("13s"),
+						})}),
+						"pod_gc_controller_config": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"terminated_pod_gc_threshold": knownvalue.Int64Exact(10000),
 						})}),
 					})})),
 				},
@@ -3209,7 +3215,7 @@ resource "aws_eks_cluster" "test" {
 `, rName, strategyType))
 }
 
-func testAccClusterConfig_kubeControllerManagerConfig(rName, syncPeriod string) string {
+func testAccClusterConfig_kubeControllerManagerConfig(rName, syncPeriod string, terminatedPodGCThreshold int) string {
 	return acctest.ConfigCompose(testAccClusterConfig_base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
   name     = %[1]q
@@ -3227,9 +3233,13 @@ resource "aws_eks_cluster" "test" {
     horizontal_pod_autoscaler_controller_config {
       horizontal_pod_autoscaler_sync_period = %[2]q
     }
+
+    pod_gc_controller_config {
+      terminated_pod_gc_threshold = %[3]d
+    }
   }
 
   depends_on = [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy]
 }
-`, rName, syncPeriod))
+`, rName, syncPeriod, terminatedPodGCThreshold))
 }

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -437,6 +437,7 @@ The `service_node_port_range` configuration block supports the following argumen
 The `kube_controller_manager_config` configuration block supports the following arguments:
 
 * `horizontal_pod_autoscaler_controller_config` - (Optional) Configuration block for the horizontal pod autoscaler controller. [Detailed](#horizontal_pod_autoscaler_controller_config) below.
+* `pod_gc_controller_config` - (Optional) Configuration block for the pod garbage collection controller. [Detailed](#pod_gc_controller_config) below.
 
 ~> **NOTE:** The `horizontal_pod_autoscaler_controller_config` requires a Provisioned Control Plane scaling tier (e.g., `tier-xl` or higher). It cannot be configured on clusters using the `standard` tier.
 
@@ -445,6 +446,12 @@ The `kube_controller_manager_config` configuration block supports the following 
 The `horizontal_pod_autoscaler_controller_config` configuration block supports the following arguments:
 
 * `horizontal_pod_autoscaler_sync_period` - (Optional) The interval between each sync of the horizontal pod autoscaler. Must be a single-unit duration (e.g., `10s`, `15s`). Valid range: `10s` to `15s`. Default is `15s`.
+
+#### pod_gc_controller_config
+
+The `pod_gc_controller_config` configuration block supports the following arguments:
+
+* `terminated_pod_gc_threshold` - (Optional) The number of terminated pods that can exist before the pod garbage collector starts deleting them. Valid range: `0` to `12500`. Refer to the `aws_eks_cluster_versions` data source for any version-specific constraints.
 
 ### kube_scheduler_config
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->
Add pod_gc_controller_config block with terminated_pod_gc_threshold argument to the kube_controller_manager_config configuration block on aws_eks_cluster. This exposes the EKS API's pod garbage collection controller settings (KubeControllerManagerConfigRequest.PodGcControllerConfig) introduced in AWS SDK for Go v2 EKS v1.93.0.

Includes resource implementation, acceptance tests, and documentation.


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Partially addresses #49709 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=eks TESTS="TestAccEKSCluster_kubeControllerManagerConfig"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
make: Running acceptance tests on branch: 🌿 f_eks_kube_controller_manager_config 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestAccEKSCluster_kubeControllerManagerConfig'  -timeout 360m -vet=off -buildvcs=false
2026/08/27 22:06:32 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/27 22:06:32 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSCluster_kubeControllerManagerConfig
=== PAUSE TestAccEKSCluster_kubeControllerManagerConfig
=== CONT  TestAccEKSCluster_kubeControllerManagerConfig
--- PASS: TestAccEKSCluster_kubeControllerManagerConfig (1267.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        1274.010s
```
