### PR TITLE
internal/acctest: move `PreCheck` credential search outside `sync.Once.Do`

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -319,15 +319,15 @@ func ProtoV5FactoriesMultipleRegions(ctx context.Context, t *testing.T, n int) m
 func PreCheck(ctx context.Context, t *testing.T) {
 	t.Helper()
 
+	envvar.FailIfAllEmpty(t, []string{envvar.Profile, envvar.AccessKeyId, envvar.ContainerCredentialsFullURI}, "credentials for running acceptance testing")
+
+	if os.Getenv(envvar.AccessKeyId) != "" {
+		envvar.FailIfEmpty(t, envvar.SecretAccessKey, "static credentials value when using "+envvar.AccessKeyId)
+	}
+
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
 	testAccProviderConfigure.Do(func() {
-		envvar.FailIfAllEmpty(t, []string{envvar.Profile, envvar.AccessKeyId, envvar.ContainerCredentialsFullURI}, "credentials for running acceptance testing")
-
-		if os.Getenv(envvar.AccessKeyId) != "" {
-			envvar.FailIfEmpty(t, envvar.SecretAccessKey, "static credentials value when using "+envvar.AccessKeyId)
-		}
-
 		// Setting the AWS_DEFAULT_REGION environment variable here allows all tests to omit
 		// a provider configuration with a region. This defaults to us-west-2 for provider
 		// developer simplicity and has been in the codebase for a very long time.


### PR DESCRIPTION




<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


This ensures each test is failed individually when credentials are missing, instead of just the first test to reach the `Do` method on the global variable. Prevents crashes in scenarios where credentials are not set and subsequent pre checks initialize service clients.

Before:

```console
% make t K=rds T="TestAccRDSOrderableInstanceDataSource_supportsGlobalDatabases|TestAccRDSOrderableInstanceDataSource_basic"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-pre-check-crash 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSOrderableInstanceDataSource_supportsGlobalDatabases|TestAccRDSOrderableInstanceDataSource_basic'  -timeout 360m -vet=off -buildvcs=false
2026/08/28 10:45:37 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 10:45:37 Initializing Terraform AWS Provider (SDKv2-style)...
=== NAME  TestAccRDSOrderableInstanceDataSource_basic
    acctest.go:325: at least one environment variable of [AWS_PROFILE AWS_ACCESS_KEY_ID AWS_CONTAINER_CREDENTIALS_FULL_URI] must be set. Usage: credentials for running acceptance testing
--- FAIL: TestAccRDSOrderableInstanceDataSource_basic (0.00s)
--- FAIL: TestAccRDSOrderableInstanceDataSource_supportsGlobalDatabases (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x111f64174]

goroutine 36 [running]:
testing.tRunner.func1.2({0x12dd1f1a0, 0x131ace180})
        /Users/jaredbaker/sdk/go1.26.6/src/testing/testing.go:1974 +0x1a0
testing.tRunner.func1()
        /Users/jaredbaker/sdk/go1.26.6/src/testing/testing.go:1977 +0x318
panic({0x12dd1f1a0?, 0x131ace180?})
        /Users/jaredbaker/sdk/go1.26.6/src/runtime/panic.go:860 +0x12c
github.com/hashicorp/terraform-provider-aws/internal/conns.(*AWSClient).Region(0x5c4f6ddc97a0, {0x1312e7270, 0x5c4f6f2ba240})
        /Users/jaredbaker/development/_worktrees/td-pre-check-crash/internal/conns/awsclient.go:198 +0x84
github.com/hashicorp/terraform-provider-aws/internal/conns.client[...]({0x1312e7270, 0x5c4f6fcbeb70}, 0x5c4f6ddc97a0, {0x1186bc48b, 0x3}, 0x5c4f6f2d76a8)
        /Users/jaredbaker/development/_worktrees/td-pre-check-crash/internal/conns/awsclient.go:455 +0x94
github.com/hashicorp/terraform-provider-aws/internal/conns.(*AWSClient).RDSClient(0x5c4f6ddc97a0, {0x1312e7270, 0x5c4f6fcbeb70})
        /Users/jaredbaker/development/_worktrees/td-pre-check-crash/internal/conns/awsclient_gen.go:1087 +0xa0
github.com/hashicorp/terraform-provider-aws/internal/service/rds_test.testAccOrderableInstancePreCheck({0x1312e7270, 0x5c4f6fcbeb70}, 0x5c4f6dfe7208)
        /Users/jaredbaker/development/_worktrees/td-pre-check-crash/internal/service/rds/orderable_instance_data_source_test.go:467 +0x34
github.com/hashicorp/terraform-provider-aws/internal/service/rds_test.TestAccRDSOrderableInstanceDataSource_supportsGlobalDatabases.func1()
        /Users/jaredbaker/development/_worktrees/td-pre-check-crash/internal/service/rds/orderable_instance_data_source_test.go:188 +0x40
github.com/hashicorp/terraform-plugin-testing/helper/resource.Test({0x131560d80, 0x5c4f6dfe7208}, {0x0, 0x5c4f6edbeb40, {0x0, 0x0, 0x0}, 0x0, 0x5c4f6dea9680, 0x0, ...})
        /Users/jaredbaker/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.16.0/helper/resource/testing.go:997 +0x388
github.com/hashicorp/terraform-plugin-testing/helper/resource.ParallelTest({0x131560d80, 0x5c4f6dfe7208}, {0x0, 0x5c4f6edbeb40, {0x0, 0x0, 0x0}, 0x0, 0x5c4f6dea9680, 0x0, ...})
        /Users/jaredbaker/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.16.0/helper/resource/testing.go:922 +0x70
github.com/hashicorp/terraform-provider-aws/internal/acctest.ParallelTest({0x1312e7270, 0x5c4f6fcbeb70}, 0x5c4f6dfe7208, {0x0, 0x5c4f6edbeb40, {0x0, 0x0, 0x0}, 0x0, 0x5c4f6dea9680, ...})
        /Users/jaredbaker/development/_worktrees/td-pre-check-crash/internal/acctest/vcr.go:522 +0xfc
github.com/hashicorp/terraform-provider-aws/internal/service/rds_test.TestAccRDSOrderableInstanceDataSource_supportsGlobalDatabases(0x5c4f6dfe7208)
        /Users/jaredbaker/development/_worktrees/td-pre-check-crash/internal/service/rds/orderable_instance_data_source_test.go:187 +0x5e8
testing.tRunner(0x5c4f6dfe7208, 0x130cde480)
        /Users/jaredbaker/sdk/go1.26.6/src/testing/testing.go:2036 +0xc4
created by testing.(*T).Run in goroutine 1
        /Users/jaredbaker/sdk/go1.26.6/src/testing/testing.go:2101 +0x3a8
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/rds        8.684s
FAIL
make: *** [t] Error 1
```

After:

```console
% make t K=rds T="TestAccRDSOrderableInstanceDataSource_supportsGlobalDatabases|TestAccRDSOrderableInstanceDataSource_basic"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-pre-check-crash 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSOrderableInstanceDataSource_supportsGlobalDatabases|TestAccRDSOrderableInstanceDataSource_basic'  -timeout 360m -vet=off -buildvcs=false
2026/08/28 10:47:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 10:47:03 Initializing Terraform AWS Provider (SDKv2-style)...
    orderable_instance_data_source_test.go:29: at least one environment variable of [AWS_PROFILE AWS_ACCESS_KEY_ID AWS_CONTAINER_CREDENTIALS_FULL_URI] must be set. Usage: credentials for running acceptance testing
--- FAIL: TestAccRDSOrderableInstanceDataSource_basic (0.00s)
    orderable_instance_data_source_test.go:188: at least one environment variable of [AWS_PROFILE AWS_ACCESS_KEY_ID AWS_CONTAINER_CREDENTIALS_FULL_URI] must be set. Usage: credentials for running acceptance testing
--- FAIL: TestAccRDSOrderableInstanceDataSource_supportsGlobalDatabases (0.00s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/rds        8.937s
FAIL
make: *** [t] Error 1
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49734



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make smoke
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2026/08/28 10:52:25 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 10:52:25 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (48.37s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (48.38s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON (53.29s)
--- PASS: TestAccIAMPolicy_List_basic (60.52s)
--- PASS: TestAccIAMRole_disappears (63.70s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (63.91s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (64.16s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (64.83s)
--- PASS: TestAccIAMRole_basic (66.44s)
--- PASS: TestAccIAMPolicy_basic (66.45s)
--- PASS: TestAccIAMRolePolicy_basic (66.53s)
--- PASS: TestAccIAMRole_namePrefix (66.54s)
--- PASS: TestAccIAMInstanceProfile_basic (68.51s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (80.91s)
--- PASS: TestAccIAMPolicy_policy (81.20s)
--- PASS: TestAccIAMRole_Identity_basic (81.22s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (92.71s)
--- PASS: TestAccIAMPolicy_tags (125.12s)
--- PASS: TestAccIAMInstanceProfile_tags (140.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        149.352s
2026/08/28 10:55:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 10:55:28 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccLogsLogGroup_multiple (17.35s)
--- PASS: TestAccLogsLogGroup_basic (20.67s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       29.739s
2026/08/28 10:56:16 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 10:56:16 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccVPCSubnet_basic (40.33s)
--- PASS: TestAccVPCRouteTable_basic (41.00s)
--- PASS: TestAccVPCDataSource_basic (44.14s)
--- PASS: TestAccVPCSecurityGroup_basic (44.37s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (44.64s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (45.19s)
--- PASS: TestAccVPCSecurityGroup_egressMode (72.57s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (77.72s)
--- PASS: TestAccVPC_tenancy (78.43s)
--- PASS: TestAccVPCSecurityGroupRule_race (175.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        211.091s
2026/08/28 10:56:03 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 10:56:03 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccECSTaskDefinition_basic (40.10s)
--- PASS: TestAccECSService_basic (95.40s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        117.035s
?       github.com/hashicorp/terraform-provider-aws/internal/service/ecs/test-fixtures  [no test files]
2026/08/28 10:55:50 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 10:55:50 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccELBV2TargetGroup_basic (29.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      38.360s
2026/08/28 10:56:09 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 10:56:09 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccEventsPutEventsAction_basic (139.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     167.742s
2026/08/28 10:55:57 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 10:55:57 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccKMSKey_basic (46.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kms        61.535s
2026/08/28 11:00:05 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 11:00:05 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccLambdaPermission_basic (61.67s)
--- PASS: TestAccLambdaFunction_basic (78.12s)
--- PASS: TestAccLambdaCapacityProvider_List_basic (79.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     94.819s
2026/08/28 11:00:19 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 11:00:19 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccMetaRegionDataSource_endpoint (32.19s)
--- PASS: TestAccMetaPartitionDataSource_basic (32.49s)
--- PASS: TestAccMetaRegionDataSource_basic (33.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/meta       62.252s
2026/08/28 11:00:12 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 11:00:12 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccRoute53ZoneDataSource_name (95.35s)
--- PASS: TestAccRoute53Record_basic_ShortName (156.26s)
--- PASS: TestAccRoute53Record_basic_FullName (157.29s)
--- PASS: TestAccRoute53Record_Latency_basic (158.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    180.193s
2026/08/28 11:00:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 11:00:33 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccS3BucketPublicAccessBlock_basic (65.33s)
--- PASS: TestAccS3BucketPolicy_basic (65.85s)
--- PASS: TestAccS3Bucket_Basic_basic (65.98s)
--- PASS: TestAccS3Object_basic (73.93s)
--- PASS: TestAccS3BucketACL_updateACL (85.00s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (86.31s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 124.509s
2026/08/28 11:00:25 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 11:00:25 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccSSMParameterEphemeral_basic (37.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        68.302s
2026/08/28 11:00:39 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 11:00:39 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccSecretsManagerSecret_basic (48.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     92.581s
2026/08/28 11:00:52 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 11:00:52 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestAccSTSCallerIdentityDataSource_basic (29.55s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sts        86.605s
2026/08/28 11:00:46 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/28 11:00:46 Initializing Terraform AWS Provider (SDKv2-style)...
--- PASS: TestARNParseFunction_known (29.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/function   80.259s
```
