### PR TITLE
🤖🤖🤖 Fix organization telemetry rule all-regions updates

### DIFF
--- a/.changelog/49743.txt
+++ b/.changelog/49743.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_observabilityadmin_telemetry_rule_for_organization: Fix updates when `all_regions` is enabled
+```

--- a/internal/service/observabilityadmin/telemetry_rule_for_organization.go
+++ b/internal/service/observabilityadmin/telemetry_rule_for_organization.go
@@ -249,6 +249,7 @@ func (r *telemetryRuleForOrganizationResource) Update(ctx context.Context, reque
 		if response.Diagnostics.HasError() {
 			return
 		}
+		normalizeTelemetryRuleRegionSelection(input.Rule)
 
 		// Additional fields.
 		input.RuleIdentifier = aws.String(ruleName)

--- a/internal/service/observabilityadmin/telemetry_rule_for_organization_flex_test.go
+++ b/internal/service/observabilityadmin/telemetry_rule_for_organization_flex_test.go
@@ -22,14 +22,14 @@ func TestNormalizeTelemetryRuleRegionSelection(t *testing.T) {
 		"all regions": {
 			rule: &awstypes.TelemetryRule{
 				AllRegions: aws.Bool(true),
-				Regions:    []string{"us-east-1", "us-west-2"},
+				Regions:    []string{"region-1", "region-2"},
 			},
 		},
 		"selected regions": {
 			rule: &awstypes.TelemetryRule{
-				Regions: []string{"us-east-1"},
+				Regions: []string{"region-1"},
 			},
-			wantRegions: []string{"us-east-1"},
+			wantRegions: []string{"region-1"},
 		},
 	}
 

--- a/internal/service/observabilityadmin/telemetry_rule_for_organization_flex_test.go
+++ b/internal/service/observabilityadmin/telemetry_rule_for_organization_flex_test.go
@@ -1,0 +1,50 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package observabilityadmin
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/observabilityadmin/types"
+)
+
+func TestNormalizeTelemetryRuleRegionSelection(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		rule        *awstypes.TelemetryRule
+		wantRegions []string
+	}{
+		"nil rule": {},
+		"all regions": {
+			rule: &awstypes.TelemetryRule{
+				AllRegions: aws.Bool(true),
+				Regions:    []string{"us-east-1", "us-west-2"},
+			},
+		},
+		"selected regions": {
+			rule: &awstypes.TelemetryRule{
+				Regions: []string{"us-east-1"},
+			},
+			wantRegions: []string{"us-east-1"},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			normalizeTelemetryRuleRegionSelection(testCase.rule)
+
+			if testCase.rule == nil {
+				return
+			}
+			if got, want := testCase.rule.Regions, testCase.wantRegions; !slices.Equal(got, want) {
+				t.Errorf("Regions = %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/internal/service/observabilityadmin/telemetry_rule_for_organization_test.go
+++ b/internal/service/observabilityadmin/telemetry_rule_for_organization_test.go
@@ -241,13 +241,21 @@ func testAccTelemetryRuleForOrganization_allRegions(t *testing.T) {
 		CheckDestroy:             testAccCheckTelemetryRuleForOrganizationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTelemetryRuleForOrganizationConfig_allRegions(rName),
+				Config: testAccTelemetryRuleForOrganizationConfig_allRegions(rName, 30),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTelemetryRuleForOrganizationExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.destination_configuration.0.retention_in_days", "30"),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("rule_arn"), tfknownvalue.RegionalARNExact("observabilityadmin", "organization-telemetry-rule/"+rName)),
 				},
+			},
+			{
+				Config: testAccTelemetryRuleForOrganizationConfig_allRegions(rName, 14),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTelemetryRuleForOrganizationExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "rule.0.destination_configuration.0.retention_in_days", "14"),
+				),
 			},
 			{
 				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "rule_name"),
@@ -386,21 +394,34 @@ resource "aws_observabilityadmin_telemetry_evaluation_for_organization" "test" {
 `, rName)
 }
 
-func testAccTelemetryRuleForOrganizationConfig_allRegions(rName string) string {
+func testAccTelemetryRuleForOrganizationConfig_allRegions(rName string, retentionInDays int) string {
 	return fmt.Sprintf(`
 resource "aws_observabilityadmin_telemetry_rule_for_organization" "test" {
   rule_name = %[1]q
 
   rule {
-    resource_type          = "AWS::EKS::Cluster"
-    telemetry_type         = "Logs"
-    telemetry_source_types = ["EKS_AUDIT_LOGS"]
-    all_regions            = true
+    resource_type  = "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    telemetry_type = "Logs"
+    all_regions    = true
+
+    destination_configuration {
+      destination_type    = "cloud-watch-logs"
+      destination_pattern = "/aws/alb"
+      retention_in_days   = %[2]d
+
+      elb_load_balancer_logging_parameters {
+        output_format = "json"
+      }
+
+      log_delivery_parameters {
+        log_types = ["ALB_ACCESS_LOGS", "ALB_CONNECTION_LOGS", "ALB_HEALTH_CHECK_LOGS"]
+      }
+    }
   }
 
   depends_on = [aws_observabilityadmin_telemetry_evaluation_for_organization.test]
 }
 
 resource "aws_observabilityadmin_telemetry_evaluation_for_organization" "test" {}
-`, rName)
+`, rName, retentionInDays)
 }

--- a/internal/service/observabilityadmin/telemetry_rule_regions.go
+++ b/internal/service/observabilityadmin/telemetry_rule_regions.go
@@ -1,0 +1,15 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package observabilityadmin
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/observabilityadmin/types"
+)
+
+func normalizeTelemetryRuleRegionSelection(rule *awstypes.TelemetryRule) {
+	if rule != nil && aws.ToBool(rule.AllRegions) {
+		rule.Regions = nil
+	}
+}


### PR DESCRIPTION
## Rollback Plan

Revert this pull request.

## Changes to Security Controls

None.

### Description

AWS returns the expanded region list when an organization telemetry rule uses `all_regions = true`. The provider retains that computed value in state, and AutoFlex subsequently expands both `allRegions` and `regions` into update requests. Observability Admin rejects those mutually exclusive parameters.

This change removes the computed `regions` value from the SDK update request when `allRegions` is true, while preserving the AWS-returned region list in Terraform state. It also adds offline unit coverage for request normalization and an acceptance-test update step that changes `retention_in_days` with `all_regions = true`.

AI assistance was used to trace the config/state-to-SDK request flow and draft the initial implementation and regression tests. I reviewed the resulting changes and validation output.

### Relations

Closes #49692

### References

None.

### Output from Acceptance Testing

Acceptance testing was not run because it requires an AWS Organizations management account and creates real AWS resources. Best-effort acceptance test coverage was added for maintainers or CI to execute.

Targeted offline unit test:

```console
% go test internal/service/observabilityadmin/telemetry_rule_regions.go internal/service/observabilityadmin/telemetry_rule_for_organization_flex_test.go -count=1
ok  command-line-arguments  0.231s
```
