### PR TITLE
fix: accept substitution templates for iot_topic_rule cloudwatch_metric metric_timestamp

### DIFF
--- a/.changelog/49755.txt
+++ b/.changelog/49755.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iot_topic_rule: Allow `cloudwatch_metric.metric_timestamp` and `error_action.cloudwatch_metric.metric_timestamp` to accept an IoT SQL substitution template (e.g. `${timestamp()}`)
+```

--- a/internal/service/iot/exports_test.go
+++ b/internal/service/iot/exports_test.go
@@ -41,4 +41,6 @@ var (
 	FindThingTypeByName                      = findThingTypeByName
 	FindTopicRuleDestinationByARN            = findTopicRuleDestinationByARN
 	FindTopicRuleByName                      = findTopicRuleByName
+
+	ValidCloudWatchMetricTimestamp = validCloudWatchMetricTimestamp
 )

--- a/internal/service/iot/topic_rule.go
+++ b/internal/service/iot/topic_rule.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"log"
 	"reflect"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -150,7 +151,7 @@ func resourceTopicRule() *schema.Resource {
 							"metric_timestamp": {
 								Type:         schema.TypeString,
 								Optional:     true,
-								ValidateFunc: verify.ValidUTCTimestamp,
+								ValidateFunc: validCloudWatchMetricTimestamp,
 							},
 							"metric_unit": {
 								Type:     schema.TypeString,
@@ -361,7 +362,7 @@ func resourceTopicRule() *schema.Resource {
 										"metric_timestamp": {
 											Type:         schema.TypeString,
 											Optional:     true,
-											ValidateFunc: verify.ValidUTCTimestamp,
+											ValidateFunc: validCloudWatchMetricTimestamp,
 										},
 										"metric_unit": {
 											Type:     schema.TypeString,
@@ -1534,6 +1535,21 @@ func expandCloudWatchLogsAction(tfList []any) *awstypes.CloudwatchLogsAction {
 	}
 
 	return apiObject
+}
+
+// validCloudWatchMetricTimestamp validates metric_timestamp as either a UTC
+// timestamp or an IoT SQL substitution template (e.g. "${timestamp()}"), the
+// latter of which is resolved by AWS at rule execution time and so can't be
+// validated statically.
+// https://docs.aws.amazon.com/iot/latest/developerguide/iot-substitution-templates.html
+func validCloudWatchMetricTimestamp(v any, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if strings.Contains(value, "${") {
+		return ws, errors
+	}
+
+	return verify.ValidUTCTimestamp(v, k)
 }
 
 func expandCloudWatchMetricAction(tfList []any) *awstypes.CloudwatchMetricAction {

--- a/internal/service/iot/topic_rule_test.go
+++ b/internal/service/iot/topic_rule_test.go
@@ -27,6 +27,32 @@ func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 	)
 }
 
+func TestValidCloudWatchMetricTimestamp(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"2006-01-02T15:04:05Z",
+		"${timestamp()}",
+		"${my_timestamp}",
+		"prefix-${timestamp()}-suffix",
+	}
+	for _, v := range valid {
+		if _, errors := tfiot.ValidCloudWatchMetricTimestamp(v, "metric_timestamp"); len(errors) > 0 {
+			t.Errorf("%q should be valid, got errors: %v", v, errors)
+		}
+	}
+
+	invalid := []string{
+		"2015-03-07 23:45:00",
+		"not-a-timestamp",
+	}
+	for _, v := range invalid {
+		if _, errors := tfiot.ValidCloudWatchMetricTimestamp(v, "metric_timestamp"); len(errors) == 0 {
+			t.Errorf("%q should be invalid", v)
+		}
+	}
+}
+
 func TestAccIoTTopicRule_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := testAccTopicRuleName(t)
@@ -481,6 +507,39 @@ func TestAccIoTTopicRule_cloudWatchMetric(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sqs.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "step_functions.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "timestream.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIoTTopicRule_cloudWatchMetricTimestampSubstitution(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := testAccTopicRuleName(t)
+	resourceName := "aws_iot_topic_rule.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IoTServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTopicRuleDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// metric_timestamp must accept an IoT SQL substitution template, not
+				// just a literal UTC timestamp: AWS resolves the template at rule
+				// execution time.
+				Config: testAccTopicRuleConfig_cloudWatchMetricTimestampSubstitution(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicRuleExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch_metric.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "cloudwatch_metric.*", map[string]string{
+						"metric_timestamp": "${timestamp()}",
+					}),
 				),
 			},
 			{
@@ -2644,6 +2703,28 @@ resource "aws_iot_topic_rule" "test" {
   }
 }
 `, rName, metricName))
+}
+
+func testAccTopicRuleConfig_cloudWatchMetricTimestampSubstitution(rName string) string {
+	return acctest.ConfigCompose(
+		testAccTopicRuleConfig_destinationRole(rName),
+		fmt.Sprintf(`
+resource "aws_iot_topic_rule" "test" {
+  name        = %[1]q
+  enabled     = true
+  sql         = "SELECT * FROM 'topic/test'"
+  sql_version = "2015-10-08"
+
+  cloudwatch_metric {
+    metric_name      = "TestName"
+    metric_namespace = "TestNS"
+    metric_value     = "10"
+    metric_unit      = "s"
+    metric_timestamp = "$${timestamp()}"
+    role_arn         = aws_iam_role.test.arn
+  }
+}
+`, rName))
 }
 
 func testAccTopicRuleConfig_dynamoDB(rName string, tableName string) string {

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -106,7 +106,7 @@ The `cloudwatch_metric` object takes the following arguments:
 
 * `metric_name` - (Required) The CloudWatch metric name.
 * `metric_namespace` - (Required) The CloudWatch metric namespace name.
-* `metric_timestamp` - (Optional) An optional Unix timestamp (http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#about_timestamp).
+* `metric_timestamp` - (Optional) An optional Unix timestamp (http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#about_timestamp), or an IoT SQL [substitution template](https://docs.aws.amazon.com/iot/latest/developerguide/iot-substitution-templates.html) such as `${timestamp()}`.
 * `metric_unit` - (Required) The metric unit (supported units can be found here: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#Unit)
 * `metric_value` - (Required) The CloudWatch metric value.
 * `role_arn` - (Required) The IAM role ARN that allows access to the CloudWatch metric.


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This only widens a client-side input validator so a value AWS already accepts isn't rejected at plan time.

### Description

`aws_iot_topic_rule`'s `cloudwatch_metric.metric_timestamp` (and the same field under `error_action.cloudwatch_metric`) was validated as a literal UTC timestamp only (`verify.ValidUTCTimestamp`). AWS IoT Rules SQL supports substitution templates such as `${timestamp()}` for this field, resolved by the rules engine at execution time, and the AWS docs explicitly show this usage. Any configuration using a substitution template failed `ValidateFunc` at plan time even though AWS would accept it.

Changes in `internal/service/iot/topic_rule.go`:
- Added `validCloudWatchMetricTimestamp`, which skips the static UTC-timestamp check for values containing a substitution template (`${...}`) and otherwise delegates to the existing `verify.ValidUTCTimestamp`. Literal timestamp values are validated exactly as before.
- Used it for both `metric_timestamp` schema fields (top-level `cloudwatch_metric` and `error_action.cloudwatch_metric`).

Also updated the resource documentation for `metric_timestamp` to mention substitution templates are accepted.

### Relations

Closes #45375

### References

- https://docs.aws.amazon.com/iot/latest/developerguide/iot-substitution-templates.html

### Output from Acceptance Testing

I don't have AWS credentials to run acceptance tests locally. I added `TestAccIoTTopicRule_cloudWatchMetricTimestampSubstitution`, which configures `metric_timestamp = "$${timestamp()}"` and checks it round-trips, plus a unit test (`TestValidCloudWatchMetricTimestamp`) covering the new validator directly against both literal timestamps and substitution templates. Locally verified: `go build`, `go vet`, `gofmt`, and `golangci-lint run` all clean for `internal/service/iot`, and the new unit test passes:

```console
$ go test ./internal/service/iot/... -run '^TestValidCloudWatchMetricTimestamp$' -v
=== RUN   TestValidCloudWatchMetricTimestamp
--- PASS: TestValidCloudWatchMetricTimestamp (0.00s)
PASS
```

---

**AI disclosure:** Per `docs/ai-usage.md`, I used an AI coding agent (Claude, via Claude Code) to find this open, unassigned issue, implement the fix, write the tests above, and run the local verification shown. I am submitting it under my own account and am responsible for the change.
