### PR TITLE
`tags` interceptor and system tags

### DIFF
--- a/internal/provider/framework/tags_interceptor.go
+++ b/internal/provider/framework/tags_interceptor.go
@@ -227,6 +227,11 @@ func (r tagsResourceInterceptor) update(ctx context.Context, opts interceptorOpt
 func (r tagsResourceInterceptor) modifyPlan(ctx context.Context, opts interceptorOptions[resource.ModifyPlanRequest, resource.ModifyPlanResponse]) {
 	c := opts.c
 
+	sp, _, _, _, _, ok := interceptors.InfoFromContext(ctx, c)
+	if !ok {
+		return
+	}
+
 	switch request, response, when := opts.request, opts.response, opts.when; when {
 	case Before:
 		// If the entire plan is null, the resource is planned for destruction.
@@ -242,7 +247,7 @@ func (r tagsResourceInterceptor) modifyPlan(ctx context.Context, opts intercepto
 		}
 
 		if planTags.IsWhollyKnown() {
-			allTags := c.DefaultTagsConfig(ctx).MergeTags(tftags.New(ctx, planTags)).IgnoreConfig(c.IgnoreTagsConfig(ctx))
+			allTags := c.DefaultTagsConfig(ctx).MergeTags(tftags.New(ctx, planTags)).IgnoreSystem(sp.ServicePackageName()).IgnoreConfig(c.IgnoreTagsConfig(ctx))
 			opts.response.Diagnostics.Append(response.Plan.SetAttribute(ctx, path.Root(names.AttrTagsAll), fwflex.FlattenFrameworkStringValueMapLegacy(ctx, allTags.Map()))...)
 		} else {
 			opts.response.Diagnostics.Append(response.Plan.SetAttribute(ctx, path.Root(names.AttrTagsAll), tftags.Unknown)...)

--- a/internal/provider/framework/tags_interceptor_test.go
+++ b/internal/provider/framework/tags_interceptor_test.go
@@ -5,13 +5,16 @@ package framework
 
 import (
 	"context"
+	"maps"
 	"testing"
+	"unique"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -67,6 +70,115 @@ func (sp mockServicePackage) SDKResources(context.Context) []*inttypes.ServicePa
 
 func (sp mockServicePackage) ServicePackageName() string {
 	return "Test"
+}
+
+type mockTagsClient struct {
+	mockRequiredTagsClient
+	defaultTags *tftags.DefaultConfig
+	ignoreTags  *tftags.IgnoreConfig
+}
+
+func (c mockTagsClient) DefaultTagsConfig(context.Context) *tftags.DefaultConfig {
+	return c.defaultTags
+}
+
+func (c mockTagsClient) IgnoreTagsConfig(context.Context) *tftags.IgnoreConfig {
+	return c.ignoreTags
+}
+
+func TestTagsResourceInterceptorModifyPlan(t *testing.T) {
+	t.Parallel()
+
+	resourceSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrTags: tftags.TagsAttribute(),
+			names.AttrTagsAll: schema.MapAttribute{
+				CustomType:  tftags.MapType,
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+		},
+	}
+	tagsType := tftypes.Map{ElementType: tftypes.String}
+
+	testCases := map[string]struct {
+		defaultTags map[string]string
+		planTags    map[string]string
+		want        map[string]string
+	}{
+		"system tag only": {
+			planTags: map[string]string{
+				"aws:autoscaling-group-123": "managed",
+			},
+			want: map[string]string{},
+		},
+		"system tag excluded while resource and default tags remain": {
+			defaultTags: map[string]string{
+				"default": "value",
+			},
+			planTags: map[string]string{
+				"aws:autoscaling-group-123": "managed",
+				"resource":                  "value",
+			},
+			want: map[string]string{
+				"default":  "value",
+				"resource": "value",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := conns.NewResourceContext(t.Context(), "Test", "test", "aws_test", "")
+			client := mockTagsClient{
+				defaultTags: &tftags.DefaultConfig{Tags: tftags.New(ctx, testCase.defaultTags)},
+			}
+			ctx = tftags.NewContext(ctx, client.DefaultTagsConfig(ctx), client.IgnoreTagsConfig(ctx), nil)
+
+			planTags := make(map[string]tftypes.Value, len(testCase.planTags))
+			for k, v := range testCase.planTags {
+				planTags[k] = tftypes.NewValue(tftypes.String, v)
+			}
+			rawPlan := tftypes.NewValue(resourceSchema.Type().TerraformType(ctx), map[string]tftypes.Value{
+				names.AttrTags:    tftypes.NewValue(tagsType, planTags),
+				names.AttrTagsAll: tftypes.NewValue(tagsType, tftypes.UnknownValue),
+			})
+
+			response := &resource.ModifyPlanResponse{
+				Plan: tfsdk.Plan{
+					Raw:    rawPlan,
+					Schema: resourceSchema,
+				},
+			}
+			r := resourceTransparentTagging(unique.Make(inttypes.ServicePackageResourceTags{})).(resourceModifyPlanInterceptor)
+			r.modifyPlan(ctx, interceptorOptions[resource.ModifyPlanRequest, resource.ModifyPlanResponse]{
+				c: client,
+				request: &resource.ModifyPlanRequest{
+					Plan: tfsdk.Plan{
+						Raw:    rawPlan,
+						Schema: resourceSchema,
+					},
+				},
+				response: response,
+				when:     Before,
+			})
+			if response.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics: %s", response.Diagnostics)
+			}
+
+			var gotTagsAll tftags.Map
+			response.Diagnostics.Append(response.Plan.GetAttribute(ctx, path.Root(names.AttrTagsAll), &gotTagsAll)...)
+			if response.Diagnostics.HasError() {
+				t.Fatalf("reading planned tags_all: %s", response.Diagnostics)
+			}
+
+			if got := tftags.New(ctx, gotTagsAll).Map(); !maps.Equal(got, testCase.want) {
+				t.Errorf("planned tags_all = %#v, want %#v", got, testCase.want)
+			}
+		})
+	}
 }
 
 func Test_resourceValidateRequiredTagsInterceptor(t *testing.T) {

--- a/internal/provider/sdkv2/tags_interceptor.go
+++ b/internal/provider/sdkv2/tags_interceptor.go
@@ -267,6 +267,10 @@ func (r tagsDataSourceCRUDInterceptor) run(ctx context.Context, opts crudInterce
 	return diags
 }
 
+func calculateTagsAll(defaultConfig *tftags.DefaultConfig, ignoreConfig *tftags.IgnoreConfig, serviceName string, tags tftags.KeyValueTags) tftags.KeyValueTags {
+	return defaultConfig.MergeTags(tags).IgnoreSystem(serviceName).IgnoreConfig(ignoreConfig)
+}
+
 func setTagsAll() customizeDiffInterceptor {
 	return interceptorFunc1[*schema.ResourceDiff, error](func(ctx context.Context, opts customizeDiffInterceptorOptions) error {
 		c := opts.c
@@ -283,8 +287,13 @@ func setTagsAll() customizeDiffInterceptor {
 					return nil
 				}
 
+				sp, _, _, _, _, ok := interceptors.InfoFromContext(ctx, c)
+				if !ok {
+					return nil
+				}
+
 				newTags := tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))
-				allTags := c.DefaultTagsConfig(ctx).MergeTags(newTags).IgnoreConfig(c.IgnoreTagsConfig(ctx))
+				allTags := calculateTagsAll(c.DefaultTagsConfig(ctx), c.IgnoreTagsConfig(ctx), sp.ServicePackageName(), newTags)
 				if d.HasChange(names.AttrTags) {
 					if newTags.HasZeroValue() {
 						if err := d.SetNewComputed(names.AttrTagsAll); err != nil {

--- a/internal/provider/sdkv2/tags_interceptor_test.go
+++ b/internal/provider/sdkv2/tags_interceptor_test.go
@@ -6,6 +6,7 @@ package sdkv2
 import (
 	"context"
 	"errors"
+	"maps"
 	"testing"
 	"unique"
 
@@ -57,6 +58,54 @@ func (t *mockService) ListTags(ctx context.Context, meta any, identifier string)
 
 func (t *mockService) UpdateTags(context.Context, any, string, any, any) error {
 	return nil
+}
+
+func TestCalculateTagsAll(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	testCases := map[string]struct {
+		defaultTags  map[string]string
+		resourceTags map[string]string
+		want         map[string]string
+	}{
+		"system tag only": {
+			resourceTags: map[string]string{
+				"aws:autoscaling-group-123": "managed",
+			},
+			want: map[string]string{},
+		},
+		"system tag excluded while resource and default tags remain": {
+			defaultTags: map[string]string{
+				"default": "value",
+			},
+			resourceTags: map[string]string{
+				"aws:autoscaling-group-123": "managed",
+				"resource":                  "value",
+			},
+			want: map[string]string{
+				"default":  "value",
+				"resource": "value",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := calculateTagsAll(
+				&tftags.DefaultConfig{Tags: tftags.New(ctx, testCase.defaultTags)},
+				nil,
+				"TestService",
+				tftags.New(ctx, testCase.resourceTags),
+			).Map()
+
+			if !maps.Equal(got, testCase.want) {
+				t.Errorf("tags_all = %#v, want %#v", got, testCase.want)
+			}
+		})
+	}
 }
 
 func TestTagsResourceInterceptor(t *testing.T) {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Addresses a problem found when testing https://github.com/hashicorp/terraform-provider-aws/pull/49551: If a resource has "system tags" (AWS-applied tags) then `terraform plan` shows `tags_all` diffs.

```console
% make testacc TESTARGS='-run=TestAccAccountAccess_serial/^Application$$/^tags$$/^basic$$' PKG=accountaccess
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     6.105s
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework 6.051s
make: Running acceptance tests on branch: 🌿 HEAD 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/accountaccess/... -v -count 1 -parallel 20  -run=TestAccAccountAccess_serial/^Application$/^tags$/^basic$ -timeout 360m -vet=off -buildvcs=false
2026/08/31 11:32:07 Creating Terraform AWS Provider (SDKv2-style)...
2026/08/31 11:32:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAccountAccess_serial
=== PAUSE TestAccAccountAccess_serial
=== CONT  TestAccAccountAccess_serial
=== RUN   TestAccAccountAccess_serial/Application
=== RUN   TestAccAccountAccess_serial/Application/tags
=== RUN   TestAccAccountAccess_serial/Application/tags/basic
    application_tags_gen_test.go:58: Step 1/8 error: After applying this test step, the refresh plan was not empty.
        stdout


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_accountaccess_application.test will be updated in-place
          ~ resource "aws_accountaccess_application" "test" {
                tags                            = {
                    "key1" = "value1"
                }
              ~ tags_all                        = {
                  + "key1" = "value1"
                }
                # (5 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccAccountAccess_serial (35.60s)
    --- FAIL: TestAccAccountAccess_serial/Application (35.60s)
        --- FAIL: TestAccAccountAccess_serial/Application/tags (35.60s)
            --- FAIL: TestAccAccountAccess_serial/Application/tags/basic (30.59s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/accountaccess      41.912s
FAIL
make: *** [testacc] Error 1
```

#### Kiro's analysis

Finding and fix

  The Framework interceptor handled system tags inconsistently:

  - create, read, and update remove system tags with IgnoreSystem(sp.ServicePackageName()).
  - modifyPlan previously merged defaults and applied ignore_tags, but did not remove system tags.
  - IgnoreSystem removes all aws:-prefixed tags for normal services, including aws:autoscaling-group-123.

  This caused plan-time tags_all to disagree with post-apply/refresh state: a system-only configured map could be present in the plan then become
  empty after the lifecycle handler filtered it. The map conversion path is not the cause: its unit tests and implementation preserve arbitrary
  string keys, including keys containing :.

  I updated internal/provider/framework/tags_interceptor.go so modifyPlan resolves the service package from context and computes:

  default_tags + tags
      → IgnoreSystem(service)
      → IgnoreConfig(ignore_tags)

  This now matches the rest of the interceptor lifecycle.

  Regression coverage

  Added TestTagsResourceInterceptorModifyPlan in internal/provider/framework/tags_interceptor_test.go covering:

  1. A system-only aws:autoscaling-group-123 tag plans an empty tags_all.
  2. A mixed tag map excludes the system tag while retaining resource and provider-default tags.

  Validation

  Passed:

  - go test ./internal/provider/framework
  - go test ./internal/tags ./internal/framework/flex
  - go test -count=1 -run '^TestTagsResourceInterceptorModifyPlan$' ./internal/provider/framework
  - git diff --check

  Only the interceptor implementation and its test file are modified.

  Added focused unit regression coverage and implemented the corresponding plan-time filtering fix.

  Yes—the SDKv2 implementation had the same inconsistency.

  setTagsAll() in internal/provider/sdkv2/tags_interceptor.go previously calculated planned tags_all with:

  default_tags + resource tags → ignore_tags

  but SDKv2 CRUD paths use:

  default_tags + resource tags → IgnoreSystem(service) → ignore_tags

  So aws: system-tag keys could be retained in the plan and then disappear after apply/refresh.

  Changes made:

  - Added calculateTagsAll(...), which merges defaults, removes system tags using the resource service package, then applies ignore_tags.
  - Updated setTagsAll() to resolve the service package from context and use that helper.
  - Added TestCalculateTagsAll, covering:
    - system-only aws:autoscaling-group-123 produces empty tags_all;
    - mixed system/resource/default tags retain only the resource and default tags.

  Validation passed:

  - go test ./internal/provider/sdkv2
  - go test -count=1 -run '^TestCalculateTagsAll$' ./internal/provider/sdkv2
  - go test ./internal/provider/framework ./internal/provider/sdkv2
  - go test ./internal/tags

  The working tree now contains the intended Framework and SDKv2 implementation/test changes only.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
