### PR TITLE
resource/aws_appflow_flow: Add force_delete argument

### DIFF
--- a/.changelog/49799.txt
+++ b/.changelog/49799.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appflow_flow: Add `force_delete` argument
+```

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -56,6 +56,11 @@ func resourceFlow() *schema.Resource {
 					Optional:     true,
 					ValidateFunc: validation.StringMatch(regexache.MustCompile(`[\w!@#\-.?,\s]*`), "must contain only alphanumeric, underscore (_), exclamation point (!), at sign (@), number sign (#), hyphen (-), period (.), question mark (?), comma (,), and whitespace characters"),
 				},
+				names.AttrForceDelete: {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
 				"destination_flow_config": {
 					Type:     schema.TypeList,
 					Required: true,
@@ -1449,7 +1454,8 @@ func resourceFlowDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 
 	log.Printf("[INFO] Deleting AppFlow Flow: %s", d.Get(names.AttrName))
 	input := appflow.DeleteFlowInput{
-		FlowName: aws.String(d.Get(names.AttrName).(string)),
+		FlowName:    aws.String(d.Get(names.AttrName).(string)),
+		ForceDelete: d.Get(names.AttrForceDelete).(bool),
 	}
 	_, err := conn.DeleteFlow(ctx, &input)
 

--- a/internal/service/appflow/flow_test.go
+++ b/internal/service/appflow/flow_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/appflow"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -310,6 +312,67 @@ func TestAccAppFlowFlow_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAppFlowFlow_forceDelete(t *testing.T) {
+	ctx := acctest.Context(t)
+	var flowOutput appflow.DescribeFlowOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_appflow_flow.test"
+	scheduleStartTime := time.Now().UTC().AddDate(0, 0, 1).Format(time.RFC3339)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppFlowServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFlowDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlowConfig_forceDelete(rName, scheduleStartTime, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFlowExists(ctx, t, resourceName, &flowOutput),
+					resource.TestCheckResourceAttr(resourceName, names.AttrForceDelete, acctest.CtFalse),
+					testAccActivateFlow(ctx, t, resourceName),
+				),
+			},
+			{
+				Config:      testAccFlowConfig_base(rName),
+				ExpectError: regexache.MustCompile(`please set forceDelete to true`),
+			},
+			{
+				Config: testAccFlowConfig_forceDelete(rName, scheduleStartTime, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFlowExists(ctx, t, resourceName, &flowOutput),
+					resource.TestCheckResourceAttr(resourceName, names.AttrForceDelete, acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrForceDelete,
+				},
+			},
+		},
+	})
+}
+
+func testAccActivateFlow(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).AppFlowClient(ctx)
+
+		_, err := conn.StartFlow(ctx, &appflow.StartFlowInput{
+			FlowName: aws.String(rs.Primary.Attributes[names.AttrName]),
+		})
+
+		return err
+	}
+}
+
 func TestAccAppFlowFlow_metadataCatalog(t *testing.T) {
 	ctx := acctest.Context(t)
 	var flowOutput appflow.DescribeFlowOutput
@@ -468,6 +531,65 @@ resource "aws_appflow_flow" "test" {
   }
 }
 `, rName, scheduleStartTime),
+	)
+}
+
+func testAccFlowConfig_forceDelete(rName, scheduleStartTime string, forceDelete bool) string {
+	return acctest.ConfigCompose(
+		testAccFlowConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_appflow_flow" "test" {
+  name         = %[1]q
+  force_delete = %[3]t
+
+  source_flow_config {
+    connector_type = "S3"
+    source_connector_properties {
+      s3 {
+        bucket_name   = aws_s3_bucket_policy.test_source.bucket
+        bucket_prefix = "flow"
+      }
+    }
+  }
+
+  destination_flow_config {
+    connector_type = "S3"
+    destination_connector_properties {
+      s3 {
+        bucket_name = aws_s3_bucket_policy.test_destination.bucket
+
+        s3_output_format_config {
+          prefix_config {
+            prefix_type = "PATH"
+          }
+        }
+      }
+    }
+  }
+
+  task {
+    source_fields     = ["testField"]
+    destination_field = "testField"
+    task_type         = "Map"
+
+    connector_operator {
+      s3 = "NO_OP"
+    }
+  }
+
+  trigger_config {
+    trigger_type = "Scheduled"
+
+    trigger_properties {
+      scheduled {
+        data_pull_mode      = "Incremental"
+        schedule_expression = "rate(3hours)"
+        schedule_start_time = %[2]q
+      }
+    }
+  }
+}
+`, rName, scheduleStartTime, forceDelete),
 	)
 }
 

--- a/internal/service/appflow/sweep.go
+++ b/internal/service/appflow/sweep.go
@@ -36,6 +36,7 @@ func sweepInstanceProfile(ctx context.Context, client *conns.AWSClient) ([]sweep
 			d := r.Data(nil)
 			d.SetId(aws.ToString(flow.FlowArn))
 			d.Set(names.AttrName, flow.FlowName)
+			d.Set(names.AttrForceDelete, true)
 
 			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 		}

--- a/website/docs/r/appflow_flow.html.markdown
+++ b/website/docs/r/appflow_flow.html.markdown
@@ -135,6 +135,7 @@ This resource supports the following arguments:
 
 * `description` - (Optional) Description of the flow.
 * `destination_flow_config` - (Required) Configuration that controls how Amazon AppFlow places data in the destination connector. See the `destination_flow_config` Block for details.
+* `force_delete` - (Optional) Whether to force deleting the flow even if it is currently in use. Defaults to `false`.
 * `kms_arn` - (Optional) ARN of the KMS key you provide for encryption. Required if you do not want to use the Amazon AppFlow-managed KMS key. Uses the Amazon AppFlow-managed KMS key when not provided.
 * `metadata_catalog_config` - (Optional) Configuration that determines how Amazon AppFlow catalogs the data that the flow transfers. See the `metadata_catalog_config` Block for details.
 * `name` - (Required) Name of the flow.


### PR DESCRIPTION
- Adds an optional `force_delete` argument to `aws_appflow_flow`, passed through to AppFlow's `DeleteFlow` API `ForceDelete` parameter, so a flow can be deleted while active without first deactivating it. The sweeper is updated to force-delete orphaned flows.
- Acceptance test activates the flow out-of-band via `StartFlow` (since `flow_status` has no Terraform-controllable argument) to verify deletion fails without the flag and succeeds with it, against real AWS.
- Relates to #37501 (adds a `flow_status` argument for activation/deactivation — separate concern from delete-time force, but touches the same underlying `StartFlow`/`StopFlow` mechanism).

**AI Disclosure:** Used Claude Code for creating tests and self-review, during which the sweeper gap was found. Reviewed and tested everything, including a real run against AWS.

**Output from Acceptance Testing:**
```
% make testacc TESTARGS='-run=TestAccAppFlowFlow_forceDelete' PKG=appflow
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.26.6 test ./internal/service/appflow/... -v -count 1 -parallel 20  -run=TestAccAppFlowFlow_forceDelete -timeout 360m
=== RUN   TestAccAppFlowFlow_forceDelete
=== PAUSE TestAccAppFlowFlow_forceDelete
=== CONT  TestAccAppFlowFlow_forceDelete
--- PASS: TestAccAppFlowFlow_forceDelete (43.01s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appflow	53.382s
```