### PR TITLE
resource/aws_dx_gateway_association: Ignore inactive Transit Gateway attachments

### DIFF
--- a/.changelog/49784.txt
+++ b/.changelog/49784.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dx_gateway_association: Fix `too many results` errors when recreating a Transit Gateway association
+```

--- a/internal/service/directconnect/gateway_association_test.go
+++ b/internal/service/directconnect/gateway_association_test.go
@@ -221,6 +221,41 @@ func TestAccDirectConnectGatewayAssociation_basicTransitGatewaySingleAccount(t *
 	})
 }
 
+func TestAccDirectConnectGatewayAssociation_recreateTransitGateway(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_dx_gateway_association.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	rBgpAsn := acctest.RandIntRange(t, 64512, 65534)
+	var ga awstypes.DirectConnectGatewayAssociation
+	var gap awstypes.DirectConnectGatewayAssociationProposal
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DirectConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGatewayAssociationDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGatewayAssociationConfig_basicTransitSingleAccount(rName, rBgpAsn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayAssociationExists(ctx, t, resourceName, &ga, &gap),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrTransitGatewayAttachmentID),
+				),
+			},
+			{
+				Config: testAccGatewayAssociationConfigBase_transitGatewaySingleAccount(rName, rBgpAsn),
+			},
+			{
+				Config: testAccGatewayAssociationConfig_basicTransitSingleAccount(rName, rBgpAsn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGatewayAssociationExists(ctx, t, resourceName, &ga, &gap),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrTransitGatewayAttachmentID),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDirectConnectGatewayAssociation_basicTransitGatewayCrossAccount(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dx_gateway_association.test"
@@ -642,7 +677,7 @@ resource "aws_dx_gateway_association" "test" {
 `)
 }
 
-func testAccGatewayAssociationConfig_basicTransitSingleAccount(rName string, rBgpAsn int) string {
+func testAccGatewayAssociationConfigBase_transitGatewaySingleAccount(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
   name            = %[1]q
@@ -654,7 +689,13 @@ resource "aws_ec2_transit_gateway" "test" {
     Name = %[1]q
   }
 }
+`, rName, rBgpAsn)
+}
 
+func testAccGatewayAssociationConfig_basicTransitSingleAccount(rName string, rBgpAsn int) string {
+	return acctest.ConfigCompose(
+		testAccGatewayAssociationConfigBase_transitGatewaySingleAccount(rName, rBgpAsn),
+		`
 resource "aws_dx_gateway_association" "test" {
   dx_gateway_id         = aws_dx_gateway.test.id
   associated_gateway_id = aws_ec2_transit_gateway.test.id
@@ -664,7 +705,7 @@ resource "aws_dx_gateway_association" "test" {
     "10.255.255.8/30",
   ]
 }
-`, rName, rBgpAsn)
+`)
 }
 
 func testAccGatewayAssociationConfig_basicTransitCrossAccount(rName string, rBgpAsn int) string {

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4905,7 +4905,35 @@ func findTransitGatewayAttachmentByTransitGatewayIDAndDirectConnectGatewayID(ctx
 		},
 	}
 
-	return findTransitGatewayAttachment(ctx, conn, &input)
+	output, err := findTransitGatewayAttachments(ctx, conn, &input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Deleted attachments remain visible after an association is recreated with the same gateways.
+	return findActiveTransitGatewayAttachment(output)
+}
+
+func findActiveTransitGatewayAttachment(attachments []awstypes.TransitGatewayAttachment) (*awstypes.TransitGatewayAttachment, error) {
+	return tfresource.AssertSingleValueResult(tfslices.Filter(attachments, func(v awstypes.TransitGatewayAttachment) bool {
+		return !transitGatewayAttachmentStateIsInactive(v.State)
+	}))
+}
+
+func transitGatewayAttachmentStateIsInactive(state awstypes.TransitGatewayAttachmentState) bool {
+	switch state {
+	case awstypes.TransitGatewayAttachmentStateRollingBack,
+		awstypes.TransitGatewayAttachmentStateDeleting,
+		awstypes.TransitGatewayAttachmentStateDeleted,
+		awstypes.TransitGatewayAttachmentStateFailing,
+		awstypes.TransitGatewayAttachmentStateFailed,
+		awstypes.TransitGatewayAttachmentStateRejecting,
+		awstypes.TransitGatewayAttachmentStateRejected:
+		return true
+	default:
+		return false
+	}
 }
 
 func findTransitGatewayConnect(ctx context.Context, conn *ec2.Client, input *ec2.DescribeTransitGatewayConnectsInput) (*awstypes.TransitGatewayConnect, error) {

--- a/internal/service/ec2/transitgateway_attachment_test.go
+++ b/internal/service/ec2/transitgateway_attachment_test.go
@@ -1,0 +1,165 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestTransitGatewayAttachmentStateIsInactive(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		state        ec2types.TransitGatewayAttachmentState
+		wantInactive bool
+	}{
+		"initiating": {
+			state: ec2types.TransitGatewayAttachmentStateInitiating,
+		},
+		"initiating request": {
+			state: ec2types.TransitGatewayAttachmentStateInitiatingRequest,
+		},
+		"pending acceptance": {
+			state: ec2types.TransitGatewayAttachmentStatePendingAcceptance,
+		},
+		"pending": {
+			state: ec2types.TransitGatewayAttachmentStatePending,
+		},
+		"available": {
+			state: ec2types.TransitGatewayAttachmentStateAvailable,
+		},
+		"modifying": {
+			state: ec2types.TransitGatewayAttachmentStateModifying,
+		},
+		"rolling back": {
+			state:        ec2types.TransitGatewayAttachmentStateRollingBack,
+			wantInactive: true,
+		},
+		"deleting": {
+			state:        ec2types.TransitGatewayAttachmentStateDeleting,
+			wantInactive: true,
+		},
+		"deleted": {
+			state:        ec2types.TransitGatewayAttachmentStateDeleted,
+			wantInactive: true,
+		},
+		"failing": {
+			state:        ec2types.TransitGatewayAttachmentStateFailing,
+			wantInactive: true,
+		},
+		"failed": {
+			state:        ec2types.TransitGatewayAttachmentStateFailed,
+			wantInactive: true,
+		},
+		"rejecting": {
+			state:        ec2types.TransitGatewayAttachmentStateRejecting,
+			wantInactive: true,
+		},
+		"rejected": {
+			state:        ec2types.TransitGatewayAttachmentStateRejected,
+			wantInactive: true,
+		},
+		"unknown": {
+			state: ec2types.TransitGatewayAttachmentState("unknown"),
+		},
+		"empty": {},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := transitGatewayAttachmentStateIsInactive(tc.state); got != tc.wantInactive {
+				t.Errorf("transitGatewayAttachmentStateIsInactive(%q) = %t, want %t", tc.state, got, tc.wantInactive)
+			}
+		})
+	}
+}
+
+func TestFindActiveTransitGatewayAttachment(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attachments []ec2types.TransitGatewayAttachment
+		wantID      string
+		wantError   error
+	}{
+		"selects transitional attachment despite stale teardown attachment": {
+			attachments: []ec2types.TransitGatewayAttachment{
+				{
+					State:                      ec2types.TransitGatewayAttachmentStateDeleting,
+					TransitGatewayAttachmentId: aws.String("tgw-attach-stale"),
+				},
+				{
+					State:                      ec2types.TransitGatewayAttachmentStatePending,
+					TransitGatewayAttachmentId: aws.String("tgw-attach-active"),
+				},
+			},
+			wantID: "tgw-attach-active",
+		},
+		"selects unknown state": {
+			attachments: []ec2types.TransitGatewayAttachment{
+				{
+					State:                      ec2types.TransitGatewayAttachmentState("unknown"),
+					TransitGatewayAttachmentId: aws.String("tgw-attach-unknown"),
+				},
+			},
+			wantID: "tgw-attach-unknown",
+		},
+		"empty": {
+			wantError: tfresource.ErrEmptyResult,
+		},
+		"only inactive attachments": {
+			attachments: []ec2types.TransitGatewayAttachment{
+				{
+					State:                      ec2types.TransitGatewayAttachmentStateDeleted,
+					TransitGatewayAttachmentId: aws.String("tgw-attach-deleted"),
+				},
+				{
+					State:                      ec2types.TransitGatewayAttachmentStateFailed,
+					TransitGatewayAttachmentId: aws.String("tgw-attach-failed"),
+				},
+			},
+			wantError: tfresource.ErrEmptyResult,
+		},
+		"multiple active attachments": {
+			attachments: []ec2types.TransitGatewayAttachment{
+				{
+					State:                      ec2types.TransitGatewayAttachmentStateInitiating,
+					TransitGatewayAttachmentId: aws.String("tgw-attach-initiating"),
+				},
+				{
+					State:                      ec2types.TransitGatewayAttachmentStateAvailable,
+					TransitGatewayAttachmentId: aws.String("tgw-attach-available"),
+				},
+			},
+			wantError: tfresource.ErrTooManyResults,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			attachment, err := findActiveTransitGatewayAttachment(tc.attachments)
+			if tc.wantError != nil {
+				if !errors.Is(err, tc.wantError) {
+					t.Fatalf("findActiveTransitGatewayAttachment() error = %v, want %v", err, tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("findActiveTransitGatewayAttachment() error = %v", err)
+			}
+			if got := aws.ToString(attachment.TransitGatewayAttachmentId); got != tc.wantID {
+				t.Errorf("attachment ID = %q, want %q", got, tc.wantID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No.

### Description

EC2 can retain deleted Transit Gateway attachments after a Direct Connect gateway association is removed. Recreating the association with the same gateways can therefore return multiple attachments and fail refresh with `too many results`.

This change limits the Direct Connect-specific lookup to the single active attachment. It excludes teardown and terminal states while retaining valid transitional states, avoiding the eventual-consistency risk of filtering only for `available`.

Unit tests cover every current SDK attachment state, unknown future states, stale-plus-active selection, and ambiguous results. An acceptance test recreates the association while retaining the same Direct Connect gateway and Transit Gateway.

### Relations

Closes #46716

### References

- [AWS SDK for Go v2 `TransitGatewayAttachmentState` values](https://github.com/aws/aws-sdk-go-v2/blob/d2f2c67af2d7a70a5edd1bc010678afaba18931f/service/ec2/types/enums.go#L12466-L12506)

### Output from Acceptance Testing

```console
% AWS_PROFILE=xxx make t K=directconnect T='TestAccDirectConnectGatewayAssociation_recreateTransitGateway' P=1
=== RUN   TestAccDirectConnectGatewayAssociation_recreateTransitGateway
=== PAUSE TestAccDirectConnectGatewayAssociation_recreateTransitGateway
=== CONT  TestAccDirectConnectGatewayAssociation_recreateTransitGateway
--- PASS: TestAccDirectConnectGatewayAssociation_recreateTransitGateway (866.44s)
PASS
ok  github.com/hashicorp/terraform-provider-aws/internal/service/directconnect  866.608s
```

### Additional Testing
