### PR TITLE
fix: allow 0 for storagegateway_smb_file_share cache_stale_timeout_in_seconds

### DIFF
--- a/.changelog/49754.txt
+++ b/.changelog/49754.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_storagegateway_smb_file_share: Allow `cache_attributes.cache_stale_timeout_in_seconds` to be set to `0` to disable the cache refresh
+```

--- a/internal/service/storagegateway/exports_test.go
+++ b/internal/service/storagegateway/exports_test.go
@@ -31,4 +31,6 @@ var (
 	ParseVolumeGatewayARNAndTargetNameFromARN = parseVolumeGatewayARNAndTargetNameFromARN
 	UploadBufferParseResourceID               = uploadBufferParseResourceID
 	WorkingStorageParseResourceID             = workingStorageParseResourceID
+
+	ExpandCacheAttributes = expandCacheAttributes
 )

--- a/internal/service/storagegateway/smb_file_share.go
+++ b/internal/service/storagegateway/smb_file_share.go
@@ -14,11 +14,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/storagegateway"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/storagegateway/types"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfcty "github.com/hashicorp/terraform-provider-aws/internal/cty"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -89,9 +91,12 @@ func resourceSMBFileShare() *schema.Resource {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"cache_stale_timeout_in_seconds": {
-								Type:         schema.TypeInt,
-								Optional:     true,
-								ValidateFunc: validation.IntBetween(300, 2592000),
+								Type:     schema.TypeInt,
+								Optional: true,
+								ValidateFunc: validation.Any(
+									validation.IntInSlice([]int{0}),
+									validation.IntBetween(300, 2592000),
+								),
 							},
 						},
 					},
@@ -248,7 +253,7 @@ func resourceSMBFileShareCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if v, ok := d.GetOk("cache_attributes"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-		input.CacheAttributes = expandCacheAttributes(v.([]any)[0].(map[string]any))
+		input.CacheAttributes = expandCacheAttributes(v.([]any)[0].(map[string]any), cacheStaleTimeoutInSecondsConfigured(d))
 	}
 
 	if v, ok := d.GetOk("case_sensitivity"); ok {
@@ -386,7 +391,7 @@ func resourceSMBFileShareUpdate(ctx context.Context, d *schema.ResourceData, met
 
 		if d.HasChange("cache_attributes") {
 			if v, ok := d.GetOk("cache_attributes"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-				input.CacheAttributes = expandCacheAttributes(v.([]any)[0].(map[string]any))
+				input.CacheAttributes = expandCacheAttributes(v.([]any)[0].(map[string]any), cacheStaleTimeoutInSecondsConfigured(d))
 			} else {
 				input.CacheAttributes = &awstypes.CacheAttributes{}
 			}
@@ -578,18 +583,34 @@ func waitSMBFileShareDeleted(ctx context.Context, conn *storagegateway.Client, a
 	return nil, err
 }
 
-func expandCacheAttributes(tfMap map[string]any) *awstypes.CacheAttributes {
+func expandCacheAttributes(tfMap map[string]any, cacheStaleTimeoutInSecondsConfigured bool) *awstypes.CacheAttributes {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.CacheAttributes{}
 
-	if v, ok := tfMap["cache_stale_timeout_in_seconds"].(int); ok && v != 0 {
+	// 0 is a valid API value (disables the cache refresh), distinct from the
+	// attribute being omitted from the configuration entirely, so it can't be
+	// filtered out using the zero value alone.
+	if v, ok := tfMap["cache_stale_timeout_in_seconds"].(int); ok && (v != 0 || cacheStaleTimeoutInSecondsConfigured) {
 		apiObject.CacheStaleTimeoutInSeconds = aws.Int32(int32(v))
 	}
 
 	return apiObject
+}
+
+// cacheStaleTimeoutInSecondsConfigured reports whether cache_stale_timeout_in_seconds
+// is present in the configuration, so that an explicit 0 can be distinguished from
+// the attribute being left unset.
+func cacheStaleTimeoutInSecondsConfigured(d *schema.ResourceData) bool {
+	path := cty.GetAttrPath("cache_attributes").IndexInt(0).GetAttr("cache_stale_timeout_in_seconds")
+	v, ok, err := tfcty.PathSafeApply(path, d.GetRawConfig())
+	if err != nil || !ok {
+		return false
+	}
+
+	return !v.IsNull()
 }
 
 func flattenCacheAttributes(apiObject *awstypes.CacheAttributes) map[string]any {

--- a/internal/service/storagegateway/smb_file_share_test.go
+++ b/internal/service/storagegateway/smb_file_share_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/storagegateway/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -18,6 +19,51 @@ import (
 	tfstoragegateway "github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+func TestExpandCacheAttributes(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		tfMap                                map[string]any
+		cacheStaleTimeoutInSecondsConfigured bool
+		wantCacheStaleTimeoutInSeconds       *int32
+	}{
+		"explicit zero configured": {
+			tfMap:                                map[string]any{"cache_stale_timeout_in_seconds": 0},
+			cacheStaleTimeoutInSecondsConfigured: true,
+			wantCacheStaleTimeoutInSeconds:       aws.Int32(0),
+		},
+		"zero value not configured": {
+			tfMap:                                map[string]any{"cache_stale_timeout_in_seconds": 0},
+			cacheStaleTimeoutInSecondsConfigured: false,
+			wantCacheStaleTimeoutInSeconds:       nil,
+		},
+		"non-zero value": {
+			tfMap:                                map[string]any{"cache_stale_timeout_in_seconds": 300},
+			cacheStaleTimeoutInSecondsConfigured: false,
+			wantCacheStaleTimeoutInSeconds:       aws.Int32(300),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfstoragegateway.ExpandCacheAttributes(tc.tfMap, tc.cacheStaleTimeoutInSecondsConfigured)
+
+			switch {
+			case tc.wantCacheStaleTimeoutInSeconds == nil:
+				if got.CacheStaleTimeoutInSeconds != nil {
+					t.Errorf("CacheStaleTimeoutInSeconds = %d, want nil", aws.ToInt32(got.CacheStaleTimeoutInSeconds))
+				}
+			case got.CacheStaleTimeoutInSeconds == nil:
+				t.Errorf("CacheStaleTimeoutInSeconds = nil, want %d", aws.ToInt32(tc.wantCacheStaleTimeoutInSeconds))
+			case aws.ToInt32(got.CacheStaleTimeoutInSeconds) != aws.ToInt32(tc.wantCacheStaleTimeoutInSeconds):
+				t.Errorf("CacheStaleTimeoutInSeconds = %d, want %d", aws.ToInt32(got.CacheStaleTimeoutInSeconds), aws.ToInt32(tc.wantCacheStaleTimeoutInSeconds))
+			}
+		})
+	}
+}
 
 func TestAccStorageGatewaySMBFileShare_Authentication_activeDirectory(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -830,6 +876,21 @@ func TestAccStorageGatewaySMBFileShare_cacheAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "300"),
 				),
+			},
+			{
+				// 0 disables the cache refresh and is a valid API value distinct from
+				// the attribute being unset; it must not be dropped on apply, and
+				// re-applying the same configuration must not produce a diff.
+				Config: testAccSMBFileShareConfig_cacheAttributes(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSMBFileShareExists(ctx, t, resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "0"),
+				),
+			},
+			{
+				Config:   testAccSMBFileShareConfig_cacheAttributes(rName, 0),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -77,7 +77,7 @@ The `cache_attributes` configuration block supports the following arguments:
 
 * `cache_stale_timeout_in_seconds` - (Optional) Refreshes a file share's cache by using Time To Live (TTL).
  TTL is the length of time since the last refresh after which access to the directory would cause the file gateway
-  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: 300 to 2,592,000 seconds (5 minutes to 30 days)
+  to first refresh that directory's contents from the Amazon S3 bucket. Valid values: `0` (disables the cache refresh) or 300 to 2,592,000 seconds (5 minutes to 30 days)
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This widens a client-side input validator and fixes an expand function so an already-valid API value (`0`) is no longer dropped before the request is sent.

### Description

The AWS Storage Gateway API documents `CacheAttributes.CacheStaleTimeoutInSeconds` as accepting `0` (disables the cache refresh) or `300`-`2,592,000`, but the provider only allowed the latter range, and separately, the expand logic filtered out an explicit `0` using a bare Go zero-value check before it ever reached the API request. Together this made it impossible to disable cache refresh through Terraform, and left shares that had `0` set out-of-band (console/CLI) in a permanent, non-convergent diff, since the provider could never write the value back.

Changes in `internal/service/storagegateway/smb_file_share.go`:
- Widen `cache_stale_timeout_in_seconds`'s `ValidateFunc` to accept `0` in addition to the existing `300`-`2,592,000` range.
- Use `d.GetRawConfig()` (via the existing `internal/cty` helpers already used elsewhere in the provider) to tell an explicit `0` apart from the attribute being left unset, since both read back as the same Go zero value through the schema. `expandCacheAttributes` now only omits the field when it's genuinely unconfigured.

Also updated the resource documentation to note `0` is a valid value.

### Relations

Closes #48876

### References

- https://docs.aws.amazon.com/storagegateway/latest/APIReference/API_CacheAttributes.html documents `0` as a valid `CacheStaleTimeoutInSeconds` value.

### Output from Acceptance Testing

I don't have AWS credentials to run acceptance tests locally. I extended `TestAccStorageGatewaySMBFileShare_cacheAttributes` with a step that sets `cache_stale_timeout_in_seconds = 0` and a follow-up `PlanOnly` step to assert no drift, and added a unit test (`TestExpandCacheAttributes`) covering the fixed expand logic directly. Locally verified: `go build`, `go vet`, `gofmt`, and `golangci-lint run` all clean for `internal/service/storagegateway`, and the new unit test passes:

```console
$ go test ./internal/service/storagegateway/... -run '^TestExpandCacheAttributes$' -v
=== RUN   TestExpandCacheAttributes
--- PASS: TestExpandCacheAttributes (0.00s)
    --- PASS: TestExpandCacheAttributes/explicit_zero_configured (0.00s)
    --- PASS: TestExpandCacheAttributes/non-zero_value (0.00s)
    --- PASS: TestExpandCacheAttributes/zero_value_not_configured (0.00s)
PASS
```

---

**AI disclosure:** Per `docs/ai-usage.md`, I used an AI coding agent (Claude, via Claude Code) to find this open, unassigned issue, implement the fix, write the tests above, and run the local verification shown. I am submitting it under my own account and am responsible for the change.
