### PR TITLE
F data source eks kube controller manager config

### DIFF
--- a/.changelog/49728.txt
+++ b/.changelog/49728.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_eks_cluster: Add `pod_gc_controller_config` attribute to the `kube_controller_manager_config` configuration block
+```

--- a/internal/service/eks/cluster_data_source.go
+++ b/internal/service/eks/cluster_data_source.go
@@ -179,6 +179,18 @@ func dataSourceCluster() *schema.Resource {
 									},
 								},
 							},
+							"pod_gc_controller_config": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"terminated_pod_gc_threshold": {
+											Type:     schema.TypeInt,
+											Computed: true,
+										},
+									},
+								},
+							},
 						},
 					},
 				},

--- a/internal/service/eks/cluster_data_source_test.go
+++ b/internal/service/eks/cluster_data_source_test.go
@@ -283,6 +283,7 @@ func TestAccEKSClusterDataSource_kubeControllerManagerConfig(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, dataSourceResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(dataSourceResourceName, "kube_controller_manager_config.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "kube_controller_manager_config.0.horizontal_pod_autoscaler_controller_config.0.horizontal_pod_autoscaler_sync_period", dataSourceResourceName, "kube_controller_manager_config.0.horizontal_pod_autoscaler_controller_config.0.horizontal_pod_autoscaler_sync_period"),
+					resource.TestCheckResourceAttrPair(resourceName, "kube_controller_manager_config.0.pod_gc_controller_config.0.terminated_pod_gc_threshold", dataSourceResourceName, "kube_controller_manager_config.0.pod_gc_controller_config.0.terminated_pod_gc_threshold"),
 				),
 			},
 		},

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -66,6 +66,8 @@ This data source exports the following attributes in addition to the arguments a
 * `kube_controller_manager_config` - Configuration for the Kubernetes controller manager.
     * `horizontal_pod_autoscaler_controller_config` - Configuration for the horizontal pod autoscaler controller.
         * `horizontal_pod_autoscaler_sync_period` - The interval between each sync of the horizontal pod autoscaler.
+    * `pod_gc_controller_config` - Configuration for the pod garbage collection controller.
+        * `terminated_pod_gc_threshold` - The number of terminated pods that can exist before the pod garbage collector starts deleting them.
 * `kube_scheduler_config` - Configuration for the Kubernetes scheduler.
     * `node_resources_fit` - Configuration for the NodeResourcesFit scheduler plugin.
         * `scoring_strategy` - The scoring strategy used to rank nodes during scheduling.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
Add pod_gc_controller_config attribute with terminated_pod_gc_threshold to the kube_controller_manager_config block on the aws_eks_cluster data source, mirroring the resource. Reuses the resource's flatten logic and acceptance test configuration.

Includes schema, acceptance test assertion, and documentation.
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Partially Addresses #49709 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
terraform-provider-aws % make testacc PKG=eks TESTS=TestAccEKSClusterDataSource_kubeControllerManagerConfig

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     5.488s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 7.088s
make: Running acceptance tests on branch: 🌿 f_data_source_eks_kube_controller_manager_config 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestAccEKSClusterDataSource_kubeControllerManagerConfig'  -timeout 360m -vet=off -buildvcs=false
2026/08/28 08:03:09 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 08:03:09 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSClusterDataSource_kubeControllerManagerConfig
=== PAUSE TestAccEKSClusterDataSource_kubeControllerManagerConfig
=== CONT  TestAccEKSClusterDataSource_kubeControllerManagerConfig
--- PASS: TestAccEKSClusterDataSource_kubeControllerManagerConfig (454.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        461.497s
```
