### PR TITLE
r/aws_bedrockagentcore_harness: add ECR pull permissions to acceptance test execution role

### DIFF
--- a/internal/service/bedrockagentcore/harness_test.go
+++ b/internal/service/bedrockagentcore/harness_test.go
@@ -2654,7 +2654,10 @@ resource "aws_iam_role_policy" "test" {
     "Effect": "Allow",
     "Action": [
       "bedrock:InvokeModel",
-      "bedrock:InvokeModelWithResponseStream"
+      "bedrock:InvokeModelWithResponseStream",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer"
     ],
     "Resource": "*"
   }


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Yes — but scoped to test infrastructure only. This adds Amazon ECR read/pull
permissions (`ecr:GetAuthorizationToken`, `ecr:BatchGetImage`,
`ecr:GetDownloadUrlForLayer`) to the IAM execution role created **within the
`aws_bedrockagentcore_harness` acceptance tests** (`testAccHarnessConfig_iamRole`).
These are the standard read-only image-pull actions AWS documents for a harness
that uses a private ECR container image (see References). No provider/runtime
code, resource behavior, or production security control is changed.

### Description

The acceptance test execution role for `aws_bedrockagentcore_harness`
(`testAccHarnessConfig_iamRole`) grants only `bedrock:InvokeModel` and
`bedrock:InvokeModelWithResponseStream`.

However, several harness acceptance tests configure the harness with a **custom
private-ECR container image** — `testAccHarnessConfig_environmentArtifact` sets
`environment_artifact { agentcore_runtime_environment { container_uri =
data.aws_ecr_image.test.image_uri } }` — and compose `testAccHarnessConfig_iamRole`
as the `execution_role_arn`. Per the AgentCore documentation, a harness that uses
a private ECR image requires ECR pull permissions on its execution role
(`ecr:GetAuthorizationToken`, `ecr:BatchGetImage`, `ecr:GetDownloadUrlForLayer`).
Because the test role omits them, `CreateHarness` can fail image validation with:

```
The execution role requires permissions for ecr:GetAuthorizationToken,
ecr:BatchGetImage, and ecr:GetDownloadUrlForLayer operations.
```

This adds those three ECR actions to the harness test execution role. It matches
`testAccAgentRuntimeConfig_baseIAMRole` for `aws_bedrockagentcore_agent_runtime`,
which already grants the same three actions (`resources = ["*"]`, since
`ecr:GetAuthorizationToken` does not support resource-level scoping).

Test-only change; no CHANGELOG entry required.

### Relations

n/a — no linked issue.

### References

- AgentCore harness execution role policy — *Private ECR access (custom container images)*:
  https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-security.html#harness-custom-container-ecr
  documents the required execution-role actions `ecr:GetDownloadUrlForLayer`,
  `ecr:BatchGetImage`, and `ecr:GetAuthorizationToken` for a harness using a
  private ECR image.
- Same page, *VPC mode: managed image pull from private ECR*:
  https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-security.html#harness-vpc-managed-ecr
- Harness custom environments / ECR:
  https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-environment.html

### Output from Acceptance Testing

Not run in this environment; the harness acceptance tests require an account
with a valid container image. Requesting a maintainer/AWS acceptance-test run.

```console
% make testacc TESTS=TestAccBedrockAgentCoreHarness_ PKG=bedrockagentcore

...
```
