### PR TITLE
teamcity: simplify tctest workflow

### DIFF
--- a/.github/workflows/pr-test-trigger.yml
+++ b/.github/workflows/pr-test-trigger.yml
@@ -83,7 +83,6 @@ jobs:
         id: run_tests
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
-          PKGS: ${{ steps.pkgs.outputs.pkgs }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           TCTEST_SERVER: ${{ secrets.TCTEST_SERVER }}
           TCTEST_BUILD_TYPE_ID: ${{ secrets.TCTEST_BUILD_TYPE_ID }}
@@ -108,25 +107,28 @@ jobs:
             pattern="${raw_pattern}"
           fi
 
-          # Validate PKGS (from GitHub API) before embedding in properties string.
-          if [[ ! "${PKGS}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-            echo "::error::PKGS contains unexpected characters: ${PKGS}"
-            exit 1
-          fi
-          properties="PKG=${PKGS}"
+          properties=""
           if [[ -n "${parallelism_value}" ]]; then
             if [[ "${parallelism_value}" -gt 20 ]]; then
               echo "::error::Parallelism value ${parallelism_value} exceeds maximum of 20"
               exit 1
             fi
-            properties="${properties};ACCTEST_PARALLELISM=${parallelism_value}"
+            properties="ACCTEST_PARALLELISM=${parallelism_value}"
           fi
 
           # Invoke tctest directly — no eval, no string-assembled commands.
           if [[ -n "${pattern}" ]]; then
-            tctest pr "${PR_NUMBER}" "${pattern}" --properties "${properties}" --comment --reappend-split-character
+            if [[ -n "${properties}" ]]; then
+              tctest pr "${PR_NUMBER}" "${pattern}" --properties "${properties}" --comment --reappend-split-character
+            else
+              tctest pr "${PR_NUMBER}" "${pattern}" --comment --reappend-split-character
+            fi
           else
-            tctest pr "${PR_NUMBER}" --properties "${properties}" --comment --reappend-split-character
+            if [[ -n "${properties}" ]]; then
+              tctest pr "${PR_NUMBER}" --properties "${properties}" --comment --reappend-split-character
+            else
+              tctest pr "${PR_NUMBER}" --comment --reappend-split-character
+            fi
           fi
 
       - name: Comment on Test Start

--- a/.teamcity/scripts/pullrequest_tests/tests.sh
+++ b/.teamcity/scripts/pullrequest_tests/tests.sh
@@ -5,12 +5,12 @@
 set -euo pipefail
 
 # shellcheck disable=2050 # This isn't a constant string, it's a TeamCity variable substitution
-if [[ "%PKG%" == "" ]]; then
-	echo "PKG variable is required"
+if [[ "%SERVICE_PACKAGE%" == "" ]]; then
+	echo "SERVICE_PACKAGE variable is required"
 	exit 1
 fi
 
-PKG="./internal/service/%PKG%/..."
+PKG="./internal/service/%SERVICE_PACKAGE%/..."
 
 # shellcheck disable=2050 # This isn't a constant string, it's a TeamCity variable substitution
 if [[ "%TEST_PATTERN%" == "" || "%TEST_PATTERN%" == "TestAcc" ]]; then


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

tctest `v1.3.0` now passes SERVICE_PACKAGE as part of the request. We can use this instead of deriving ourselves

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
