### PR TITLE
fix: prevent fms_policy resource_tag_logical_operator drift on unrelated updates

### DIFF
--- a/.changelog/49756.txt
+++ b/.changelog/49756.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fms_policy: Fix `resource_tag_logical_operator` silently reverting to its API default on updates where it was left unconfigured
+```

--- a/internal/service/fms/policy.go
+++ b/internal/service/fms/policy.go
@@ -501,7 +501,15 @@ func expandPolicy(d *schema.ResourceData) *awstypes.Policy {
 				Key:   aws.String(k),
 				Value: aws.String(v),
 			})
-			apiObject.ResourceTagLogicalOperator = awstypes.ResourceTagLogicalOperator(d.Get("resource_tag_logical_operator").(string))
+		}
+
+		// resource_tag_logical_operator is Optional+Computed with no default, so an
+		// unconfigured value must not be sent as "": d.Get would return the empty
+		// string and the API would silently reset it to its own default ("AND"),
+		// clobbering a value that was only ever set out-of-band. GetOk sends it
+		// whenever a value is known, whether from config or the last Read.
+		if v, ok := d.GetOk("resource_tag_logical_operator"); ok {
+			apiObject.ResourceTagLogicalOperator = awstypes.ResourceTagLogicalOperator(v.(string))
 		}
 	}
 

--- a/internal/service/fms/policy_test.go
+++ b/internal/service/fms/policy_test.go
@@ -309,6 +309,17 @@ func testAccPolicy_resourceTagLogicalOperator(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resource_tag_logical_operator", "OR"),
 				),
 			},
+			{
+				// Removing resource_tag_logical_operator from the configuration, while
+				// applying an unrelated change, must not silently reset the previously
+				// set "OR" back to the API's own default ("AND"): the attribute is
+				// Optional+Computed, so an unconfigured value must be preserved.
+				Config: testAccPolicyConfig_resourceTagLogicalOperator_default(rName, acctest.CtKey1, acctest.CtValue1Updated),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "resource_tags.key1", acctest.CtValue1Updated),
+					resource.TestCheckResourceAttr(resourceName, "resource_tag_logical_operator", "OR"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This is a bug fix that stops the provider from silently overwriting a field's value in AWS during unrelated updates.

### Description

`resource_tag_logical_operator` on `aws_fms_policy` is `Optional` + `Computed` with no `Default`, meaning: if the user doesn't configure it, the provider should leave whatever value is already there alone. `expandPolicy` didn't honor that contract — it called `d.Get("resource_tag_logical_operator")` unconditionally whenever `resource_tags` was non-empty. `d.Get` returns the empty string once the attribute isn't set in config, and the FMS API interprets an empty `ResourceTagLogicalOperator` as its own default (`AND`). So any `Update` that touched the policy for an unrelated reason (e.g. changing a tag value) silently reset `resource_tag_logical_operator` back to `AND`, even if it had previously been set to `OR` (via Terraform or out-of-band) and the plan showed no change to that attribute at all.

Change in `internal/service/fms/policy.go`:
- Use `d.GetOk("resource_tag_logical_operator")` instead of `d.Get(...)`, so the field is only sent to the API when a value is actually known (from config or the last `Read`), never as an empty string that the API would treat as "reset to default."

### Relations

Closes #47771

### References

None beyond the linked issue, which includes AWS console screenshots reproducing the drift.

### Output from Acceptance Testing

I don't have AWS credentials to run acceptance tests locally (this resource also requires AWS Organizations + FMS admin account setup). I extended the existing `testAccPolicy_resourceTagLogicalOperator` test with a step that removes `resource_tag_logical_operator` from config while changing an unrelated `resource_tags` value, asserting the previously-set `OR` is preserved rather than reset to `AND`. Locally verified: `go build`, `go vet`, `gofmt`, and `golangci-lint run` all clean for `internal/service/fms` (no new lint findings; the package's few existing findings are unrelated to this change).

```console
$ go vet ./internal/service/fms/...
$ golangci-lint run ./internal/service/fms/...
(no findings on changed lines)
```

---

**AI disclosure:** Per `docs/ai-usage.md`, I used an AI coding agent (Claude, via Claude Code) to find this open, unassigned issue — root-caused here by a maintainer-approved `dosu` bot comment on the issue — implement the fix, write the test above, and run the local verification shown. I am submitting it under my own account and am responsible for the change.
