### PR TITLE
aws_glue_catalog_table: Fix perpetual diff for validated Athena view_original_text

### DIFF
--- a/.changelog/49736.txt
+++ b/.changelog/49736.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_table: Fix perpetual diff when AWS Glue replaces configured `view_definition.representations.view_original_text` with an encoded Presto view for validated ATHENA views
+```

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -737,9 +737,9 @@ func resourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("target_table", nil)
 	}
 	if table.ViewDefinition != nil {
-		// Glue does not echo back ValidationConnection, ViewOriginalText, or
-		// ViewExpandedText for validated ATHENA views — GetTable returns them as
-		// null. Preserve user supplied values.
+		// Preserve user-supplied values that Glue does not echo back. For
+		// validated ATHENA views, status details contain the submitted SQL while
+		// ViewOriginalText contains an engine-generated Presto representation.
 		var priorRepresentations []any
 		if v, ok := d.GetOk("view_definition"); ok {
 			vdList := v.([]any)
@@ -750,7 +750,7 @@ func resourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta 
 				}
 			}
 		}
-		if err := d.Set("view_definition", []any{flattenViewDefinition(table.ViewDefinition, priorRepresentations)}); err != nil {
+		if err := d.Set("view_definition", []any{flattenViewDefinition(table.ViewDefinition, priorRepresentations, table.Status)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting view_definition: %s", err)
 		}
 	} else {
@@ -900,9 +900,10 @@ func catalogTableParseResourceID(id string) (string, string, string, error) {
 
 func findTableByThreePartKey(ctx context.Context, conn *glue.Client, catalogID, dbName, name string) (*awstypes.Table, error) {
 	input := glue.GetTableInput{
-		CatalogId:    aws.String(catalogID),
-		DatabaseName: aws.String(dbName),
-		Name:         aws.String(name),
+		CatalogId:            aws.String(catalogID),
+		DatabaseName:         aws.String(dbName),
+		IncludeStatusDetails: aws.Bool(true),
+		Name:                 aws.String(name),
 	}
 
 	return findTable(ctx, conn, &input)
@@ -1924,7 +1925,7 @@ func expandViewRepresentationInputs(tfList []any) []awstypes.ViewRepresentationI
 	return apiObjects
 }
 
-func flattenViewDefinition(apiObject *awstypes.ViewDefinition, priorRepresentations []any) map[string]any {
+func flattenViewDefinition(apiObject *awstypes.ViewDefinition, priorRepresentations []any, status *awstypes.TableStatus) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
@@ -1948,7 +1949,7 @@ func flattenViewDefinition(apiObject *awstypes.ViewDefinition, priorRepresentati
 	}
 
 	if v := apiObject.Representations; len(v) > 0 {
-		tfMap["representations"] = flattenViewRepresentations(v, priorRepresentations)
+		tfMap["representations"] = flattenViewRepresentations(v, priorRepresentations, status)
 	}
 
 	tfMap["view_version_id"] = apiObject.ViewVersionId
@@ -1961,10 +1962,10 @@ func flattenViewDefinition(apiObject *awstypes.ViewDefinition, priorRepresentati
 }
 
 // flattenViewRepresentations flattens API representations, falling back to
-// prior state values for fields Glue does not echo back on GetTable
-// (ValidationConnection, ViewOriginalText, ViewExpandedText). Matching is by
-// dialect so the merge is order-independent.
-func flattenViewRepresentations(apiObjects []awstypes.ViewRepresentation, prior []any) []any {
+// prior state values for fields Glue does not echo back on GetTable. Matching
+// prior state and successful validation details by dialect makes the merge
+// order-independent.
+func flattenViewRepresentations(apiObjects []awstypes.ViewRepresentation, prior []any, status *awstypes.TableStatus) []any {
 	// Build a lookup of prior state representations keyed by dialect string.
 	priorByDialect := make(map[string]map[string]any, len(prior))
 	for _, raw := range prior {
@@ -1977,16 +1978,53 @@ func flattenViewRepresentations(apiObjects []awstypes.ViewRepresentation, prior 
 
 	tfList := make([]any, len(apiObjects))
 	for i, v := range apiObjects {
-		tfList[i] = flattenViewRepresentation(v, priorByDialect[string(v.Dialect)])
+		priorRepresentation := priorByDialect[string(v.Dialect)]
+		if v.Dialect == awstypes.ViewDialectAthena && isPrestoViewOriginalText(aws.ToString(v.ViewOriginalText)) {
+			if text := successfulViewValidationText(v, status); text != "" {
+				v.ViewOriginalText = aws.String(text)
+			} else if priorRepresentation != nil {
+				if priorText, ok := priorRepresentation["view_original_text"].(string); ok && priorText != "" {
+					v.ViewOriginalText = nil
+				}
+			}
+		}
+		tfList[i] = flattenViewRepresentation(v, priorRepresentation)
 	}
 	return tfList
 }
 
-// flattenViewRepresentation flattens one API representation. For the three
-// fields Glue strips on validated views (ValidationConnection,
-// ViewOriginalText, ViewExpandedText), the API value takes precedence when
-// non-empty; otherwise the prior state value is preserved so state stays
-// consistent with what the user configured.
+func isPrestoViewOriginalText(v string) bool {
+	return strings.HasPrefix(strings.TrimSpace(v), "/* Presto View:")
+}
+
+func successfulViewValidationText(representation awstypes.ViewRepresentation, status *awstypes.TableStatus) string {
+	if status == nil || status.State != awstypes.ResourceStateSuccess || status.Details == nil {
+		return ""
+	}
+
+	for _, validation := range status.Details.ViewValidations {
+		if validation.Dialect != representation.Dialect {
+			continue
+		}
+		validationVersion := aws.ToString(validation.DialectVersion)
+		representationVersion := aws.ToString(representation.DialectVersion)
+		if validationVersion != "" && representationVersion != "" && validationVersion != representationVersion {
+			continue
+		}
+		if validation.State != "" && validation.State != awstypes.ResourceStateSuccess {
+			continue
+		}
+		if v := aws.ToString(validation.ViewValidationText); v != "" {
+			return v
+		}
+	}
+
+	return ""
+}
+
+// flattenViewRepresentation flattens one API representation. For fields Glue
+// strips on validated views, the API value takes precedence when non-empty;
+// otherwise the prior state value is preserved.
 func flattenViewRepresentation(apiObject awstypes.ViewRepresentation, prior map[string]any) map[string]any {
 	tfMap := make(map[string]any)
 
@@ -1998,7 +2036,6 @@ func flattenViewRepresentation(apiObject awstypes.ViewRepresentation, prior map[
 		tfMap["dialect_version"] = v
 	}
 
-	// Glue does not store these fields back for validated ATHENA views.
 	// Use the API value when present; fall back to prior state otherwise.
 	if v := aws.ToString(apiObject.ValidationConnection); v != "" {
 		tfMap["validation_connection"] = v

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -213,12 +213,189 @@ func TestFlattenViewRepresentations(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := tfglue.FlattenViewRepresentations(tc.apiObjects, tc.prior)
+			got := tfglue.FlattenViewRepresentations(tc.apiObjects, tc.prior, nil)
 
 			if len(got) != tc.wantLen {
 				t.Fatalf("len(got) = %d, want %d", len(got), tc.wantLen)
 			}
 			tc.checkFn(t, got)
+		})
+	}
+}
+
+func TestFlattenViewRepresentations_ViewValidationText(t *testing.T) {
+	t.Parallel()
+
+	const (
+		prestoViewOriginalText = "/* Presto View: encoded */"
+		priorSQL               = "SELECT old_value"
+		submittedSQL           = "SELECT accountid AS account_id\nFROM accounts"
+	)
+
+	successfulStatus := func(validations ...awstypes.ViewValidation) *awstypes.TableStatus {
+		return &awstypes.TableStatus{
+			State: awstypes.ResourceStateSuccess,
+			Details: &awstypes.StatusDetails{
+				ViewValidations: validations,
+			},
+		}
+	}
+
+	testCases := []struct {
+		name         string
+		apiObject    awstypes.ViewRepresentation
+		status       *awstypes.TableStatus
+		omitPriorSQL bool
+		wantSQL      string
+	}{
+		{
+			name: "successful athena validation restores exact submitted sql",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect:          awstypes.ViewDialectAthena,
+				DialectVersion:   aws.String("3"),
+				ViewOriginalText: aws.String(prestoViewOriginalText),
+			},
+			status: successfulStatus(
+				awstypes.ViewValidation{
+					Dialect:            awstypes.ViewDialectSpark,
+					DialectVersion:     aws.String("3"),
+					State:              awstypes.ResourceStateSuccess,
+					ViewValidationText: aws.String("SELECT spark_value"),
+				},
+				awstypes.ViewValidation{
+					Dialect:            awstypes.ViewDialectAthena,
+					DialectVersion:     aws.String("3"),
+					State:              awstypes.ResourceStateSuccess,
+					ViewValidationText: aws.String(submittedSQL),
+				},
+			),
+			wantSQL: submittedSQL,
+		},
+		{
+			name: "failed table status falls back to prior state",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect:          awstypes.ViewDialectAthena,
+				DialectVersion:   aws.String("3"),
+				ViewOriginalText: aws.String(prestoViewOriginalText),
+			},
+			status: &awstypes.TableStatus{
+				State: awstypes.ResourceStateFailed,
+				Details: &awstypes.StatusDetails{
+					ViewValidations: []awstypes.ViewValidation{
+						{
+							Dialect:            awstypes.ViewDialectAthena,
+							DialectVersion:     aws.String("3"),
+							State:              awstypes.ResourceStateSuccess,
+							ViewValidationText: aws.String(submittedSQL),
+						},
+					},
+				},
+			},
+			wantSQL: priorSQL,
+		},
+		{
+			name: "failed view validation falls back to prior state",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect:          awstypes.ViewDialectAthena,
+				DialectVersion:   aws.String("3"),
+				ViewOriginalText: aws.String(prestoViewOriginalText),
+			},
+			status: successfulStatus(awstypes.ViewValidation{
+				Dialect:            awstypes.ViewDialectAthena,
+				DialectVersion:     aws.String("3"),
+				State:              awstypes.ResourceStateFailed,
+				ViewValidationText: aws.String(submittedSQL),
+			}),
+			wantSQL: priorSQL,
+		},
+		{
+			name: "different dialect version falls back to prior state",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect:          awstypes.ViewDialectAthena,
+				DialectVersion:   aws.String("3"),
+				ViewOriginalText: aws.String(prestoViewOriginalText),
+			},
+			status: successfulStatus(awstypes.ViewValidation{
+				Dialect:            awstypes.ViewDialectAthena,
+				DialectVersion:     aws.String("2"),
+				State:              awstypes.ResourceStateSuccess,
+				ViewValidationText: aws.String(submittedSQL),
+			}),
+			wantSQL: priorSQL,
+		},
+		{
+			name: "empty validation text falls back to prior state",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect:          awstypes.ViewDialectAthena,
+				DialectVersion:   aws.String("3"),
+				ViewOriginalText: aws.String(prestoViewOriginalText),
+			},
+			status: successfulStatus(awstypes.ViewValidation{
+				Dialect:        awstypes.ViewDialectAthena,
+				DialectVersion: aws.String("3"),
+				State:          awstypes.ResourceStateSuccess,
+			}),
+			wantSQL: priorSQL,
+		},
+		{
+			name: "missing prior sql preserves generated api value",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect:          awstypes.ViewDialectAthena,
+				DialectVersion:   aws.String("3"),
+				ViewOriginalText: aws.String(prestoViewOriginalText),
+			},
+			status: &awstypes.TableStatus{
+				State: awstypes.ResourceStateFailed,
+			},
+			omitPriorSQL: true,
+			wantSQL:      prestoViewOriginalText,
+		},
+		{
+			name: "plain athena api value is unchanged",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect:          awstypes.ViewDialectAthena,
+				DialectVersion:   aws.String("3"),
+				ViewOriginalText: aws.String("SELECT api_value"),
+			},
+			status: successfulStatus(awstypes.ViewValidation{
+				Dialect:            awstypes.ViewDialectAthena,
+				DialectVersion:     aws.String("3"),
+				State:              awstypes.ResourceStateSuccess,
+				ViewValidationText: aws.String(submittedSQL),
+			}),
+			wantSQL: "SELECT api_value",
+		},
+		{
+			name: "spark representation is unchanged",
+			apiObject: awstypes.ViewRepresentation{
+				Dialect:          awstypes.ViewDialectSpark,
+				DialectVersion:   aws.String("3"),
+				ViewOriginalText: aws.String(prestoViewOriginalText),
+			},
+			status: successfulStatus(awstypes.ViewValidation{
+				Dialect:            awstypes.ViewDialectSpark,
+				DialectVersion:     aws.String("3"),
+				State:              awstypes.ResourceStateSuccess,
+				ViewValidationText: aws.String(submittedSQL),
+			}),
+			wantSQL: prestoViewOriginalText,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			prior := map[string]any{"dialect": string(tc.apiObject.Dialect)}
+			if !tc.omitPriorSQL {
+				prior["view_original_text"] = priorSQL
+			}
+
+			got := tfglue.FlattenViewRepresentations([]awstypes.ViewRepresentation{tc.apiObject}, []any{prior}, tc.status)
+
+			if gotSQL := got[0].(map[string]any)["view_original_text"]; gotSQL != tc.wantSQL {
+				t.Errorf("view_original_text = %q, want %q", gotSQL, tc.wantSQL)
+			}
 		})
 	}
 }
@@ -1096,6 +1273,47 @@ func TestAccGlueCatalogTable_viewDefinition_noPerpetualDiff(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccGlueCatalogTable_viewDefinitionAthenaNoPerpetualDiff(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_glue_catalog_table.test"
+	configuredSQL := fmt.Sprintf(`SELECT accountid AS account_id FROM %q.%q`, rName, "accounts")
+	config := testAccCatalogTableConfig_viewDefinitionAthenaNoPerpetualDiff(rName, configuredSQL)
+
+	acctest.Test(ctx, t, resource.TestCase{ // nosemgrep:ci.semgrep.acctest.testcase-use-paralleltest -- Lake Formation data lake settings are an account-wide singleton
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogTableDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "view_definition.0.representations.0.view_original_text", configuredSQL),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
 					},
 				},
 			},
@@ -2169,4 +2387,278 @@ resource "aws_glue_catalog_table" "test" {
   }
 }
 `, rName, viewOriginalText, viewExpandedText)
+}
+
+func testAccCatalogTableConfig_viewDefinitionAthenaNoPerpetualDiff(rName, viewOriginalText string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
+resource "aws_lakeformation_data_lake_settings" "test" {
+  admins = [data.aws_iam_session_context.current.issuer_arn]
+
+  parameters = {
+    CROSS_ACCOUNT_VERSION = "4"
+    SET_CONTEXT           = "TRUE"
+  }
+}
+
+resource "aws_s3_bucket" "source" {
+  bucket        = "%[1]s-source"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket" "athena_results" {
+  bucket        = "%[1]s-results"
+  force_destroy = true
+}
+
+resource "aws_athena_workgroup" "test" {
+  name          = "%[1]s-validation"
+  force_destroy = true
+
+  configuration {
+    enforce_workgroup_configuration = true
+
+    engine_version {
+      selected_engine_version = "Athena engine version 3"
+    }
+
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.athena_results.bucket}/results/"
+    }
+  }
+}
+
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+
+  depends_on = [aws_lakeformation_data_lake_settings.test]
+}
+
+resource "aws_glue_catalog_table" "source" {
+  name          = "accounts"
+  database_name = aws_glue_catalog_database.test.name
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL       = "TRUE"
+    classification = "parquet"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.source.bucket}/accounts/"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      name                  = "parquet"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+
+    columns {
+      name = "accountid"
+      type = "string"
+    }
+  }
+}
+
+resource "aws_iam_role" "lakeformation_access" {
+  name = "%[1]s-lf-access"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "lakeformation.amazonaws.com"
+      }
+      Action = [
+        "sts:AssumeRole",
+        "sts:SetContext",
+      ]
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "lakeformation_access" {
+  name = "source-bucket-access"
+  role = aws_iam_role.lakeformation_access.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+        ]
+        Resource = aws_s3_bucket.source.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:PutObject",
+        ]
+        Resource = "${aws_s3_bucket.source.arn}/*"
+      },
+    ]
+  })
+}
+
+resource "aws_lakeformation_resource" "source" {
+  arn      = aws_s3_bucket.source.arn
+  role_arn = aws_iam_role.lakeformation_access.arn
+
+  depends_on = [
+    aws_glue_catalog_table.source,
+    aws_iam_role_policy.lakeformation_access,
+  ]
+}
+
+resource "aws_iam_role" "view_definer" {
+  name = "%[1]s-definer"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "glue.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      },
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lakeformation.amazonaws.com"
+        }
+        Action = [
+          "sts:AssumeRole",
+          "sts:SetContext",
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "view_definer" {
+  name = "view-validation"
+  role = aws_iam_role.view_definer.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "athena:GetQueryExecution",
+          "athena:GetQueryResults",
+          "athena:GetWorkGroup",
+          "athena:StartQueryExecution",
+          "athena:StopQueryExecution",
+          "glue:BatchGetPartition",
+          "glue:GetDatabase",
+          "glue:GetDatabases",
+          "glue:GetPartition",
+          "glue:GetPartitions",
+          "glue:GetTable",
+          "glue:GetTables",
+          "glue:GetTableVersion",
+          "glue:GetTableVersions",
+          "glue:PassConnection",
+          "lakeformation:GetDataAccess",
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          aws_s3_bucket.source.arn,
+          aws_s3_bucket.athena_results.arn,
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+        ]
+        Resource = [
+          "${aws_s3_bucket.source.arn}/*",
+          "${aws_s3_bucket.athena_results.arn}/*",
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_lakeformation_permissions" "create_view" {
+  principal   = aws_iam_role.view_definer.arn
+  permissions = ["CREATE_TABLE"]
+
+  database {
+    catalog_id = data.aws_caller_identity.current.account_id
+    name       = aws_glue_catalog_database.test.name
+  }
+}
+
+resource "aws_lakeformation_permissions" "select_source" {
+  principal                     = aws_iam_role.view_definer.arn
+  permissions                   = ["SELECT"]
+  permissions_with_grant_option = ["SELECT"]
+
+  table {
+    catalog_id    = data.aws_caller_identity.current.account_id
+    database_name = aws_glue_catalog_database.test.name
+    name          = aws_glue_catalog_table.source.name
+  }
+
+  depends_on = [aws_lakeformation_resource.source]
+}
+
+resource "aws_glue_connection" "test" {
+  name            = "%[1]s-validation"
+  connection_type = "VIEW_VALIDATION_ATHENA"
+
+  connection_properties = {
+    WORKGROUP_NAME = aws_athena_workgroup.test.name
+  }
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = "accounts_view"
+  database_name = aws_glue_catalog_database.test.name
+  table_type    = "VIRTUAL_VIEW"
+
+  depends_on = [
+    aws_iam_role_policy.view_definer,
+    aws_lakeformation_permissions.create_view,
+    aws_lakeformation_permissions.select_source,
+  ]
+
+  view_definition {
+    definer      = aws_iam_role.view_definer.arn
+    is_protected = true
+
+    representations {
+      dialect               = "ATHENA"
+      dialect_version       = "3"
+      validation_connection = aws_glue_connection.test.name
+      view_original_text    = %[2]q
+    }
+  }
+}
+`, rName, viewOriginalText)
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

## Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When `aws_glue_catalog_table` manages a validated Athena Data Catalog view, Glue replaces the configured `view_original_text` in the standard `GetTable` response with an encoded `/* Presto View: ... */` representation. The provider stores that generated value in state even though the configuration still contains the submitted SQL. As a result, every subsequent plan proposes changing `view_original_text` back to the configured SQL.

For example, after applying a view with:

```hcl
representations {
  dialect               = "ATHENA"
  dialect_version       = "3"
  validation_connection = aws_glue_connection.test.name
  view_original_text    = "SELECT accountid AS account_id FROM \"example\".\"accounts\""
}
```

A fresh plan with no configuration changes contains:

```console
~ view_original_text = "/* Presto View: <base64 JSON> */" -> "SELECT accountid AS account_id FROM \"example\".\"accounts\""
```

When status details are requested, `GetTable` retains the exact submitted SQL in `Status.Details.ViewValidations[].ViewValidationText`. Decoding the generated Presto payload is not sufficient because Athena reformats the SQL stored inside it.

This PR requests status details when reading catalog tables and, for successful Athena validations whose returned value is an encoded Presto view, restores `view_original_text` from the matching validation result. If successful validation details are unavailable, the existing prior-state fallback remains in place.

OpenAI Codex (GPT-5.6 Sol) was used to help confirm and reproduce the issue after it was observed, investigate the Glue API response, implement the fix, and develop the unit and acceptance tests. Anthropic Claude Code (Fable 5) was also used to review the code for correctness and adherence to standards. I personally reviewed and validated all resulting changes.

## Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49731

## References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

N/A

## Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make test PKG=glue

ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue      5.533s

% make testacc PKG=glue \
  TESTS='TestAccGlueCatalogTable_viewDefinitionAthenaNoPerpetualDiff$' \
  ACCTEST_PARALLELISM=1

=== RUN   TestAccGlueCatalogTable_viewDefinitionAthenaNoPerpetualDiff
--- PASS: TestAccGlueCatalogTable_viewDefinitionAthenaNoPerpetualDiff (45.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue      50.931s
```

The locally built provider was also tested against the original reproduction configuration provided in the linked issue:

```console
% terraform plan -no-color -detailed-exitcode

No changes. Your infrastructure matches the configuration.
```
