### PR TITLE
🤖🤖🤖 docs: correct ElastiCache IAM user example

### DIFF
--- a/website/docs/r/elasticache_user.html.markdown
+++ b/website/docs/r/elasticache_user.html.markdown
@@ -27,8 +27,8 @@ resource "aws_elasticache_user" "test" {
 
 ```terraform
 resource "aws_elasticache_user" "test" {
-  user_id       = "testUserId"
-  user_name     = "testUserName"
+  user_id       = "testuserid"
+  user_name     = "testuserid"
   access_string = "on ~* +@all"
   engine        = "redis"
 
@@ -59,7 +59,7 @@ The following arguments are required:
 * `access_string` - (Required) Access permissions string used for this user. See [Specifying Permissions Using an Access String](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.RBAC.html#Access-string) for more details.
 * `engine` - (Required) The current supported values are `redis`, `valkey` (case insensitive).
 * `user_id` - (Required) The ID of the user.
-* `user_name` - (Required) The username of the user.
+* `user_name` - (Required) The username of the user. For IAM authentication, this value must match `user_id`.
 
 The following arguments are optional:
 


### PR DESCRIPTION
## Rollback Plan

Revert this documentation-only change.

## Changes to Security Controls

None.

### Description

Correct the `aws_elasticache_user` IAM authentication example so that `user_id` and `user_name` are identical, as required by ElastiCache.

Document this requirement in the `user_name` argument reference.

### Relations

N/A

### References

AWS documents the following limitation:

> For IAM-enabled ElastiCache users the username and user id properties must be identical.

https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth-iam.html#auth-iam-limits

### Output from Acceptance Testing

Not run; documentation-only change.

### Validation

- `make website-markdown-lint`
- `git diff --check`

### AI Usage

AI assisted with investigating the provider implementation, updating the documentation, and drafting this pull request. The resulting changes were reviewed by the contributor.
