### PR TITLE
resource/aws_ssmquicksetup_configuration_manager: Suppress empty parameter drift

### DIFF
--- a/.changelog/49760.txt
+++ b/.changelog/49760.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssmquicksetup_configuration_manager: Prevent recurring updates when the API omits empty S3 output parameters
+```

--- a/internal/service/ssmquicksetup/configuration_manager.go
+++ b/internal/service/ssmquicksetup/configuration_manager.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -16,6 +17,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ssmquicksetup/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -78,7 +80,7 @@ func (r *configurationManagerResource) Schema(ctx context.Context, request resou
 		},
 		Blocks: map[string]schema.Block{
 			"configuration_definition": schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[configurationDefinitionModel](ctx),
+				CustomType: fwtypes.NewListNestedObjectTypeOf[configurationDefinitionModel](ctx, fwtypes.WithSemanticEqualityFunc(configurationDefinitionSemanticEqualityFunc)),
 				Validators: []validator.List{
 					listvalidator.IsRequired(),
 					listvalidator.SizeAtLeast(1),
@@ -123,6 +125,78 @@ func (r *configurationManagerResource) Schema(ctx context.Context, request resou
 			}),
 		},
 	}
+}
+
+func configurationDefinitionSemanticEqualityFunc(ctx context.Context, oldValue, newValue fwtypes.NestedCollectionValue[configurationDefinitionModel]) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	oldDefinitions, d := oldValue.ToSlice(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	newDefinitions, d := newValue.ToSlice(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	if len(oldDefinitions) != len(newDefinitions) {
+		return false, diags
+	}
+
+	for i, oldDefinition := range oldDefinitions {
+		newDefinition := newDefinitions[i]
+		if !oldDefinition.ID.Equal(newDefinition.ID) ||
+			!oldDefinition.LocalDeploymentAdministrationRoleARN.Equal(newDefinition.LocalDeploymentAdministrationRoleARN) ||
+			!oldDefinition.LocalDeploymentExecutionRoleName.Equal(newDefinition.LocalDeploymentExecutionRoleName) ||
+			!oldDefinition.Type.Equal(newDefinition.Type) ||
+			!oldDefinition.TypeVersion.Equal(newDefinition.TypeVersion) {
+			return false, diags
+		}
+
+		if oldDefinition.Parameters.IsNull() || oldDefinition.Parameters.IsUnknown() ||
+			newDefinition.Parameters.IsNull() || newDefinition.Parameters.IsUnknown() {
+			if !oldDefinition.Parameters.Equal(newDefinition.Parameters) {
+				return false, diags
+			}
+
+			continue
+		}
+
+		var oldParameters, newParameters map[string]string
+		diags.Append(oldDefinition.Parameters.ElementsAs(ctx, &oldParameters, false)...)
+		diags.Append(newDefinition.Parameters.ElementsAs(ctx, &newParameters, false)...)
+		if diags.HasError() {
+			return false, diags
+		}
+
+		if !configurationManagerParametersEqual(oldParameters, newParameters) {
+			return false, diags
+		}
+	}
+
+	return true, diags
+}
+
+func configurationManagerParametersEqual(oldParameters, newParameters map[string]string) bool {
+	if maps.Equal(oldParameters, newParameters) {
+		return true
+	}
+
+	oldParameters = maps.Clone(oldParameters)
+	newParameters = maps.Clone(newParameters)
+	for _, key := range []string{"OutputBucketRegion", "OutputS3BucketName", "OutputS3KeyPrefix"} {
+		if oldParameters[key] == "" {
+			delete(oldParameters, key)
+		}
+		if newParameters[key] == "" {
+			delete(newParameters, key)
+		}
+	}
+
+	return maps.Equal(oldParameters, newParameters)
 }
 
 func (r *configurationManagerResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {

--- a/internal/service/ssmquicksetup/configuration_manager_internal_test.go
+++ b/internal/service/ssmquicksetup/configuration_manager_internal_test.go
@@ -1,0 +1,73 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ssmquicksetup
+
+import "testing"
+
+func TestConfigurationManagerParametersEqual(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		oldParameters map[string]string
+		newParameters map[string]string
+		want          bool
+	}{
+		"exact equality": {
+			oldParameters: map[string]string{"OutputLogEnableS3": "false"},
+			newParameters: map[string]string{"OutputLogEnableS3": "false"},
+			want:          true,
+		},
+		"API default empty parameters added": {
+			oldParameters: map[string]string{"OutputLogEnableS3": "false"},
+			newParameters: map[string]string{
+				"OutputLogEnableS3":  "false",
+				"OutputBucketRegion": "",
+				"OutputS3BucketName": "",
+				"OutputS3KeyPrefix":  "",
+			},
+			want: true,
+		},
+		"API default empty parameters removed": {
+			oldParameters: map[string]string{
+				"OutputLogEnableS3":  "false",
+				"OutputBucketRegion": "",
+				"OutputS3BucketName": "",
+				"OutputS3KeyPrefix":  "",
+			},
+			newParameters: map[string]string{"OutputLogEnableS3": "false"},
+			want:          true,
+		},
+		"non-empty default parameter added": {
+			oldParameters: map[string]string{"OutputLogEnableS3": "false"},
+			newParameters: map[string]string{
+				"OutputLogEnableS3":  "false",
+				"OutputS3BucketName": "example-bucket",
+			},
+			want: false,
+		},
+		"non-default empty parameter added": {
+			oldParameters: map[string]string{"OutputLogEnableS3": "false"},
+			newParameters: map[string]string{
+				"OutputLogEnableS3":  "false",
+				"UnrelatedParameter": "",
+			},
+			want: false,
+		},
+		"configured parameter changed": {
+			oldParameters: map[string]string{"RateControlConcurrency": "10%"},
+			newParameters: map[string]string{"RateControlConcurrency": "20%"},
+			want:          false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := configurationManagerParametersEqual(testCase.oldParameters, testCase.newParameters); got != testCase.want {
+				t.Errorf("configurationManagerParametersEqual() = %t, want %t", got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/service/ssmquicksetup/configuration_manager_test.go
+++ b/internal/service/ssmquicksetup/configuration_manager_test.go
@@ -41,6 +41,11 @@ func TestAccSSMQuickSetupConfigurationManager_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigurationManagerConfig_basic(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationManagerExists(ctx, t, resourceName, &cm),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

Revert this pull request. The resource will return to its previous comparison behavior.

## Changes to Security Controls

No security controls are changed. This only changes how the provider compares three API-defaulted empty output parameters when determining whether configuration drift exists.

### Description

The SSM Quick Setup API omits the following parameters when their values are empty:

- `OutputBucketRegion`
- `OutputS3BucketName`
- `OutputS3KeyPrefix`

Terraform state retains those parameters as empty strings, causing `aws_ssmquicksetup_configuration_manager` to report the same in-place update after every refresh.

This change adds semantic equality handling for `configuration_definition`. Missing and empty values are treated as equivalent only for these three parameters. Non-empty values, unrelated parameters, and other configuration changes continue to produce a diff.

This includes unit regression coverage and a post-apply/post-refresh acceptance-test assertion confirming that the configuration is stable.

### Relations

Closes #49739

### References

- https://github.com/hashicorp/terraform-provider-aws/issues/49739

### Output from Acceptance Testing

```console
% AWS_PROFILE=billing TF_ACC=1 go test ./internal/service/ssmquicksetup \
    -v -count 1 -parallel 1 \
    -run '^TestAccSSMQuickSetupConfigurationManager_basic$' \
    -timeout 60m -vet=off -buildvcs=false

=== RUN   TestAccSSMQuickSetupConfigurationManager_basic
=== PAUSE TestAccSSMQuickSetupConfigurationManager_basic
=== CONT  TestAccSSMQuickSetupConfigurationManager_basic
--- PASS: TestAccSSMQuickSetupConfigurationManager_basic (250.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssmquicksetup  256.085s
```

### Unit Testing

```console
% /opt/homebrew/opt/go@1.26/bin/go test ./internal/service/ssmquicksetup -count=1

ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssmquicksetup  5.793s
```