### PR TITLE
Adds SSH Key Pair for generated tests

### DIFF
--- a/docs/acc-test-generation.md
+++ b/docs/acc-test-generation.md
@@ -158,6 +158,10 @@ To override the common name, set the annotation `@Testing(tlsKeyDomain=<referenc
 For example, the API Gateway v2 Domain Name sets the variable `rName` to `acctest.RandomSubdomain()`
 and sets the annotation `@Testing(tlsKeyDomain=rName)` to reference it.
 
+Some acceptance tests require an SSH public key.
+This can be included by setting the annotation `@Testing(sshKeyPair=true)`.
+The Terraform variable name will be `public_key`.
+
 Some acceptance tests require a TLS ECDSA public key PEM.
 This can be included by setting the annotation `@Testing(tlsEcdsaPublicKeyPem=true)`.
 The Terraform variable name will be `rTlsEcdsaPublicKeyPem`.

--- a/internal/generate/identitytests/resource_test.go.gtpl
+++ b/internal/generate/identitytests/resource_test.go.gtpl
@@ -162,7 +162,7 @@ ImportPlanChecks: resource.ImportPlanChecks{
 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New({{ .IDAttrDuplicates }}), knownvalue.NotNull()),
 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
 		{{ else if eq (len .IdentityAttributes) 1 -}}
-			{{ if eq .PlannableResourceAction "Replace" -}}
+			{{ if and (eq .PlannableResourceAction "Replace") (eq .Implementation "framework") -}}
 				{{ range .IdentityAttributes -}}
 				plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New({{ or .ResourceAttributeName .Name }})),
 				{{ end -}}
@@ -216,7 +216,7 @@ ImportPlanChecks: resource.ImportPlanChecks{
 				plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), tfknownvalue.AccountID()),
 			{{ end -}}
 		{{ else if eq (len .IdentityAttributes) 1 -}}
-			{{ if eq .PlannableResourceAction "Replace" -}}
+			{{ if and (eq .PlannableResourceAction "Replace") (eq .Implementation "framework") -}}
 				{{ range .IdentityAttributes -}}
 				plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New({{ or .ResourceAttributeName .Name }})),
 				{{ end -}}

--- a/internal/generate/tests/annotations.go
+++ b/internal/generate/tests/annotations.go
@@ -569,6 +569,32 @@ if err != nil {
 		}
 	}
 
+	if attr, ok := args.Keyword["sshKeyPair"]; ok {
+		if _, err := common.ParseBoolAttr("sshKeyPair", attr); err != nil {
+			return err
+		} else {
+			goVarName := "publicKey"
+			tfVarName := "public_key"
+			stuff.GoImports = append(stuff.GoImports,
+				common.GoImport{
+					Path:  "github.com/hashicorp/terraform-plugin-testing/helper/acctest",
+					Alias: "sdkacctest",
+				},
+			)
+			stuff.InitCodeBlocks = append(stuff.InitCodeBlocks, CodeBlock{
+				Code: fmt.Sprintf(`%s, _, err := sdkacctest.RandSSHKeyPair(acctest.DefaultEmailAddress)
+if err != nil {
+	t.Fatalf("error generating random SSH key: %%s", err)
+}
+`, goVarName),
+			})
+			stuff.AdditionalTfVars_[tfVarName] = TFVar{
+				GoVarName: goVarName,
+				Type:      TFVarTypeString,
+			}
+		}
+	}
+
 	if attr, ok := args.Keyword["tlsEcdsaPublicKeyPem"]; ok {
 		if _, err := common.ParseBoolAttr("tlsEcdsaPublicKeyPem", attr); err != nil {
 			return err


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds SSH Key Pair for generated tests

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>