### PR TITLE
CI: Include error output in smoke tests

### DIFF
--- a/.teamcity/scripts/sanity.sh
+++ b/.teamcity/scripts/sanity.sh
@@ -38,18 +38,21 @@ function tester {
     local pkg=$1
     local tests=$2
 
-    local results
-    results=$(TF_ACC=1 go test ./"${pkg}"/... -v -parallel 4 -run="${tests}" -timeout 60m -count 1 -vet=off -buildvcs=false  2>&1)
-    local exit_code=$?
+    local tmp
+    tmp=$(mktemp)
 
-    echo "${results}"
+    TF_ACC=1 go test ./"${pkg}"/... -v -parallel 4 -run="${tests}" -timeout 60m -count 1 -vet=off -buildvcs=false 2>&1 | tee "${tmp}"
+    local exit_code=${PIPESTATUS[0]}
 
-    if [[ "${results}" == *"text file busy"* ]]; then
+    if grep -qF "text file busy" "${tmp}"; then
+        rm -f "${tmp}"
         echo "FAILED attempt to run tests"
         echo "Trying again..."
         sleep 5
         tester "${pkg}" "${tests}"
     fi
+
+    rm -f "${tmp}"
 
     if [[ "${exit_code}" -ne 0 ]]; then
         exit "${exit_code}"

--- a/.teamcity/scripts/sanity.sh
+++ b/.teamcity/scripts/sanity.sh
@@ -50,6 +50,7 @@ function tester {
         echo "Trying again..."
         sleep 5
         tester "${pkg}" "${tests}"
+        return
     fi
 
     rm -f "${tmp}"

--- a/.teamcity/scripts/sanity.sh
+++ b/.teamcity/scripts/sanity.sh
@@ -41,7 +41,9 @@ function tester {
     local tmp
     tmp=$(mktemp)
 
-    TF_ACC=1 go test ./"${pkg}"/... -v -parallel 4 -run="${tests}" -timeout 60m -count 1 -vet=off -buildvcs=false 2>&1 | tee "${tmp}"
+    # When `-json` flag is set, some error conditions show no output if output is captured and then `echo`ed.
+    # `tee` results to a temp file so that the "text file busy" error case can be handled correctly.
+    TF_ACC=1 go test ./"${pkg}"/... -v -json -parallel 4 -run="${tests}" -timeout 60m -count 1 -vet=off -buildvcs=false 2>&1 | tee "${tmp}"
     local exit_code=${PIPESTATUS[0]}
 
     if grep -qF "text file busy" "${tmp}"; then

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -546,10 +546,6 @@ object Sweeper : BuildType({
 object Sanity : BuildType({
     name = "Sanity"
 
-    params {
-        text("env.GOFLAGS", "-json", display = ParameterDisplay.HIDDEN, readOnly = true)
-    }
-
     vcs {
         root(AbsoluteId(DslContext.getParameter("vcs_root_id")))
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The use of the `-json` flag in smoke tests was causing some error conditions to produce no output other than "Process exited with code 1". Now streams all output to TeamCity
