### PR TITLE
🤖🤖🤖 r/aws_mskconnect_connector: Detect failed update operations

### DIFF
--- a/.changelog/49766.txt
+++ b/.changelog/49766.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_mskconnect_connector: Detect failed update operations before reporting success
+```

--- a/internal/service/kafkaconnect/connector.go
+++ b/internal/service/kafkaconnect/connector.go
@@ -9,8 +9,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
+	"github.com/YakDriver/smarterr"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kafkaconnect"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/kafkaconnect/types"
@@ -529,19 +531,24 @@ func resourceConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta a
 				CurrentVersion: aws.String(currentVersion),
 			}
 
-			_, err := conn.UpdateConnector(ctx, input)
+			output, err := conn.UpdateConnector(ctx, input)
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "updating MSK Connect Connector capacity (%s): %s", d.Id(), err)
 			}
 
-			output, err := waitConnectorUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+			operationARN := aws.ToString(output.ConnectorOperationArn)
+			if _, err := waitConnectorOperationCompleted(ctx, conn, operationARN, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for MSK Connect Connector (%s) operation (%s): %s", d.Id(), operationARN, err)
+			}
+
+			connectorOutput, err := waitConnectorUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "waiting for MSK Connect Connector (%s) update: %s", d.Id(), err)
 			}
 
-			currentVersion = aws.ToString(output.CurrentVersion)
+			currentVersion = aws.ToString(connectorOutput.CurrentVersion)
 		}
 
 		if d.HasChange("connector_configuration") {
@@ -551,10 +558,15 @@ func resourceConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta a
 				CurrentVersion:         aws.String(currentVersion),
 			}
 
-			_, err := conn.UpdateConnector(ctx, input)
+			output, err := conn.UpdateConnector(ctx, input)
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "updating MSK Connect Connector configuration (%s): %s", d.Id(), err)
+			}
+
+			operationARN := aws.ToString(output.ConnectorOperationArn)
+			if _, err := waitConnectorOperationCompleted(ctx, conn, operationARN, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for MSK Connect Connector (%s) operation (%s): %s", d.Id(), operationARN, err)
 			}
 
 			if _, err := waitConnectorUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
@@ -614,6 +626,30 @@ func findConnectorByARN(ctx context.Context, conn *kafkaconnect.Client, arn stri
 	return output, nil
 }
 
+func findConnectorOperationByARN(ctx context.Context, conn *kafkaconnect.Client, arn string) (*kafkaconnect.DescribeConnectorOperationOutput, error) {
+	input := &kafkaconnect.DescribeConnectorOperationInput{
+		ConnectorOperationArn: aws.String(arn),
+	}
+
+	output, err := conn.DescribeConnectorOperation(ctx, input)
+
+	if errs.IsA[*awstypes.NotFoundException](err) {
+		return nil, smarterr.NewError(&retry.NotFoundError{
+			LastError: err,
+		})
+	}
+
+	if err != nil {
+		return nil, smarterr.NewError(err)
+	}
+
+	if output == nil {
+		return nil, smarterr.NewError(tfresource.NewEmptyResultError())
+	}
+
+	return output, nil
+}
+
 func statusConnector(conn *kafkaconnect.Client, arn string) retry.StateRefreshFunc {
 	return func(ctx context.Context) (any, string, error) {
 		output, err := findConnectorByARN(ctx, conn, arn)
@@ -627,6 +663,22 @@ func statusConnector(conn *kafkaconnect.Client, arn string) retry.StateRefreshFu
 		}
 
 		return output, string(output.ConnectorState), nil
+	}
+}
+
+func statusConnectorOperation(conn *kafkaconnect.Client, arn string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		output, err := findConnectorOperationByARN(ctx, conn, arn)
+
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.ConnectorOperationState), nil
 	}
 }
 
@@ -670,6 +722,64 @@ func waitConnectorUpdated(ctx context.Context, conn *kafkaconnect.Client, arn st
 	}
 
 	return nil, err
+}
+
+func waitConnectorOperationCompleted(ctx context.Context, conn *kafkaconnect.Client, arn string, timeout time.Duration) (*kafkaconnect.DescribeConnectorOperationOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(
+			awstypes.ConnectorOperationStatePending,
+			awstypes.ConnectorOperationStateUpdateInProgress,
+			awstypes.ConnectorOperationStateRollbackInProgress,
+		),
+		Target:  enum.Slice(awstypes.ConnectorOperationStateUpdateComplete),
+		Refresh: statusConnectorOperation(conn, arn),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*kafkaconnect.DescribeConnectorOperationOutput); ok {
+		switch output.ConnectorOperationState {
+		case awstypes.ConnectorOperationStateUpdateFailed,
+			awstypes.ConnectorOperationStateRollbackFailed,
+			awstypes.ConnectorOperationStateRollbackComplete:
+			retry.SetLastError(err, connectorOperationError(output))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func connectorOperationError(output *kafkaconnect.DescribeConnectorOperationOutput) error {
+	parts := []string{
+		fmt.Sprintf("operation (%s)", aws.ToString(output.ConnectorOperationArn)),
+		fmt.Sprintf("type (%s)", output.ConnectorOperationType),
+		fmt.Sprintf("state (%s)", output.ConnectorOperationState),
+	}
+
+	if errorInfo := output.ErrorInfo; errorInfo != nil {
+		if code := aws.ToString(errorInfo.Code); code != "" {
+			parts = append(parts, fmt.Sprintf("error code (%s)", code))
+		}
+
+		if message := aws.ToString(errorInfo.Message); message != "" {
+			parts = append(parts, fmt.Sprintf("error message (%s)", message))
+		}
+	}
+
+	if len(output.OperationSteps) > 0 {
+		steps := make([]string, 0, len(output.OperationSteps))
+
+		for _, step := range output.OperationSteps {
+			steps = append(steps, fmt.Sprintf("%s=%s", step.StepType, step.StepState))
+		}
+
+		parts = append(parts, fmt.Sprintf("steps (%s)", strings.Join(steps, ", ")))
+	}
+
+	return fmt.Errorf("%s", strings.Join(parts, ", "))
 }
 
 func waitConnectorDeleted(ctx context.Context, conn *kafkaconnect.Client, arn string, timeout time.Duration) (*kafkaconnect.DescribeConnectorOutput, error) {

--- a/internal/service/kafkaconnect/connector_operation_test.go
+++ b/internal/service/kafkaconnect/connector_operation_test.go
@@ -1,0 +1,140 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package kafkaconnect
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/kafkaconnect"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/kafkaconnect/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestWaitConnectorOperationCompleted(t *testing.T) {
+	t.Parallel()
+
+	const operationARN = "arn:aws:kafkaconnect:us-west-2:123456789012:connector-operation/test/operation"
+
+	testCases := []struct {
+		name          string
+		terminalState awstypes.ConnectorOperationState
+		expectError   bool
+	}{
+		{
+			name:          "update complete",
+			terminalState: awstypes.ConnectorOperationStateUpdateComplete,
+		},
+		{
+			name:          "update failed",
+			terminalState: awstypes.ConnectorOperationStateUpdateFailed,
+			expectError:   true,
+		},
+		{
+			name:          "rollback failed",
+			terminalState: awstypes.ConnectorOperationStateRollbackFailed,
+			expectError:   true,
+		},
+		{
+			name:          "rollback complete",
+			terminalState: awstypes.ConnectorOperationStateRollbackComplete,
+			expectError:   true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			conn := newTestKafkaConnectClient(t, operationARN, []awstypes.ConnectorOperationState{
+				awstypes.ConnectorOperationStatePending,
+				awstypes.ConnectorOperationStateUpdateInProgress,
+				testCase.terminalState,
+			})
+
+			output, err := waitConnectorOperationCompleted(context.Background(), conn, operationARN, 3*time.Second)
+
+			if testCase.expectError && err == nil {
+				t.Fatal("expected error, got none")
+			}
+
+			if !testCase.expectError && err != nil {
+				t.Fatalf("expected no error, got: %s", err)
+			}
+
+			if output == nil {
+				t.Fatal("expected non-nil operation output, got nil")
+			} else if output.ConnectorOperationState != testCase.terminalState {
+				t.Fatalf("expected operation state %s, got: %s", testCase.terminalState, output.ConnectorOperationState)
+			}
+
+			if err != nil {
+				errString := err.Error()
+				expectedContains := []string{operationARN}
+				expectedContains = append(expectedContains, enum.Slice(testCase.terminalState)...)
+				expectedContains = append(expectedContains, enum.Slice(awstypes.ConnectorOperationTypeUpdateConnectorConfiguration)...)
+				expectedContains = append(expectedContains,
+					"InvalidConnectorConfiguration",
+					"connector configuration rejected",
+					"VALIDATE_UPDATE=FAILED",
+				)
+
+				for _, expected := range expectedContains {
+					if !strings.Contains(errString, expected) {
+						t.Fatalf("expected error to contain %q, got: %s", expected, errString)
+					}
+				}
+			}
+		})
+	}
+}
+
+func newTestKafkaConnectClient(t *testing.T, operationARN string, states []awstypes.ConnectorOperationState) *kafkaconnect.Client {
+	t.Helper()
+
+	var index int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if index >= len(states) {
+			index = len(states) - 1
+		}
+
+		state := states[index]
+		index++
+
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		w.WriteHeader(http.StatusOK)
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"connectorOperationArn":   operationARN,
+			"connectorOperationState": state,
+			"connectorOperationType":  awstypes.ConnectorOperationTypeUpdateConnectorConfiguration,
+			"errorInfo": map[string]string{
+				"code":            "InvalidConnectorConfiguration",
+				names.AttrMessage: "connector configuration rejected",
+			},
+			"operationSteps": []map[string]any{
+				{
+					"stepState": awstypes.ConnectorOperationStepStateFailed,
+					"stepType":  awstypes.ConnectorOperationStepTypeValidateUpdate,
+				},
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	return kafkaconnect.New(kafkaconnect.Options{
+		Region:       "us-west-2", //lintignore:AWSAT003
+		BaseEndpoint: aws.String(server.URL),
+		Credentials:  credentials.NewStaticCredentialsProvider("AKID", "SECRET", "SESSION"),
+	})
+}


### PR DESCRIPTION
## Rollback Plan

If this change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to access controls, encryption, logging, or other security controls.

### Description

`aws_mskconnect_connector` currently treats the connector returning to `RUNNING` as proof that an update succeeded. Amazon MSK Connect tracks the asynchronous update result separately, so Terraform can report success even when the connector operation reaches `UPDATE_FAILED` or a rollback state.

This change:

- captures the `connectorOperationArn` returned by both capacity and connector configuration updates
- waits for `DescribeConnectorOperation` to report `UPDATE_COMPLETE`
- returns an error for `UPDATE_FAILED`, `ROLLBACK_FAILED`, and `ROLLBACK_COMPLETE`
- includes the operation ARN, type, state, AWS error information, and operation-step states in the error when available
- retains the existing connector-state wait as a follow-up consistency check

AI disclosure: Codex CLI was used during the original investigation, and Hermes Agent was used to inspect the current repository, implement and refine the change, add tests, and run local verification.

### Relations

Closes #48199
Relates #47004

### References

- [UpdateConnector API](https://docs.aws.amazon.com/MSKC/latest/mskc/API_UpdateConnector.html)
- [DescribeConnectorOperation API](https://docs.aws.amazon.com/MSKC/latest/mskc/API_DescribeConnectorOperation.html)

### Output from Acceptance Testing

The automated acceptance-test suite was not run because reliably creating this terminal state would require real AWS resources and remains non-deterministic. The operation waiter is covered with a local mocked AWS endpoint.

An end-to-end live AWS canary was run on 2026-09-01 against an existing MSK Connect connector that reliably reproduced the original false-success behavior:

- built this PR's exact head (`3841171489b5`) as a `linux/amd64` provider binary and loaded it through a Terraform CLI `dev_overrides` configuration
- ran Terraform 1.5.6 with a targeted plan containing `0 to add, 1 to change, 0 to destroy`
- Amazon MSK Connect accepted the configuration update and returned a connector operation ARN
- the asynchronous operation reached `UPDATE_FAILED` during `UPDATE_CONNECTOR_CONFIGURATION`; `INITIALIZE_UPDATE` completed and the validation/finalization steps were cancelled
- Terraform waited for the operation, surfaced the terminal state and AWS error details, and exited with status 1
- AWS rolled the update back; the connector returned to `RUNNING` with the tested configuration value unchanged

Representative redacted output:

```console
Error: waiting for MSK Connect Connector (...) operation (...):
unexpected state 'UPDATE_FAILED', wanted target 'UPDATE_COMPLETE'.
last error: type (UPDATE_CONNECTOR_CONFIGURATION), state (UPDATE_FAILED),
error code (KafkaConnect.InternalServerError),
steps (INITIALIZE_UPDATE=COMPLETED,
UPDATE_CONNECTOR_CONFIGURATION=FAILED,
VALIDATE_UPDATE=CANCELLED,
FINALIZE_UPDATE=CANCELLED)
```

The same environment had previously demonstrated the bug with the released provider: Terraform reported the update as successful even though AWS rolled it back, and the next plan proposed the same change again. The live canary confirms that this PR converts that false success into the expected Terraform failure.

```console
% make test PKG=kafkaconnect
make: Running unit tests on branch: 🌿 b-mskconnect-connector-operation-state 🌿...
Testing single service: kafkaconnect
Testing with -parallel 10
ok  github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect  10.300s
```

Additional local verification:

```console
% go1.26.6 build -o /tmp/terraform-provider-aws-48199 .

% make golangci-lint1 TEST=./internal/service/kafkaconnect/...
0 issues.

% make import-lint TEST=./internal/service/kafkaconnect/...

% make semgrep-code-quality PKG=kafkaconnect
Ran 195 rules on 20 files: 0 findings.

% make semgrep-constants PKG=kafkaconnect
Ran 267 rules on 20 files: 0 findings.
```

`make quick-fix PKG=kafkaconnect` completed copyright, gofmt, acceptance-test formatting, and goimports before the repository's `modern-fix` target failed because its pinned `golang.org/x/tools/.../modernize@v0.21.0` package is unavailable. `make build` also reached the repository-wide format check, which currently reports five unchanged upstream files; the direct Go 1.26.6 provider build above passed.
