### PR TITLE
storagegateway: allow zero cache stale timeout

### DIFF
--- a/.changelog/49745.txt
+++ b/.changelog/49745.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_storagegateway_smb_file_share: Allow `cache_stale_timeout_in_seconds` to be set to 0
+```

--- a/internal/service/storagegateway/smb_file_share.go
+++ b/internal/service/storagegateway/smb_file_share.go
@@ -89,9 +89,12 @@ func resourceSMBFileShare() *schema.Resource {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"cache_stale_timeout_in_seconds": {
-								Type:         schema.TypeInt,
-								Optional:     true,
-								ValidateFunc: validation.IntBetween(300, 2592000),
+								Type:     schema.TypeInt,
+								Optional: true,
+								ValidateFunc: validation.Any(
+									validation.IntInSlice([]int{0}),
+									validation.IntBetween(300, 2592000),
+								),
 							},
 						},
 					},

--- a/internal/service/storagegateway/smb_file_share_test.go
+++ b/internal/service/storagegateway/smb_file_share_test.go
@@ -831,6 +831,14 @@ func TestAccStorageGatewaySMBFileShare_cacheAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "300"),
 				),
 			},
+			{
+				Config: testAccSMBFileShareConfig_cacheAttributes(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSMBFileShareExists(ctx, t, resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "0"),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -77,7 +77,7 @@ The `cache_attributes` configuration block supports the following arguments:
 
 * `cache_stale_timeout_in_seconds` - (Optional) Refreshes a file share's cache by using Time To Live (TTL).
  TTL is the length of time since the last refresh after which access to the directory would cause the file gateway
-  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: 300 to 2,592,000 seconds (5 minutes to 30 days)
+  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: 0 or 300 to 2,592,000 seconds (5 minutes to 30 days)
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

### Description

Allow `cache_stale_timeout_in_seconds` to be set to `0` for
`aws_storagegateway_smb_file_share`.

AWS Storage Gateway accepts `0` to disable cache refresh, but the
Terraform provider currently only allows values from 300 to 2,592,000.

This change:
- Allows `0` in the resource validation.
- Adds acceptance test coverage for `0`.
- Updates the resource documentation.

### Relations

Closes #48876

### References

### Output from Acceptance Testing

Acceptance tests were not run locally because an AWS account and
acceptance-test environment are not available.

Local validation:

```console
$ go test ./internal/service/storagegateway -run '^$'
ok      github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway     3.064s [no tests to run]