### PR TITLE
resource/aws_savingsplans_savings_plan: Fix `Provider returned invalid result object after apply` for `purchase_time`

### DIFF
--- a/.changelog/49752.txt
+++ b/.changelog/49752.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_savingsplans_savings_plan: Fix `Provider returned invalid result object after apply` error for `purchase_time` when it's omitted from the configuration
+```

--- a/internal/service/savingsplans/savings_plan.go
+++ b/internal/service/savingsplans/savings_plan.go
@@ -241,6 +241,18 @@ func (r *savingsPlanResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// DescribeSavingsPlans (the source of savingsPlan above) never returns a
+	// purchase time: it's a write-only input on CreateSavingsPlan, not an
+	// attribute of the Savings Plan itself. When the practitioner doesn't set
+	// purchase_time in their configuration (the common case: an immediate,
+	// rather than future-dated, purchase), Flatten has no source value to
+	// populate it with, so it's left unknown. Resolve it to null instead so
+	// Create doesn't violate the framework's "all Computed values must be
+	// known after apply" invariant.
+	if plan.PurchaseTime.IsUnknown() {
+		plan.PurchaseTime = timetypes.NewRFC3339Null()
+	}
+
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
 }
 


### PR DESCRIPTION
### Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

### Changes to Security Controls

None.

### Description

Closes #49753.

`DescribeSavingsPlans`'s `SavingsPlan` type has no `PurchaseTime` field — it only exists as a write-only argument on `CreateSavingsPlanInput` (for scheduling a future-dated purchase). So whenever a practitioner leaves `purchase_time` unset (an immediate purchase, the common case), `Create`'s `Flatten` step has nothing to resolve it from and it's left `Unknown`, which fails with `Provider returned invalid result object after apply` — after the real purchase has already gone through.

This resolves `purchase_time` to `null` when it's still unknown after `Flatten`, matching what AWS actually reports back (nothing). Configured (future-dated) `purchase_time` values are already known going into `Create` and are unaffected.

See the linked issue for the full repro, logs, and how this was found.

### Output from Acceptance Testing

This resource's only acceptance test is `t.Skip`'d (real, non-cancellable financial commitments). Verified via `go build` / `go vet` / `gofmt`, and by confirming the SDK types directly (`go doc`) that `PurchaseTime` has no read-back path.
