### PR TITLE
Allow for odb_network_arn in vpc_default_route_table schema

### DIFF
--- a/.changelog/49800.txt
+++ b/.changelog/49800.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_default_route_table: Fix missing odb_network_arn in schema
+```

--- a/internal/service/ec2/vpc_default_route_table.go
+++ b/internal/service/ec2/vpc_default_route_table.go
@@ -135,7 +135,6 @@ func resourceDefaultRouteTable() *schema.Resource {
 								Optional:     true,
 								ValidateFunc: verify.ValidARN,
 							},
-
 						},
 					},
 					Set: resourceRouteTableHash,

--- a/internal/service/ec2/vpc_default_route_table.go
+++ b/internal/service/ec2/vpc_default_route_table.go
@@ -130,6 +130,12 @@ func resourceDefaultRouteTable() *schema.Resource {
 								Type:     schema.TypeString,
 								Optional: true,
 							},
+							"odb_network_arn": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+
 						},
 					},
 					Set: resourceRouteTableHash,


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

**no**

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This fixes an issue where if a ODB route was added to a default route table outside of terraform, that future plans will not get an error below due to aws provider adding odb_network_arn in the received api response:

```
terraform init
terraform plan

╷
│ Error: setting route: Invalid address to set: []string{"route", "0", "odb_network_arn"}
│
│   with module.redacted["redacted"].aws_default_route_table.private,
│   on ../../../modules/regional-nogwlb/tables.tf line 47, in resource "aws_default_route_table" "private":
│   47: resource "aws_default_route_table" "private" {
│
╵
╷
│ Error: setting route: Invalid address to set: []string{"route", "0", "odb_network_arn"}
│
│   with module.redacted["redacted"].aws_default_route_table.private,
│   on ../../../modules/regional-nogwlb/tables.tf line 47, in resource "aws_default_route_table" "private":
│   47: resource "aws_default_route_table" "private" {
```

This seems to be caused because the route table having a gatewayid and odbnetwork arn sent back from the aws cli.

```
ec2 describe-route-tables --route-table-ids 'rtb-redacted’ | jq ".RouteTables[0].Routes"


[
  {
    "DestinationCidrBlock": “redacted”,
    "GatewayId": "arn:aws:odb:redacted:redacted:odb-network/odbnet_redacted”,
    "Origin": "CreateRoute",
    "State": "active",
    "OdbNetworkArn": "arn:aws:odb:redacted:redacted:odb-network/odbnet_redacted”
  },
]
```



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #48237 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

I think it relates to [this issue somewhat](https://github.com/hashicorp/terraform-provider-aws/issues/48237)


### Output from Acceptance Testing

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

this is hard for me to test as I cannot run testacc from this corporate laptop, and using odb on my personal AWS requires a odb plan.  I could run make testacc from another non-corporate laptop if required.

Testing using the current released provider I get an error on planning mentioned above.

After building with this change plan completes successfully.  Also regular test for vpc package below.

```
make test PKG=vpc
make: Running unit tests on branch: 🌿 bugfix/odb-route-table-network-arn-tag 🌿...
Testing single service: vpc
Testing with -parallel 10
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        10.358s
```



