### PR TITLE
docs: fix aws_cloudwatch_event_target examples to reference rule name, not id

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -245,7 +245,7 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
 ```terraform
 resource "aws_cloudwatch_event_target" "example" {
   arn  = "${aws_api_gateway_stage.example.execution_arn}/GET"
-  rule = aws_cloudwatch_event_rule.example.id
+  rule = aws_cloudwatch_event_rule.example.name
 
   http_target {
     query_string_parameters = {
@@ -331,7 +331,7 @@ resource "aws_cloudwatch_event_target" "stop_instances" {
 ```terraform
 resource "aws_cloudwatch_event_target" "example" {
   arn  = aws_lambda_function.example.arn
-  rule = aws_cloudwatch_event_rule.example.id
+  rule = aws_cloudwatch_event_rule.example.name
 
   input_transformer {
     input_paths = {
@@ -357,7 +357,7 @@ resource "aws_cloudwatch_event_rule" "example" {
 ```terraform
 resource "aws_cloudwatch_event_target" "example" {
   arn  = aws_lambda_function.example.arn
-  rule = aws_cloudwatch_event_rule.example.id
+  rule = aws_cloudwatch_event_rule.example.name
 
   input_transformer {
     input_paths = {
@@ -465,7 +465,7 @@ resource "aws_cloudwatch_event_rule" "invoke_appsync_mutation" {
 
 resource "aws_cloudwatch_event_target" "invoke_appsync_mutation" {
   arn      = replace(aws_appsync_graphql_api.graphql-api.arn, "apis", "endpoints/graphql-api")
-  rule     = aws_cloudwatch_event_rule.invoke_appsync_mutation.id
+  rule     = aws_cloudwatch_event_rule.invoke_appsync_mutation.name
   role_arn = aws_iam_role.appsync_mutation_role.arn
 
   input_transformer {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None. Documentation-only change.

### Description

The `rule` argument on `aws_cloudwatch_event_target` takes the **name** of the EventBridge rule, per the Argument Reference (`rule` - (Required) The name of the rule you want to add targets to.). Four examples in this page incorrectly referenced `aws_cloudwatch_event_rule.<name>.id` instead of `.name`:

- API Gateway target
- Input Transformer Usage - JSON Object
- Input Transformer Usage - Simple String
- AppSync Usage

This PR fixes all four to reference `.name`, consistent with every other example already on the page.

### Relations

Closes #49798

### References


### Output from Acceptance Testing

N/A — documentation-only change, no code affected.