### PR TITLE
[bugfix] aws_elasticache_serverless_cache tag race condition

### DIFF
--- a/.changelog/49737.txt
+++ b/.changelog/49737.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_serverless_cache: Fix intermittent `Provider produced inconsistent result after apply` errors on the `status` attribute during tag-only updates by waiting for the cache to return to `available`
+```

--- a/internal/service/elasticache/serverless_cache.go
+++ b/internal/service/elasticache/serverless_cache.go
@@ -407,6 +407,9 @@ func (r *serverlessCacheResource) Update(ctx context.Context, request resource.U
 	name := new.ID.ValueString()
 	deadline := inttypes.NewDeadline(r.UpdateTimeout(ctx, new.Timeouts))
 
+	// Track whether any non-tag attribute was modified; tag-only updates run no per-field wait.
+	var modified bool
+
 	if !new.Description.Equal(old.Description) {
 		input := elasticache.ModifyServerlessCacheInput{
 			ServerlessCacheName: new.ServerlessCacheName.ValueStringPointer(),
@@ -416,6 +419,7 @@ func (r *serverlessCacheResource) Update(ctx context.Context, request resource.U
 		if response.Diagnostics.HasError() {
 			return
 		}
+		modified = true
 	}
 
 	if !new.DailySnapshotTime.Equal(old.DailySnapshotTime) {
@@ -427,6 +431,7 @@ func (r *serverlessCacheResource) Update(ctx context.Context, request resource.U
 		if response.Diagnostics.HasError() {
 			return
 		}
+		modified = true
 	}
 
 	if !new.SnapshotRetentionLimit.Equal(old.SnapshotRetentionLimit) {
@@ -438,6 +443,7 @@ func (r *serverlessCacheResource) Update(ctx context.Context, request resource.U
 		if response.Diagnostics.HasError() {
 			return
 		}
+		modified = true
 	}
 
 	if !new.CacheUsageLimits.Equal(old.CacheUsageLimits) {
@@ -468,6 +474,7 @@ func (r *serverlessCacheResource) Update(ctx context.Context, request resource.U
 		if response.Diagnostics.HasError() {
 			return
 		}
+		modified = true
 	}
 
 	if !new.SecurityGroupIDs.Equal(old.SecurityGroupIDs) {
@@ -482,6 +489,7 @@ func (r *serverlessCacheResource) Update(ctx context.Context, request resource.U
 		if response.Diagnostics.HasError() {
 			return
 		}
+		modified = true
 	}
 
 	if !new.UserGroupID.Equal(old.UserGroupID) {
@@ -497,6 +505,7 @@ func (r *serverlessCacheResource) Update(ctx context.Context, request resource.U
 		if response.Diagnostics.HasError() {
 			return
 		}
+		modified = true
 	}
 
 	// Engine and MajorEngineVersion must be sent together when engine changes.
@@ -521,6 +530,15 @@ func (r *serverlessCacheResource) Update(ctx context.Context, request resource.U
 		}
 		response.Diagnostics.Append(updateServerlessCache(ctx, conn, name, &input, deadline.Remaining())...)
 		if response.Diagnostics.HasError() {
+			return
+		}
+		modified = true
+	}
+
+	// Tag-only updates are applied by the tagging interceptor without waiting; wait for available so the computed status stays consistent with the plan.
+	if !modified {
+		if _, err := waitServerlessCacheAvailable(ctx, conn, name, deadline.Remaining()); err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("waiting for ElastiCache Serverless Cache (%s) update", name), err.Error())
 			return
 		}
 	}

--- a/internal/service/elasticache/serverless_cache_test.go
+++ b/internal/service/elasticache/serverless_cache_test.go
@@ -992,6 +992,7 @@ func TestAccElastiCacheServerlessCache_disappears(t *testing.T) {
 	})
 }
 
+// Steps 2 and 3 are tag-only updates, guarding the status race where a tag-only apply could return a transient "modifying" status and fail with "inconsistent result after apply".
 func TestAccElastiCacheServerlessCache_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -1031,6 +1032,7 @@ func TestAccElastiCacheServerlessCache_tags(t *testing.T) {
 				Config: testAccServerlessCacheConfig_tags(rName, tags1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "available"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
@@ -1039,6 +1041,7 @@ func TestAccElastiCacheServerlessCache_tags(t *testing.T) {
 				Config: testAccServerlessCacheConfig_tags(rName, tags2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "available"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
@@ -1048,6 +1051,7 @@ func TestAccElastiCacheServerlessCache_tags(t *testing.T) {
 				Config: testAccServerlessCacheConfig_tags(rName, tags3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "available"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
A tag-only `terraform apply` on `aws_elasticache_serverless_cache` sometimes failed with:

```
Error: Provider produced inconsistent result after apply
... .status: was cty.StringVal("available"), but now cty.StringVal("modifying").
```

Tags are applied by the transparent tagging interceptor, which briefly puts the cache into `modifying` and returns without waiting. On a tag-only change the resource's update makes no other API calls, so it never waited for the cache to settle before reading final state and could capture the transient `modifying` status. Non-tag updates already wait for `available`, so they were never affected. The failure was intermittent, and re-running the apply succeeded.

Fix: when an update changes only tags, wait for the cache to return to `available` before the final read, matching what non-tag updates already do. No extra wait is added to the non-tag paths.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48930

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccElastiCacheServerlessCache PKG=elasticache ACCTEST_PARALLELISM=1 ACCTEST_TIMEOUT=4880m
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
xargs: gofmt: No such file or directory
make: Validating schemas
go: downloading github.com/aws/aws-sdk-go-v2 v1.43.7
go: downloading github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.38
go: downloading github.com/aws/aws-sdk-go-v2/config v1.32.38
go: downloading github.com/aws/aws-sdk-go-v2/service/sts v1.45.7
go: downloading github.com/aws/smithy-go v1.27.8
go: downloading github.com/aws/aws-sdk-go-v2/service/agentregistrycontrol v1.0.3
go: downloading github.com/aws/aws-sdk-go-v2/service/accountaccess v1.1.1
go: downloading github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.51.7
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.25.7
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.15.7
go: downloading github.com/aws/aws-sdk-go-v2/service/chatbot v1.17.7
go: downloading github.com/aws/aws-sdk-go-v2/service/cloud9 v1.37.2
go: downloading github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.33.7
go: downloading github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.30.2
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.35.7
go: downloading github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.24.7
go: downloading github.com/aws/aws-sdk-go-v2/service/amplify v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/billing v1.14.4
go: downloading github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.33.2
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.45.7
go: downloading github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.19.7
go: downloading github.com/aws/aws-sdk-go-v2/service/appintegrations v1.40.7
go: downloading github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.33.2
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.14.0
go: downloading github.com/aws/aws-sdk-go-v2/service/athena v1.60.7
go: downloading github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.34.7
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.38.7
go: downloading github.com/aws/aws-sdk-go-v2/service/account v1.35.7
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.32.7
go: downloading github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.51.2
go: downloading github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.57.8
go: downloading github.com/aws/aws-sdk-go-v2/service/appstream v1.64.8
go: downloading github.com/aws/aws-sdk-go-v2/service/budgets v1.46.7
go: downloading github.com/aws/aws-sdk-go-v2/service/connectcases v1.45.2
go: downloading github.com/aws/aws-sdk-go-v2/service/acm v1.44.2
go: downloading github.com/aws/aws-sdk-go-v2/service/acmpca v1.50.3
go: downloading github.com/aws/aws-sdk-go-v2/service/amp v1.48.4
go: downloading github.com/aws/aws-sdk-go-v2/service/apigateway v1.42.7
go: downloading github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/appconfig v1.48.7
go: downloading github.com/aws/aws-sdk-go-v2/service/appfabric v1.19.7
go: downloading github.com/aws/aws-sdk-go-v2/service/appflow v1.54.7
go: downloading github.com/aws/aws-sdk-go-v2/service/appmesh v1.39.2
go: downloading github.com/aws/aws-sdk-go-v2/service/apprunner v1.42.7
go: downloading github.com/aws/aws-sdk-go-v2/service/appsync v1.56.7
go: downloading github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.25.7
go: downloading github.com/aws/aws-sdk-go-v2/service/auditmanager v1.49.7
go: downloading github.com/aws/aws-sdk-go-v2/service/autoscaling v1.72.2
go: downloading github.com/aws/aws-sdk-go-v2/service/backup v1.60.4
go: downloading github.com/aws/aws-sdk-go-v2/service/batch v1.70.0
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.7
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.58.7
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.59.0
go: downloading github.com/aws/aws-sdk-go-v2/service/chime v1.45.2
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.4
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudfront v1.68.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.58.7
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.67.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.82.3
go: downloading github.com/aws/aws-sdk-go-v2/service/codeartifact v1.41.7
go: downloading github.com/aws/aws-sdk-go-v2/service/codebuild v1.72.7
go: downloading github.com/aws/aws-sdk-go-v2/service/codecommit v1.38.2
go: downloading github.com/aws/aws-sdk-go-v2/service/codeconnections v1.13.7
go: downloading github.com/aws/aws-sdk-go-v2/service/codedeploy v1.38.7
go: downloading github.com/aws/aws-sdk-go-v2/service/codepipeline v1.49.7
go: downloading github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.39.2
go: downloading github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.36.7
go: downloading github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.67.7
go: downloading github.com/aws/aws-sdk-go-v2/service/comprehend v1.43.7
go: downloading github.com/aws/aws-sdk-go-v2/service/configservice v1.68.7
go: downloading github.com/aws/aws-sdk-go-v2/service/costexplorer v1.67.7
go: downloading github.com/aws/aws-sdk-go-v2/service/connect v1.189.1
go: downloading github.com/aws/aws-sdk-go-v2/service/controltower v1.32.2
go: downloading github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.26.8
go: downloading github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.65.7
go: downloading github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.66.7
go: downloading github.com/aws/aws-sdk-go-v2/service/dataexchange v1.44.7
go: downloading github.com/aws/aws-sdk-go-v2/service/databrew v1.42.7
go: downloading github.com/aws/aws-sdk-go-v2/service/datapipeline v1.33.7
go: downloading github.com/aws/aws-sdk-go-v2/service/datasync v1.61.7
go: downloading github.com/aws/aws-sdk-go-v2/service/datazone v1.69.2
go: downloading github.com/aws/aws-sdk-go-v2/service/dax v1.33.2
go: downloading github.com/aws/aws-sdk-go-v2/service/detective v1.41.7
go: downloading github.com/aws/aws-sdk-go-v2/service/devicefarm v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/devopsagent v1.10.7
go: downloading github.com/aws/aws-sdk-go-v2/service/devopsguru v1.43.7
go: downloading github.com/aws/aws-sdk-go-v2/service/directconnect v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/directoryservice v1.41.7
go: downloading github.com/aws/aws-sdk-go-v2/service/directoryservicedata v1.10.7
go: downloading github.com/aws/aws-sdk-go-v2/service/dlm v1.40.2
go: downloading github.com/aws/aws-sdk-go-v2/service/docdb v1.51.7
go: downloading github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.23.7
go: downloading github.com/aws/aws-sdk-go-v2/service/drs v1.43.1
go: downloading github.com/aws/aws-sdk-go-v2/service/dsql v1.16.8
go: downloading github.com/aws/aws-sdk-go-v2/service/dynamodb v1.63.4
go: downloading github.com/aws/aws-sdk-go-v2/service/ec2 v1.322.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ecr v1.60.7
go: downloading github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.41.7
go: downloading github.com/aws/aws-sdk-go-v2/service/ecs v1.90.3
go: downloading github.com/aws/aws-sdk-go-v2/service/efs v1.44.7
go: downloading github.com/aws/aws-sdk-go-v2/service/eks v1.92.1
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticache v1.56.7
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.36.7
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.58.8
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.45.7
go: downloading github.com/aws/aws-sdk-go-v2/service/emr v1.64.7
go: downloading github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.45.7
go: downloading github.com/aws/aws-sdk-go-v2/service/emrserverless v1.44.7
go: downloading github.com/aws/aws-sdk-go-v2/service/eventbridge v1.48.7
go: downloading github.com/aws/aws-sdk-go-v2/service/evs v1.13.7
go: downloading github.com/aws/aws-sdk-go-v2/service/finspace v1.36.7
go: downloading github.com/aws/aws-sdk-go-v2/service/firehose v1.46.7
go: downloading github.com/aws/aws-sdk-go-v2/service/fis v1.40.7
go: downloading github.com/aws/aws-sdk-go-v2/service/fms v1.48.2
go: downloading github.com/aws/aws-sdk-go-v2/service/fsx v1.68.7
go: downloading github.com/aws/aws-sdk-go-v2/service/gamelift v1.61.3
go: downloading github.com/aws/aws-sdk-go-v2/service/glacier v1.35.7
go: downloading github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.38.7
go: downloading github.com/aws/aws-sdk-go-v2/service/glue v1.153.1
go: downloading github.com/aws/aws-sdk-go-v2/service/grafana v1.38.7
go: downloading github.com/aws/aws-sdk-go-v2/service/greengrass v1.35.7
go: downloading github.com/aws/aws-sdk-go-v2/service/groundstation v1.46.2
go: downloading golang.org/x/crypto v0.55.0
go: downloading github.com/aws/aws-sdk-go-v2/service/guardduty v1.85.7
go: downloading github.com/aws/aws-sdk-go-v2/service/healthlake v1.43.3
go: downloading github.com/aws/aws-sdk-go-v2/service/iam v1.59.2
go: downloading github.com/aws/aws-sdk-go-v2/service/identitystore v1.39.7
go: downloading github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.58.7
go: downloading github.com/aws/aws-sdk-go-v2/service/inspector v1.33.7
go: downloading github.com/aws/aws-sdk-go-v2/service/inspector2 v1.54.4
go: downloading github.com/aws/aws-sdk-go-v2/service/interconnect v1.4.6
go: downloading github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.29.7
go: downloading github.com/aws/aws-sdk-go-v2/service/invoicing v1.13.7
go: downloading github.com/aws/aws-sdk-go-v2/service/iot v1.77.7
go: downloading github.com/aws/aws-sdk-go-v2/service/ivs v1.55.7
go: downloading github.com/aws/aws-sdk-go-v2/service/ivschat v1.24.7
go: downloading github.com/aws/aws-sdk-go-v2/service/kafka v1.58.3
go: downloading github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.33.7
go: downloading github.com/aws/aws-sdk-go-v2/service/kendra v1.64.2
go: downloading github.com/aws/aws-sdk-go-v2/service/keyspaces v1.28.8
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesis v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.34.2
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.42.2
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.36.7
go: downloading github.com/aws/aws-sdk-go-v2/service/kms v1.55.7
go: downloading github.com/aws/aws-sdk-go-v2/service/lakeformation v1.50.7
go: downloading github.com/aws/aws-sdk-go-v2/service/lambda v1.102.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lambdacore v1.2.7
go: downloading github.com/aws/aws-sdk-go-v2/service/lambdamicrovms v1.2.7
go: downloading github.com/aws/aws-sdk-go-v2/service/launchwizard v1.17.7
go: downloading github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.38.7
go: downloading github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.64.7
go: downloading github.com/aws/aws-sdk-go-v2/service/licensemanager v1.41.7
go: downloading github.com/aws/aws-sdk-go-v2/service/lightsail v1.58.7
go: downloading github.com/aws/aws-sdk-go-v2/service/location v1.54.7
go: downloading github.com/aws/aws-sdk-go-v2/service/m2 v1.29.7
go: downloading github.com/aws/aws-sdk-go-v2/service/macie2 v1.54.7
go: downloading github.com/aws/aws-sdk-go-v2/service/mailmanager v1.21.7
go: downloading github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.54.2
go: downloading github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.97.4
go: downloading github.com/aws/aws-sdk-go-v2/service/medialive v1.104.1
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackage v1.42.7
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.44.3
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.42.7
go: downloading github.com/aws/aws-sdk-go-v2/service/mediastore v1.32.7
go: downloading github.com/aws/aws-sdk-go-v2/service/memorydb v1.37.2
go: downloading github.com/aws/aws-sdk-go-v2/service/mgn v1.49.2
go: downloading github.com/aws/aws-sdk-go-v2/service/mpa v1.10.7
go: downloading github.com/aws/aws-sdk-go-v2/service/mq v1.39.7
go: downloading github.com/aws/aws-sdk-go-v2/service/mwaa v1.43.7
go: downloading github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.4.1
go: downloading github.com/aws/aws-sdk-go-v2/service/neptune v1.48.7
go: downloading github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.24.7
go: downloading github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.67.4
go: downloading github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.14.7
go: downloading github.com/aws/aws-sdk-go-v2/service/networkmanager v1.44.7
go: downloading github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.16.7
go: downloading github.com/aws/aws-sdk-go-v2/service/notifications v1.11.2
go: downloading github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.9.2
go: downloading github.com/aws/aws-sdk-go-v2/service/oam v1.26.7
go: downloading github.com/aws/aws-sdk-go-v2/service/odb v1.16.2
go: downloading github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.23.1
go: downloading github.com/aws/aws-sdk-go-v2/service/opensearch v1.75.7
go: downloading github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.34.7
go: downloading github.com/aws/aws-sdk-go-v2/service/organizations v1.54.1
go: downloading github.com/aws/aws-sdk-go-v2/service/osis v1.24.7
go: downloading github.com/aws/aws-sdk-go-v2/service/outposts v1.67.1
go: downloading github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.33.7
go: downloading github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.18.7
go: downloading github.com/aws/aws-sdk-go-v2/service/pcs v1.24.7
go: downloading github.com/aws/aws-sdk-go-v2/service/pinpoint v1.42.7
go: downloading github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.33.2
go: downloading github.com/aws/aws-sdk-go-v2/service/pipes v1.26.7
go: downloading github.com/aws/aws-sdk-go-v2/service/polly v1.60.7
go: downloading github.com/aws/aws-sdk-go-v2/service/pricing v1.44.7
go: downloading github.com/aws/aws-sdk-go-v2/service/qbusiness v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/quicksight v1.124.2
go: downloading github.com/aws/aws-sdk-go-v2/service/ram v1.39.7
go: downloading github.com/aws/aws-sdk-go-v2/service/rbin v1.30.7
go: downloading github.com/aws/aws-sdk-go-v2/service/rds v1.124.4
go: downloading github.com/aws/aws-sdk-go-v2/service/rdsdata v1.35.7
go: downloading github.com/aws/aws-sdk-go-v2/service/redshift v1.66.1
go: downloading github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.43.7
go: downloading github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.39.1
go: downloading github.com/aws/aws-sdk-go-v2/service/rekognition v1.54.7
go: downloading github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.38.7
go: downloading github.com/aws/aws-sdk-go-v2/service/resiliencehubv2 v1.4.4
go: downloading github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.27.8
go: downloading github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.37.2
go: downloading github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.36.2
go: downloading github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.26.6
go: downloading github.com/aws/aws-sdk-go-v2/service/route53 v1.65.9
go: downloading github.com/aws/aws-sdk-go-v2/service/route53domains v1.39.2
go: downloading github.com/aws/aws-sdk-go-v2/service/route53profiles v1.12.7
go: downloading github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.35.7
go: downloading github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.29.7
go: downloading github.com/aws/aws-sdk-go-v2/service/route53resolver v1.48.7
go: downloading github.com/aws/aws-sdk-go-v2/service/rum v1.33.7
go: downloading github.com/aws/aws-sdk-go-v2/service/s3 v1.107.3
go: downloading github.com/aws/aws-sdk-go-v2/service/s3control v1.73.7
go: downloading github.com/aws/aws-sdk-go-v2/service/s3files v1.3.7
go: downloading github.com/aws/aws-sdk-go-v2/service/s3outposts v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/s3tables v1.18.7
go: downloading github.com/aws/aws-sdk-go-v2/service/s3vectors v1.10.7
go: downloading github.com/aws/aws-sdk-go-v2/service/sagemaker v1.268.0
go: downloading github.com/aws/aws-sdk-go-v2/service/savingsplans v1.35.7
go: downloading github.com/aws/aws-sdk-go-v2/service/scheduler v1.20.7
go: downloading github.com/aws/aws-sdk-go-v2/service/schemas v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.44.7
go: downloading github.com/aws/aws-sdk-go-v2/service/securityhub v1.76.3
go: downloading github.com/aws/aws-sdk-go-v2/service/securitylake v1.29.2
go: downloading github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.33.7
go: downloading github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.42.7
go: downloading github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.38.7
go: downloading github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.43.7
go: downloading github.com/aws/aws-sdk-go-v2/service/servicequotas v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/ses v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/sesv2 v1.67.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sfn v1.45.7
go: downloading github.com/aws/aws-sdk-go-v2/service/shield v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/signer v1.35.7
go: downloading github.com/aws/aws-sdk-go-v2/service/sns v1.42.7
go: downloading github.com/aws/aws-sdk-go-v2/service/sqs v1.46.7
go: downloading github.com/aws/aws-sdk-go-v2/service/ssm v1.73.7
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.34.7
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.42.7
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.12.2
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmsap v1.30.2
go: downloading github.com/aws/aws-sdk-go-v2/service/sso v1.33.7
go: downloading github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.43.4
go: downloading github.com/aws/aws-sdk-go-v2/service/storagegateway v1.46.7
go: downloading github.com/aws/aws-sdk-go-v2/service/swf v1.37.7
go: downloading github.com/aws/aws-sdk-go-v2/service/synthetics v1.47.7
go: downloading github.com/aws/aws-sdk-go-v2/service/taxsettings v1.21.2
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.23.4
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.39.7
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.38.7
go: downloading github.com/aws/aws-sdk-go-v2/service/transcribe v1.58.7
go: downloading github.com/aws/aws-sdk-go-v2/service/transfer v1.75.7
go: downloading github.com/aws/aws-sdk-go-v2/service/uxc v1.3.7
go: downloading github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.36.7
go: downloading github.com/aws/aws-sdk-go-v2/service/vpclattice v1.26.1
go: downloading github.com/aws/aws-sdk-go-v2/service/waf v1.33.7
go: downloading github.com/aws/aws-sdk-go-v2/service/wafregional v1.33.7
go: downloading github.com/aws/aws-sdk-go-v2/service/wafv2 v1.77.7
go: downloading github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.43.2
go: downloading github.com/aws/aws-sdk-go-v2/service/workmail v1.40.2
go: downloading github.com/aws/aws-sdk-go-v2/service/workspaces v1.74.1
go: downloading github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.42.7
go: downloading github.com/aws/aws-sdk-go-v2/service/xray v1.39.7
go: downloading github.com/aws/aws-sdk-go-v2/credentials v1.19.37
go: downloading github.com/beevik/etree v1.7.1
go: downloading golang.org/x/text v0.41.0
go: downloading github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.44
go: downloading github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.38
go: downloading github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.39
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.17
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.38
go: downloading github.com/aws/aws-sdk-go-v2/service/signin v1.5.7
go: downloading github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.7
go: downloading github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.15
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.39
go: downloading golang.org/x/net v0.58.0
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.31
go: downloading github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.38
go: downloading golang.org/x/mod v0.40.0
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	0.255s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	0.233s
make: Running acceptance tests on branch: 🌿 f-elasticache-serverless-tag-race 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/elasticache/... -v -count 1 -parallel 1 -run='TestAccElastiCacheServerlessCache'  -timeout 4880m -vet=off -buildvcs=false
2026/08/26 17:10:31 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/26 17:10:31 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheServerlessCacheDataSource_Redis_basic
=== PAUSE TestAccElastiCacheServerlessCacheDataSource_Redis_basic
=== RUN   TestAccElastiCacheServerlessCacheDataSource_Valkey_basic
=== PAUSE TestAccElastiCacheServerlessCacheDataSource_Valkey_basic
=== RUN   TestAccElastiCacheServerlessCache_basicRedis
=== PAUSE TestAccElastiCacheServerlessCache_basicRedis
=== RUN   TestAccElastiCacheServerlessCache_basicValkey
=== PAUSE TestAccElastiCacheServerlessCache_basicValkey
=== RUN   TestAccElastiCacheServerlessCache_full
=== PAUSE TestAccElastiCacheServerlessCache_full
=== RUN   TestAccElastiCacheServerlessCache_fullRedis
=== PAUSE TestAccElastiCacheServerlessCache_fullRedis
=== RUN   TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
=== PAUSE TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
=== RUN   TestAccElastiCacheServerlessCache_updateWithUserGroupRemoval
=== PAUSE TestAccElastiCacheServerlessCache_updateWithUserGroupRemoval
=== RUN   TestAccElastiCacheServerlessCache_fullValkey
=== PAUSE TestAccElastiCacheServerlessCache_fullValkey
=== RUN   TestAccElastiCacheServerlessCache_description
=== PAUSE TestAccElastiCacheServerlessCache_description
=== RUN   TestAccElastiCacheServerlessCache_cacheUsageLimits
=== PAUSE TestAccElastiCacheServerlessCache_cacheUsageLimits
=== RUN   TestAccElastiCacheServerlessCache_engine
=== PAUSE TestAccElastiCacheServerlessCache_engine
=== RUN   TestAccElastiCacheServerlessCache_networkType
=== PAUSE TestAccElastiCacheServerlessCache_networkType
=== RUN   TestAccElastiCacheServerlessCache_valkeyMajorEngineVersion
=== PAUSE TestAccElastiCacheServerlessCache_valkeyMajorEngineVersion
=== RUN   TestAccElastiCacheServerlessCache_modifyMultipleParameters_redis
=== PAUSE TestAccElastiCacheServerlessCache_modifyMultipleParameters_redis
=== RUN   TestAccElastiCacheServerlessCache_modifyMultipleParameters_valkey
=== PAUSE TestAccElastiCacheServerlessCache_modifyMultipleParameters_valkey
=== RUN   TestAccElastiCacheServerlessCache_modifyDescriptionAndSecurityGroups
=== PAUSE TestAccElastiCacheServerlessCache_modifyDescriptionAndSecurityGroups
=== RUN   TestAccElastiCacheServerlessCache_disappears
=== PAUSE TestAccElastiCacheServerlessCache_disappears
=== RUN   TestAccElastiCacheServerlessCache_tags
=== PAUSE TestAccElastiCacheServerlessCache_tags
=== CONT  TestAccElastiCacheServerlessCacheDataSource_Redis_basic
--- PASS: TestAccElastiCacheServerlessCacheDataSource_Redis_basic (309.56s)
=== CONT  TestAccElastiCacheServerlessCache_cacheUsageLimits
--- PASS: TestAccElastiCacheServerlessCache_cacheUsageLimits (745.19s)
=== CONT  TestAccElastiCacheServerlessCache_tags
--- PASS: TestAccElastiCacheServerlessCache_tags (394.54s)
=== CONT  TestAccElastiCacheServerlessCache_disappears
--- PASS: TestAccElastiCacheServerlessCache_disappears (322.04s)
=== CONT  TestAccElastiCacheServerlessCache_modifyDescriptionAndSecurityGroups
--- PASS: TestAccElastiCacheServerlessCache_modifyDescriptionAndSecurityGroups (409.44s)
=== CONT  TestAccElastiCacheServerlessCache_modifyMultipleParameters_valkey
--- PASS: TestAccElastiCacheServerlessCache_modifyMultipleParameters_valkey (710.57s)
=== CONT  TestAccElastiCacheServerlessCache_modifyMultipleParameters_redis
--- PASS: TestAccElastiCacheServerlessCache_modifyMultipleParameters_redis (731.86s)
=== CONT  TestAccElastiCacheServerlessCache_valkeyMajorEngineVersion
--- PASS: TestAccElastiCacheServerlessCache_valkeyMajorEngineVersion (1185.58s)
=== CONT  TestAccElastiCacheServerlessCache_networkType
--- PASS: TestAccElastiCacheServerlessCache_networkType (690.07s)
=== CONT  TestAccElastiCacheServerlessCache_engine
--- PASS: TestAccElastiCacheServerlessCache_engine (1566.44s)
=== CONT  TestAccElastiCacheServerlessCache_fullRedis
--- PASS: TestAccElastiCacheServerlessCache_fullRedis (341.90s)
=== CONT  TestAccElastiCacheServerlessCache_basicValkey
--- PASS: TestAccElastiCacheServerlessCache_basicValkey (323.40s)
=== CONT  TestAccElastiCacheServerlessCache_full
--- PASS: TestAccElastiCacheServerlessCache_full (331.04s)
=== CONT  TestAccElastiCacheServerlessCache_description
--- PASS: TestAccElastiCacheServerlessCache_description (367.90s)
=== CONT  TestAccElastiCacheServerlessCache_basicRedis
--- PASS: TestAccElastiCacheServerlessCache_basicRedis (323.84s)
=== CONT  TestAccElastiCacheServerlessCache_fullValkey
--- PASS: TestAccElastiCacheServerlessCache_fullValkey (321.42s)
=== CONT  TestAccElastiCacheServerlessCache_updateWithUserGroupRemoval
--- PASS: TestAccElastiCacheServerlessCache_updateWithUserGroupRemoval (1583.43s)
=== CONT  TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
--- PASS: TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup (507.61s)
=== CONT  TestAccElastiCacheServerlessCacheDataSource_Valkey_basic
--- PASS: TestAccElastiCacheServerlessCacheDataSource_Valkey_basic (308.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	11474.921s
```
### AI Usage Disclosure
This change was developed with the assistance of an LLM-based coding agent (Kiro). I have reviewed and understand all submitted code