### PR TITLE
r/aws_accountaccess_application: Change schema to match API

### DIFF
--- a/internal/service/accountaccess/application.go
+++ b/internal/service/accountaccess/application.go
@@ -13,12 +13,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/accountaccess"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/accountaccess/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -26,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tfobjectvalidator "github.com/hashicorp/terraform-provider-aws/internal/framework/validators/objectvalidator"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -60,15 +64,7 @@ type applicationResource struct {
 func (r *applicationResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			names.AttrARN:                     framework.ARNAttributeComputedOnly(),
-			"identity_center_application_arn": framework.ARNAttributeComputedOnly(),
-			"identity_center_instance_arn": schema.StringAttribute{
-				CustomType: fwtypes.ARNType,
-				Required:   true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
+			names.AttrARN:     framework.ARNAttributeComputedOnly(),
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 			"tenant_id": schema.StringAttribute{
@@ -79,6 +75,46 @@ func (r *applicationResource) Schema(ctx context.Context, request resource.Schem
 			},
 		},
 		Blocks: map[string]schema.Block{
+			"identity_source": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[identitySourceModel](ctx),
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+					listvalidator.SizeAtLeast(1),
+					listvalidator.SizeAtMost(1),
+				},
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Validators: []validator.Object{
+						tfobjectvalidator.ExactlyOneOfChildren(
+							path.MatchRelative().AtName("identity_center"),
+						),
+					},
+					Blocks: map[string]schema.Block{
+						"identity_center": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.RequiresReplace(),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"application_arn": framework.ARNAttributeComputedOnly(),
+									"instance_arn": schema.StringAttribute{
+										CustomType: fwtypes.ARNType,
+										Required:   true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.RequiresReplace(),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				Delete: true,
@@ -96,16 +132,17 @@ func (r *applicationResource) Create(ctx context.Context, request resource.Creat
 
 	conn := r.Meta().AccountAccessClient(ctx)
 
-	identityCenterInstanceARN := fwflex.StringValueFromFramework(ctx, plan.IdentityCenterInstanceARN)
-	input := &accountaccess.CreateApplicationInput{
-		IdentitySource: &awstypes.IdentitySourceMemberIdentityCenter{
-			Value: awstypes.IdentityCenter{
-				InstanceArn: aws.String(identityCenterInstanceARN),
-			},
-		},
+	var input accountaccess.CreateApplicationInput
+	smerr.AddEnrich(ctx, &response.Diagnostics, fwflex.Expand(ctx, plan, &input))
+	if response.Diagnostics.HasError() {
+		return
 	}
 
-	output, err := conn.CreateApplication(ctx, input)
+	// Additional fields.
+	// Setting tags on CreateApplication does not work. Apply tags after creation.
+	// input.Tags = getTagsIn(ctx)
+
+	output, err := conn.CreateApplication(ctx, &input)
 	// AlreadyCreatedException means an Application already exists for this
 	// IdC instance. Surface a clear, importable error rather than a generic
 	// "ConflictException" so users know the recovery path.
@@ -119,12 +156,11 @@ func (r *applicationResource) Create(ctx context.Context, request resource.Creat
 		return
 	}
 	if err != nil {
-		smerr.AddError(ctx, &response.Diagnostics, err, smerr.ID, identityCenterInstanceARN)
+		smerr.AddError(ctx, &response.Diagnostics, err)
 		return
 	}
 
 	arn := aws.ToString(output.ApplicationArn)
-
 	app, err := waitApplicationCreated(ctx, conn, arn, r.CreateTimeout(ctx, plan.Timeouts))
 	if err != nil {
 		// Set ARN so the resource is tracked even if the waiter timed out;
@@ -143,7 +179,7 @@ func (r *applicationResource) Create(ctx context.Context, request resource.Creat
 	}
 
 	// Set values for unknowns.
-	plan.ARN = fwflex.StringValueToFramework(ctx, arn)
+	plan.ApplicationARN = fwflex.StringValueToFramework(ctx, arn)
 	smerr.AddEnrich(ctx, &response.Diagnostics, r.flatten(ctx, app, &plan))
 	if response.Diagnostics.HasError() {
 		return
@@ -161,7 +197,7 @@ func (r *applicationResource) Read(ctx context.Context, request resource.ReadReq
 
 	conn := r.Meta().AccountAccessClient(ctx)
 
-	arn := fwflex.StringValueFromFramework(ctx, state.ARN)
+	arn := fwflex.StringValueFromFramework(ctx, state.ApplicationARN)
 	app, err := findApplicationByARN(ctx, conn, arn)
 	if retry.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
@@ -190,7 +226,7 @@ func (r *applicationResource) Delete(ctx context.Context, request resource.Delet
 
 	conn := r.Meta().AccountAccessClient(ctx)
 
-	arn := fwflex.StringValueFromFramework(ctx, state.ARN)
+	arn := fwflex.StringValueFromFramework(ctx, state.ApplicationARN)
 	input := accountaccess.DeleteApplicationInput{
 		ApplicationArn: aws.String(arn),
 	}
@@ -211,17 +247,9 @@ func (r *applicationResource) Delete(ctx context.Context, request resource.Delet
 
 func (r *applicationResource) flatten(ctx context.Context, app *accountaccess.GetApplicationOutput, model *applicationResourceModel) diag.Diagnostics { //nolint:unparam
 	var diags diag.Diagnostics
-
-	model.TenantID = fwflex.StringToFramework(ctx, app.TenantId)
-
-	if details, ok := app.IdentitySource.(*awstypes.IdentitySourceDetailsMemberIdentityCenter); ok {
-		model.IdentityCenterApplicationARN = fwflex.StringToFramework(ctx, details.Value.ApplicationArn)
-		model.IdentityCenterInstanceARN = fwflex.StringToFrameworkARN(ctx, details.Value.InstanceArn)
-	}
-
+	diags.Append(fwflex.Flatten(ctx, app, model)...)
 	// The tags returned from GetApplication are not to be trusted.
 	// setTagsOut(ctx, app.Tags)
-
 	return diags
 }
 
@@ -299,11 +327,67 @@ func waitApplicationDeleted(ctx context.Context, conn *accountaccess.Client, arn
 // Account Access Application.
 type applicationResourceModel struct {
 	framework.WithRegionModel
-	ARN                          types.String   `tfsdk:"arn"`
-	IdentityCenterApplicationARN types.String   `tfsdk:"identity_center_application_arn"`
-	IdentityCenterInstanceARN    fwtypes.ARN    `tfsdk:"identity_center_instance_arn"`
-	Tags                         tftags.Map     `tfsdk:"tags"`
-	TagsAll                      tftags.Map     `tfsdk:"tags_all"`
-	TenantID                     types.String   `tfsdk:"tenant_id"`
-	Timeouts                     timeouts.Value `tfsdk:"timeouts"`
+	ApplicationARN types.String                                         `tfsdk:"arn"`
+	IdentitySource fwtypes.ListNestedObjectValueOf[identitySourceModel] `tfsdk:"identity_source"`
+	Tags           tftags.Map                                           `tfsdk:"tags"`
+	TagsAll        tftags.Map                                           `tfsdk:"tags_all"`
+	TenantID       types.String                                         `tfsdk:"tenant_id"`
+	Timeouts       timeouts.Value                                       `tfsdk:"timeouts"`
+}
+
+type identitySourceModel struct {
+	IdentityCenter fwtypes.ListNestedObjectValueOf[identityCenterModel] `tfsdk:"identity_center"`
+}
+
+var (
+	_ fwflex.Expander  = identitySourceModel{}
+	_ fwflex.Flattener = &identitySourceModel{}
+)
+
+func (m *identitySourceModel) Flatten(ctx context.Context, v any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	switch t := v.(type) {
+	case awstypes.IdentitySourceDetailsMemberIdentityCenter:
+		var model identityCenterModel
+		smerr.AddEnrich(ctx, &diags, fwflex.Flatten(ctx, t.Value, &model))
+		if diags.HasError() {
+			return diags
+		}
+		var d diag.Diagnostics
+		m.IdentityCenter, d = fwtypes.NewListNestedObjectValueOfPtr(ctx, &model)
+		smerr.AddEnrich(ctx, &diags, d)
+
+	default:
+		diags.AddError(
+			"Unsupported Type",
+			fmt.Sprintf("identitySourceModel.Flatten: %T", v),
+		)
+	}
+
+	return diags
+}
+
+func (m identitySourceModel) Expand(ctx context.Context) (any, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	switch {
+	case !m.IdentityCenter.IsNull():
+		model, d := m.IdentityCenter.ToPtr(ctx)
+		smerr.AddEnrich(ctx, &diags, d)
+		if diags.HasError() {
+			return nil, diags
+		}
+		var r awstypes.IdentitySourceMemberIdentityCenter
+		smerr.AddEnrich(ctx, &diags, fwflex.Expand(ctx, model, &r.Value))
+		if diags.HasError() {
+			return nil, diags
+		}
+		return &r, diags
+	}
+
+	return nil, diags
+}
+
+type identityCenterModel struct {
+	ApplicationARN types.String `tfsdk:"application_arn"`
+	InstanceARN    fwtypes.ARN  `tfsdk:"instance_arn"`
 }

--- a/internal/service/accountaccess/application_list.go
+++ b/internal/service/accountaccess/application_list.go
@@ -65,7 +65,7 @@ func (l *applicationListResource) List(ctx context.Context, request list.ListReq
 			result := request.NewListResult(ctx)
 			var data applicationResourceModel
 			l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
-				data.ARN = fwflex.StringValueToFramework(ctx, arn)
+				data.ApplicationARN = fwflex.StringValueToFramework(ctx, arn)
 
 				if request.IncludeResource {
 					smerr.AddEnrich(ctx, &result.Diagnostics, l.flatten(ctx, app, &data))

--- a/internal/service/accountaccess/application_list_test.go
+++ b/internal/service/accountaccess/application_list_test.go
@@ -104,7 +104,12 @@ func testAccAccountAccessApplication_List_includeResource(t *testing.T) {
 					tfquerycheck.ExpectIdentityFunc("aws_accountaccess_application.test", identity1.Checks()),
 					querycheck.ExpectResourceKnownValues("aws_accountaccess_application.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), checkApplicationARN),
-						tfquerycheck.KnownValueCheck(tfjsonpath.New("identity_center_application_arn"), knownvalue.NotNull()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("identity_source"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"identity_center": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"application_arn": knownvalue.NotNull(),
+								"instance_arn":    knownvalue.NotNull(),
+							})}),
+						})})),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
 						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
 							acctest.CtKey1: knownvalue.StringExact(acctest.CtValue1),

--- a/internal/service/accountaccess/application_test.go
+++ b/internal/service/accountaccess/application_test.go
@@ -55,8 +55,12 @@ func testAccApplication_basic(t *testing.T) {
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), checkApplicationARN),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("identity_center_application_arn"), knownvalue.NotNull()),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("identity_center_instance_arn"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("identity_source"), knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"identity_center": knownvalue.ListExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"application_arn": knownvalue.NotNull(),
+							"instance_arn":    knownvalue.NotNull(),
+						})}),
+					})})),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("tenant_id"), knownvalue.NotNull()),
 				},

--- a/internal/service/accountaccess/testdata/Application/basic/main_gen.tf
+++ b/internal/service/accountaccess/testdata/Application/basic/main_gen.tf
@@ -5,6 +5,10 @@ data "aws_ssoadmin_instances" "test" {
 }
 
 resource "aws_accountaccess_application" "test" {
-  identity_center_instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  identity_source {
+    identity_center {
+      instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+    }
+  }
 }
 

--- a/internal/service/accountaccess/testdata/Application/list_basic/main.tf
+++ b/internal/service/accountaccess/testdata/Application/list_basic/main.tf
@@ -4,5 +4,9 @@
 data "aws_ssoadmin_instances" "test" {}
 
 resource "aws_accountaccess_application" "test" {
-  identity_center_instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  identity_source {
+    identity_center {
+      instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+    }
+  }
 }

--- a/internal/service/accountaccess/testdata/Application/list_include_resource/main.tf
+++ b/internal/service/accountaccess/testdata/Application/list_include_resource/main.tf
@@ -4,7 +4,11 @@
 data "aws_ssoadmin_instances" "test" {}
 
 resource "aws_accountaccess_application" "test" {
-  identity_center_instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  identity_source {
+    identity_center {
+      instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+    }
+  }
 
   tags = var.resource_tags
 }

--- a/internal/service/accountaccess/testdata/Application/tags/main_gen.tf
+++ b/internal/service/accountaccess/testdata/Application/tags/main_gen.tf
@@ -5,7 +5,11 @@ data "aws_ssoadmin_instances" "test" {
 }
 
 resource "aws_accountaccess_application" "test" {
-  identity_center_instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  identity_source {
+    identity_center {
+      instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+    }
+  }
 
   tags = var.resource_tags
 }

--- a/internal/service/accountaccess/testdata/Application/tagsComputed1/main_gen.tf
+++ b/internal/service/accountaccess/testdata/Application/tagsComputed1/main_gen.tf
@@ -7,7 +7,11 @@ data "aws_ssoadmin_instances" "test" {
 }
 
 resource "aws_accountaccess_application" "test" {
-  identity_center_instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  identity_source {
+    identity_center {
+      instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+    }
+  }
 
   tags = {
     (var.unknownTagKey) = null_resource.test.id

--- a/internal/service/accountaccess/testdata/Application/tagsComputed2/main_gen.tf
+++ b/internal/service/accountaccess/testdata/Application/tagsComputed2/main_gen.tf
@@ -7,7 +7,11 @@ data "aws_ssoadmin_instances" "test" {
 }
 
 resource "aws_accountaccess_application" "test" {
-  identity_center_instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  identity_source {
+    identity_center {
+      instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+    }
+  }
 
   tags = {
     (var.unknownTagKey) = null_resource.test.id

--- a/internal/service/accountaccess/testdata/Application/tags_defaults/main_gen.tf
+++ b/internal/service/accountaccess/testdata/Application/tags_defaults/main_gen.tf
@@ -11,7 +11,11 @@ data "aws_ssoadmin_instances" "test" {
 }
 
 resource "aws_accountaccess_application" "test" {
-  identity_center_instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  identity_source {
+    identity_center {
+      instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+    }
+  }
 
   tags = var.resource_tags
 }

--- a/internal/service/accountaccess/testdata/Application/tags_ignore/main_gen.tf
+++ b/internal/service/accountaccess/testdata/Application/tags_ignore/main_gen.tf
@@ -14,7 +14,11 @@ data "aws_ssoadmin_instances" "test" {
 }
 
 resource "aws_accountaccess_application" "test" {
-  identity_center_instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  identity_source {
+    identity_center {
+      instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+    }
+  }
 
   tags = var.resource_tags
 }

--- a/internal/service/accountaccess/testdata/tmpl/application_basic.gtpl
+++ b/internal/service/accountaccess/testdata/tmpl/application_basic.gtpl
@@ -4,7 +4,11 @@ data "aws_ssoadmin_instances" "test" {
 
 resource "aws_accountaccess_application" "test" {
 {{- template "region" }}
-  identity_center_instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  identity_source {
+    identity_center {
+      instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+    }
+  }
 
 {{- template "tags" . }}
 }

--- a/website/docs/r/accountaccess_application.html.markdown
+++ b/website/docs/r/accountaccess_application.html.markdown
@@ -20,7 +20,11 @@ Manages an AWS Account Access Application bound to an IAM Identity Center instan
 data "aws_ssoadmin_instances" "example" {}
 
 resource "aws_accountaccess_application" "example" {
-  identity_center_instance_arn = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+  identity_source {
+    identity_center {
+      instance_arn = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+    }
+  }
 }
 ```
 
@@ -28,7 +32,11 @@ resource "aws_accountaccess_application" "example" {
 
 ```terraform
 resource "aws_accountaccess_application" "example" {
-  identity_center_instance_arn = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+  identity_source {
+    identity_center {
+      instance_arn = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+    }
+  }
 
   tags = {
     Environment = "production"
@@ -41,21 +49,39 @@ resource "aws_accountaccess_application" "example" {
 
 The following arguments are required:
 
-* `identity_center_instance_arn` - (Required) ARN of the IAM Identity Center instance to bind this Application to. Forces replacement when changed.
+* `identity_source` - (Required) Identity source for the application. Forces replacement when changed. See [`identity_source` Block](#identity_source-block) below.
 
 The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) Map of tags to assign to the Application. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block), tags with matching keys will overwrite those defined at the provider-level.
 
+### `identity_source` Block
+
+Exactly one argument must be configured.
+The `identity_source` block supports:
+
+* `identity_center` - (Optional) IAM Identity Center instance to use as the identity source. See [`identity_center` Block](#identity_center-block) below.
+
+### `identity_center` Block
+
+The `identity_center` block supports:
+
+* `instance_arn` - (Required) ARN of the IAM Identity Center instance.
+
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the Application. Used as the resource ID.
-* `identity_center_application_arn` - ARN of the IAM Identity Center Application that Account Access provisioned for this resource.
 * `tags_all` - Map of tags assigned to the Application, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `tenant_id` - Internal tenant identifier returned by the service.
+
+### `identity_source.identity_center` Block
+
+The `identity_source.identity_center` block exports the following attributes in addition to the arguments above:
+
+* `application_arn` - ARN of the IAM Identity Center application created for this account access manager application.
 
 ## Timeouts
 

--- a/website/docs/r/sesv2_multi_region_endpoint.html.markdown
+++ b/website/docs/r/sesv2_multi_region_endpoint.html.markdown
@@ -56,12 +56,12 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `arn` - ARN of the multi-region endpoint.
 * `endpoint_id` - ID assigned to the multi-region endpoint.
-* `routes` - List of active routes. See [`routes`](#routes) below.
+* `routes` - List of active routes. See [`routes` Block](#routes-block) below.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
-### `routes`
+### `routes` Block
 
-`routes` supports:
+The `routes` block supports:
 
 * `region` - AWS region name for this route.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Change the schema of the as-yet unreleased `aws_accountaccess_application` resource to match the AWS API.
Given that we don't know how this API will evolve, follow the service API.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates  https://github.com/hashicorp/terraform-provider-aws/pull/49551.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
```console
% AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccAccountAccess_serial/^Application$$' PKG=accountaccess
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 td-r/aws_accountaccess_application-schema-match-api 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/accountaccess/... -v -count 1 -parallel 20  -run=TestAccAccountAccess_serial/^Application$ -timeout 360m -vet=off -buildvcs=false
2026/09/02 09:13:07 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 09:13:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAccountAccess_serial
=== PAUSE TestAccAccountAccess_serial
=== CONT  TestAccAccountAccess_serial
=== RUN   TestAccAccountAccess_serial/Application
=== RUN   TestAccAccountAccess_serial/Application/basic
=== RUN   TestAccAccountAccess_serial/Application/disappears
=== RUN   TestAccAccountAccess_serial/Application/tags
=== RUN   TestAccAccountAccess_serial/Application/tags/DefaultTags_updateToResourceOnly
=== RUN   TestAccAccountAccess_serial/Application/tags/DefaultTags_emptyResourceTag
=== RUN   TestAccAccountAccess_serial/Application/tags/ComputedTag_OnUpdate_Replace
=== RUN   TestAccAccountAccess_serial/Application/tags/IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccAccountAccess_serial/Application/tags/basic
=== RUN   TestAccAccountAccess_serial/Application/tags/AddOnUpdate
=== RUN   TestAccAccountAccess_serial/Application/tags/EmptyTag_OnCreate
=== RUN   TestAccAccountAccess_serial/Application/tags/EmptyTag_OnUpdate_Add
=== RUN   TestAccAccountAccess_serial/Application/tags/EmptyTag_OnUpdate_Replace
=== RUN   TestAccAccountAccess_serial/Application/tags/DefaultTags_overlapping
=== RUN   TestAccAccountAccess_serial/Application/tags/DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccAccountAccess_serial/Application/tags/DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccAccountAccess_serial/Application/tags/null
=== RUN   TestAccAccountAccess_serial/Application/tags/DefaultTags_updateToProviderOnly
=== RUN   TestAccAccountAccess_serial/Application/tags/ComputedTag_OnCreate
=== RUN   TestAccAccountAccess_serial/Application/tags/ComputedTag_OnUpdate_Add
=== RUN   TestAccAccountAccess_serial/Application/tags/IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccAccountAccess_serial/Application/tags/EmptyMap
=== RUN   TestAccAccountAccess_serial/Application/tags/DefaultTags_providerOnly
=== RUN   TestAccAccountAccess_serial/Application/tags/DefaultTags_nonOverlapping
=== RUN   TestAccAccountAccess_serial/Application/Identity
=== RUN   TestAccAccountAccess_serial/Application/Identity/basic
=== RUN   TestAccAccountAccess_serial/Application/List_basic
=== RUN   TestAccAccountAccess_serial/Application/List_includeResource
--- PASS: TestAccAccountAccess_serial (1065.56s)
    --- PASS: TestAccAccountAccess_serial/Application (1065.56s)
        --- PASS: TestAccAccountAccess_serial/Application/basic (32.32s)
        --- PASS: TestAccAccountAccess_serial/Application/disappears (28.56s)
        --- PASS: TestAccAccountAccess_serial/Application/tags (911.90s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/DefaultTags_updateToResourceOnly (34.92s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/DefaultTags_emptyResourceTag (36.63s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/ComputedTag_OnUpdate_Replace (40.25s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/IgnoreTags_Overlap_ResourceTag (56.41s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/basic (81.85s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/AddOnUpdate (43.08s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/EmptyTag_OnCreate (43.01s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/EmptyTag_OnUpdate_Add (50.15s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/EmptyTag_OnUpdate_Replace (43.37s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/DefaultTags_overlapping (60.19s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/DefaultTags_nullOverlappingResourceTag (28.18s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/DefaultTags_nullNonOverlappingResourceTag (30.76s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/null (27.48s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/DefaultTags_updateToProviderOnly (44.46s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/ComputedTag_OnCreate (35.47s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/ComputedTag_OnUpdate_Add (41.24s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/IgnoreTags_Overlap_DefaultTag (43.93s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/EmptyMap (34.88s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/DefaultTags_providerOnly (71.39s)
            --- PASS: TestAccAccountAccess_serial/Application/tags/DefaultTags_nonOverlapping (59.23s)
        --- PASS: TestAccAccountAccess_serial/Application/Identity (40.73s)
            --- PASS: TestAccAccountAccess_serial/Application/Identity/basic (35.73s)
        --- PASS: TestAccAccountAccess_serial/Application/List_basic (28.64s)
        --- PASS: TestAccAccountAccess_serial/Application/List_includeResource (34.21s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/accountaccess      1071.266s
```
```
