### PR TITLE
r/bedrockagentcore_oauth2_credential_provider: Add client_authentication_method attribute

### DIFF
--- a/.changelog/49732.txt
+++ b/.changelog/49732.txt
@@ -1,0 +1,1 @@
+enhancement: `aws_bedrockagentcore_oauth2_credential_provider` - Add `client_authentication_method` attribute

--- a/internal/service/bedrockagentcore/oauth2_credential_provider.go
+++ b/internal/service/bedrockagentcore/oauth2_credential_provider.go
@@ -60,6 +60,9 @@ type oauth2CredentialProviderResource struct {
 
 func oauth2ClientCredentialsAttributes(context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
+		"client_authentication_method": schema.StringAttribute{
+			Optional: true,
+		},
 		"client_credentials_wo_version": schema.Int64Attribute{
 			Optional: true,
 			Validators: []validator.Int64{
@@ -734,6 +737,7 @@ func (m *oauth2ProviderConfigModel) clientCredentials(ctx context.Context) (oaut
 }
 
 type oauth2ClientCredentialsModel struct {
+	ClientAuthenticationMethod types.String `tfsdk:"client_authentication_method"`
 	ClientCredentialsWOVersion types.Int64  `tfsdk:"client_credentials_wo_version"`
 	ClientID                   types.String `tfsdk:"client_id"`
 	ClientIDWO                 types.String `tfsdk:"client_id_wo"`

--- a/internal/service/bedrockagentcore/oauth2_credential_provider_test.go
+++ b/internal/service/bedrockagentcore/oauth2_credential_provider_test.go
@@ -222,6 +222,7 @@ func TestAccBedrockAgentCoreOAuth2CredentialProvider_full(t *testing.T) {
 				Config: testAccOAuth2CredentialProviderConfig_full(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckOAuth2CredentialProviderExists(ctx, t, resourceName, &oauth2credentialprovider),
+					resource.TestCheckResourceAttr(resourceName, "oauth2_provider_config.0.custom_oauth2_provider_config.0.client_authentication_method", "CLIENT_SECRET_BASIC"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -237,6 +238,7 @@ func TestAccBedrockAgentCoreOAuth2CredentialProvider_full(t *testing.T) {
 				ImportStateVerifyIdentifierAttribute: names.AttrName,
 				ImportStateVerifyIgnore: []string{
 					"oauth2_provider_config.0.custom_oauth2_provider_config.0.client_credentials_wo_version",
+					"oauth2_provider_config.0.custom_oauth2_provider_config.0.client_authentication_method",
 				},
 			},
 		},
@@ -377,6 +379,7 @@ resource "aws_bedrockagentcore_oauth2_credential_provider" "test" {
       client_id_wo                  = "full-test-client-id"
       client_secret_wo              = "full-test-client-secret"
       client_credentials_wo_version = 1
+	  client_authentication_method  = "CLIENT_SECRET_BASIC"
 
       oauth_discovery {
         authorization_server_metadata {

--- a/website/docs/r/bedrockagentcore_oauth2_credential_provider.html.markdown
+++ b/website/docs/r/bedrockagentcore_oauth2_credential_provider.html.markdown
@@ -42,6 +42,7 @@ resource "aws_bedrockagentcore_oauth2_credential_provider" "auth0" {
       client_id_wo                  = "auth0-client-id"
       client_secret_wo              = "auth0-client-secret"
       client_credentials_wo_version = 1
+      client_authentication_method  = "CLIENT_SECRET_BASIC"
 
       oauth_discovery {
         discovery_url = "https://dev-company.auth0.com/.well-known/openid-configuration"
@@ -115,6 +116,7 @@ The `custom_oauth2_provider_config` block supports the following:
 * `client_id_wo` - (Optional) Write-only OAuth2 client ID. Cannot be used with `client_id`. Must be used together with `client_secret_wo` and `client_credentials_wo_version`.
 * `client_secret_wo` - (Optional) Write-only OAuth2 client secret. Cannot be used with `client_secret`. Must be used together with `client_id_wo` and `client_credentials_wo_version`.
 * `client_credentials_wo_version` - (Optional) Used together with write-only credentials to trigger an update. Increment this value when an update to `client_id_wo` or `client_secret_wo` is required.
+* `client_authentication_method` - (Optional) The authentication method for the client. Valid values are `AWS_IAM_ID_TOKEN_JWT`, `PRIVATE_KEY_JWT`, `CLIENT_SECRET_BASIC`, and `CLIENT_SECRET_POST`.
 
 **OAuth Discovery Configuration:**
 
@@ -134,6 +136,7 @@ These predefined provider blocks support the following:
 * `client_id_wo` - (Optional) Write-only OAuth2 client ID. Cannot be used with `client_id`. Must be used together with `client_secret_wo` and `client_credentials_wo_version`.
 * `client_secret_wo` - (Optional) Write-only OAuth2 client secret. Cannot be used with `client_secret`. Must be used together with `client_id_wo` and `client_credentials_wo_version`.
 * `client_credentials_wo_version` - (Optional) Used together with write-only credentials to trigger an update. Increment this value when an update to `client_id_wo` or `client_secret_wo` is required.
+* `client_authentication_method` - (Optional) The authentication method for the client. Valid values are `AWS_IAM_ID_TOKEN_JWT`, `PRIVATE_KEY_JWT`, `CLIENT_SECRET_BASIC`, and `CLIENT_SECRET_POST`.
 
 **Note:** These predefined providers automatically configure OAuth discovery settings based on their respective authorization servers.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to the provider's internal security controls. This PR exposes the `client_authentication_method` parameter, which is natively supported and enforced by the AWS Bedrock AgentCore API for OAuth2 authentication.

### Description

This PR adds the `client_authentication_method` attribute to the `aws_bedrockagentcore_oauth2_credential_provider` resource. 

The AWS API strictly validates this input (requiring values like `CLIENT_SECRET_BASIC`, `CLIENT_SECRET_POST`, etc.) when creating a provider. This attribute has been added to the shared `oauth2ClientCredentialsModel` to support both custom and predefined OAuth2 provider configurations. State import verification has been updated to ignore this field, aligning with how the API handles credential retrieval.

### Relations

Closes #49732

### References

* [AWS Bedrock AgentCore CreateOauth2CredentialProvider API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_CreateOauth2CredentialProvider.html)

### Output from Acceptance Testing

```console
% TF_ACC=1 go test ./internal/service/bedrockagentcore -v -run=TestAccBedrockAgentCoreOAuth2CredentialProvider_full

2026/08/30 17:16:46 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/30 17:16:46 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentCoreOAuth2CredentialProvider_full
=== PAUSE TestAccBedrockAgentCoreOAuth2CredentialProvider_full
=== CONT  TestAccBedrockAgentCoreOAuth2CredentialProvider_full
--- PASS: TestAccBedrockAgentCoreOAuth2CredentialProvider_full (28.07s)
PASS
ok      [github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore](https://github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagentcore)   35.160s