### PR TITLE
provider: Fix web identity token configuration

### DIFF
--- a/.changelog/49671.txt
+++ b/.changelog/49671.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: Fix `assume_role_with_web_identity.web_identity_token` being rejected when `AWS_WEB_IDENTITY_TOKEN_FILE` is set
+```

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -1003,12 +1003,12 @@ func expandAssumeRole(_ context.Context, path cty.Path, tfMap map[string]any) (r
 const (
 	// Environment variable specifying a web identity token file.
 	//
-	// Any value read from this environment variable is superseded by any value in `assume_role_with_web_identity.web_identity_token_file`.
+	// Any value read from this environment variable is ignored when a web identity token or token file is configured.
 	awsWebIdentityTokenFileEnvVar = "AWS_WEB_IDENTITY_TOKEN_FILE" // nosemgrep:ci.aws-in-const-name,ci.aws-in-var-name
 
 	// Environment variable specifying a web identity token.
 	//
-	// Any value read from this environment variable is superseded by any value in `assume_role_with_web_identity.web_identity_token`.
+	// Any value read from this environment variable is ignored when a web identity token or token file is configured.
 	tfWebIdentityTokenEnvVar = "TF_AWS_WEB_IDENTITY_TOKEN"
 )
 
@@ -1040,16 +1040,25 @@ func expandAssumeRoleWithWebIdentity(_ context.Context, tfMap map[string]any) (*
 		assumeRole.SessionName = v
 	}
 
-	assumeRole.WebIdentityToken = os.Getenv(tfWebIdentityTokenEnvVar)
-	if v, ok := tfMap["web_identity_token"].(string); ok && v != "" {
-		assumeRole.WebIdentityToken = v
+	configuredToken, _ := tfMap["web_identity_token"].(string)
+	configuredTokenFile, _ := tfMap["web_identity_token_file"].(string)
+
+	if configuredToken != "" && configuredTokenFile != "" {
+		return nil, errors.New("Exactly one of web_identity_token or web_identity_token_file is required")
 	}
 
-	// We need to read any environment variable value here:
-	// https://github.com/hashicorp/aws-sdk-go-base/blob/71dcf8ad2f4d8c9f02407d73a8dc666f79bfb555/credentials.go#L81-L82
-	assumeRole.WebIdentityTokenFile = os.Getenv(awsWebIdentityTokenFileEnvVar)
-	if v, ok := tfMap["web_identity_token_file"].(string); ok && v != "" {
-		assumeRole.WebIdentityTokenFile = v
+	// Provider configuration takes precedence over ambient environment variables across both token sources.
+	switch {
+	case configuredToken != "":
+		assumeRole.WebIdentityToken = configuredToken
+	case configuredTokenFile != "":
+		assumeRole.WebIdentityTokenFile = configuredTokenFile
+	default:
+		assumeRole.WebIdentityToken = os.Getenv(tfWebIdentityTokenEnvVar)
+
+		// We need to read any environment variable value here:
+		// https://github.com/hashicorp/aws-sdk-go-base/blob/71dcf8ad2f4d8c9f02407d73a8dc666f79bfb555/credentials.go#L81-L82
+		assumeRole.WebIdentityTokenFile = os.Getenv(awsWebIdentityTokenFileEnvVar)
 	}
 
 	if (assumeRole.WebIdentityToken != "") == (assumeRole.WebIdentityTokenFile != "") {

--- a/internal/provider/sdkv2/provider_test.go
+++ b/internal/provider/sdkv2/provider_test.go
@@ -569,7 +569,7 @@ func TestExpandAssumeRoleWithWebIdentity(t *testing.T) { //nolint:paralleltest
 			envvars:   map[string]string{},
 			expectErr: true,
 		},
-		"token envvar token_file config": {
+		"token_file config supersedes token envvar": {
 			tfMap: map[string]any{
 				"duration":                "1h",
 				"policy":                  "my-policy",
@@ -579,9 +579,14 @@ func TestExpandAssumeRoleWithWebIdentity(t *testing.T) { //nolint:paralleltest
 			envvars: map[string]string{
 				tfWebIdentityTokenEnvVar: "my-token",
 			},
-			expectErr: true,
+			expectedConfig: &awsbase.AssumeRoleWithWebIdentity{
+				Duration:             1 * time.Hour,
+				Policy:               "my-policy",
+				SessionName:          "my-session",
+				WebIdentityTokenFile: "my-token-file",
+			},
 		},
-		"token config token_file envvar": {
+		"token config supersedes token_file envvar": {
 			tfMap: map[string]any{
 				"duration":           "1h",
 				"policy":             "my-policy",
@@ -591,7 +596,12 @@ func TestExpandAssumeRoleWithWebIdentity(t *testing.T) { //nolint:paralleltest
 			envvars: map[string]string{
 				awsWebIdentityTokenFileEnvVar: "my-token-file",
 			},
-			expectErr: true,
+			expectedConfig: &awsbase.AssumeRoleWithWebIdentity{
+				Duration:         1 * time.Hour,
+				Policy:           "my-policy",
+				SessionName:      "my-session",
+				WebIdentityToken: "my-token",
+			},
 		},
 		"token envvar token_file envvar": {
 			tfMap: map[string]any{

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -299,6 +299,8 @@ See the assume role documentation [section on web identities](https://docs.aws.a
 |Policy ARNs|`policy_arns`|N/A|`policy_arns`|
 |Session Name|`session_name`|`AWS_ROLE_SESSION_NAME`|`role_session_name`|
 
+Values configured in the `assume_role_with_web_identity` block take precedence over environment variables for both token sources.
+
 ## Custom User-Agent Information
 
 By default, the underlying AWS client used by the Terraform AWS Provider creates requests with User-Agent headers including information about Terraform and AWS SDK for Go versions.


### PR DESCRIPTION

### Description

Fixes the regression introduced in v6.56.0 where configuring `assume_role_with_web_identity.web_identity_token` was rejected when `AWS_WEB_IDENTITY_TOKEN_FILE` was also present in the environment.

Provider configuration now takes precedence across both web-identity token sources. Configured `web_identity_token` and `web_identity_token_file` remain mutually exclusive, and environment-only combinations retain their existing validation.

### Relations

Closes #49671

### References

- #48736 introduced the web-identity token environment-variable support.
- The provider-side precedence now matches the underlying AWS SDK configuration behavior.

### Output from Acceptance Testing

Acceptance tests were not run because this is a provider configuration change that does not create AWS resources.

Unit and static validation:

```console
$ go test ./internal/provider/sdkv2 -run "^TestExpandAssumeRoleWithWebIdentity$" -count=1
ok
$ go test ./internal/provider/sdkv2 -run "^TestProviderConfig_AssumeRole$" -count=1
ok
$ go test ./internal/provider/... -count=1
ok
$ make fmt-check
$ make semgrep-fix-core
0 findings
```