### PR TITLE
resource/aws_rds_global_cluster: Fix eventual consistency when re-creating

### DIFF
--- a/.changelog/49804.txt
+++ b/.changelog/49804.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_global_cluster: Fix potential eventual consistency error when re-creating resource.
+```

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -515,11 +515,14 @@ func waitGlobalClusterUpdated(ctx context.Context, conn *rds.Client, id string, 
 
 func waitGlobalClusterDeleted(ctx context.Context, conn *rds.Client, id string, timeout time.Duration) (*types.GlobalCluster, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:        []string{globalClusterStatusAvailable, globalClusterStatusDeleting},
-		Target:         []string{},
-		Refresh:        statusGlobalCluster(conn, id),
-		Timeout:        timeout,
-		NotFoundChecks: 1,
+		Pending:                   []string{globalClusterStatusAvailable, globalClusterStatusDeleting},
+		Target:                    []string{},
+		Refresh:                   statusGlobalCluster(conn, id),
+		Timeout:                   timeout,
+		Delay:                     1 * time.Second,
+		MinTimeout:                1 * time.Second,
+		ContinuousTargetOccurence: 2,
+		NotFoundChecks:            1,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -5,12 +5,10 @@ package rds_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
@@ -236,9 +234,13 @@ func TestAccRDSGlobalCluster_deletionProtection(t *testing.T) {
 				Config: testAccGlobalClusterConfig_deletionProtection(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
-					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDeletionProtection, acctest.CtFalse),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -303,9 +305,13 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMinor(t *testing.T) {
 				Config: testAccGlobalClusterConfig_primaryMinorEngineVersionDynamic(rName, tfrds.InstanceEngineAuroraPostgreSQL, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
-					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -343,9 +349,13 @@ func TestAccRDSGlobalCluster_EngineVersion_AuroraMySQL_updateMinor(t *testing.T)
 				Config: testAccGlobalClusterConfig_primaryMinorEngineVersionDynamic(rName, tfrds.InstanceEngineAuroraMySQL, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
-					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -383,9 +393,13 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMajor(t *testing.T) {
 				Config: testAccGlobalClusterConfig_primaryMajorEngineVersionDynamic(rName, tfrds.InstanceEngineAuroraMySQL, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
-					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -429,9 +443,13 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMinorMultiRegion(t *testing.T) 
 				Config: testAccGlobalClusterConfig_engineVersionMinorUpgradeMultiRegionDynamic(rNameGlobal, rNamePrimary, rNameSecondary, tfrds.ClusterEngineAuroraPostgreSQL, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
-					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -466,9 +484,13 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMajorMultiRegion(t *testing.T) 
 				Config: testAccGlobalClusterConfig_engineVersionMajorUpgradeMultiRegionDynamic(rNameGlobal, rNamePrimary, rNameSecondary, tfrds.InstanceEngineAuroraMySQL, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
-					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -767,16 +789,6 @@ func testAccCheckGlobalClusterDestroy(ctx context.Context, t *testing.T) resourc
 			}
 
 			return fmt.Errorf("RDS Global Cluster %s still exists", rs.Primary.ID)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckGlobalClusterNotRecreated(i, j *types.GlobalCluster) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if aws.ToString(i.GlobalClusterArn) != aws.ToString(j.GlobalClusterArn) {
-			return fmt.Errorf("RDS Global Cluster was recreated. got: %s, expected: %s", aws.ToString(i.GlobalClusterArn), aws.ToString(j.GlobalClusterArn))
 		}
 
 		return nil

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -196,9 +196,13 @@ func TestAccRDSGlobalCluster_databaseName(t *testing.T) {
 				Config: testAccGlobalClusterConfig_databaseName(rName, "database2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
-					testAccCheckGlobalClusterRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, "database2"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
 			},
 		},
 	})
@@ -667,9 +671,13 @@ func TestAccRDSGlobalCluster_storageEncrypted(t *testing.T) {
 				Config: testAccGlobalClusterConfig_storageEncrypted(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
-					testAccCheckGlobalClusterRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStorageEncrypted, acctest.CtFalse),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+					},
+				},
 			},
 		},
 	})
@@ -769,16 +777,6 @@ func testAccCheckGlobalClusterNotRecreated(i, j *types.GlobalCluster) resource.T
 	return func(s *terraform.State) error {
 		if aws.ToString(i.GlobalClusterArn) != aws.ToString(j.GlobalClusterArn) {
 			return fmt.Errorf("RDS Global Cluster was recreated. got: %s, expected: %s", aws.ToString(i.GlobalClusterArn), aws.ToString(j.GlobalClusterArn))
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckGlobalClusterRecreated(i, j *types.GlobalCluster) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if aws.ToString(i.GlobalClusterResourceId) == aws.ToString(j.GlobalClusterResourceId) {
-			return errors.New("RDS Global Cluster was not recreated")
 		}
 
 		return nil

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -112,7 +112,7 @@ func TestAccRDSGlobalCluster_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "rds", fmt.Sprintf("global-cluster:%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, ""),
@@ -150,7 +150,7 @@ func TestAccRDSGlobalCluster_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					acctest.CheckSDKResourceDisappears(ctx, t, tfrds.ResourceGlobalCluster(), resourceName),
 				),
@@ -182,7 +182,7 @@ func TestAccRDSGlobalCluster_databaseName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_databaseName(rName, "database1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, "database1"),
 				),
@@ -194,7 +194,7 @@ func TestAccRDSGlobalCluster_databaseName(t *testing.T) {
 			},
 			{
 				Config: testAccGlobalClusterConfig_databaseName(rName, "database2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
 					testAccCheckGlobalClusterRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, "database2"),
@@ -218,7 +218,7 @@ func TestAccRDSGlobalCluster_deletionProtection(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_deletionProtection(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDeletionProtection, acctest.CtTrue),
 				),
@@ -230,7 +230,7 @@ func TestAccRDSGlobalCluster_deletionProtection(t *testing.T) {
 			},
 			{
 				Config: testAccGlobalClusterConfig_deletionProtection(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
 					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDeletionProtection, acctest.CtFalse),
@@ -254,7 +254,7 @@ func TestAccRDSGlobalCluster_engineLifecycleSupport_disabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_engineLifecycleSupport_disabled(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "rds", fmt.Sprintf("global-cluster:%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, ""),
@@ -290,14 +290,14 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMinor(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_primaryMinorEngineVersionDynamic(rName, tfrds.InstanceEngineAuroraPostgreSQL, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.test", "version_actual"),
 				),
 			},
 			{
 				Config: testAccGlobalClusterConfig_primaryMinorEngineVersionDynamic(rName, tfrds.InstanceEngineAuroraPostgreSQL, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
 					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
@@ -330,14 +330,14 @@ func TestAccRDSGlobalCluster_EngineVersion_AuroraMySQL_updateMinor(t *testing.T)
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_primaryMinorEngineVersionDynamic(rName, tfrds.InstanceEngineAuroraMySQL, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.test", "version_actual"),
 				),
 			},
 			{
 				Config: testAccGlobalClusterConfig_primaryMinorEngineVersionDynamic(rName, tfrds.InstanceEngineAuroraMySQL, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
 					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
@@ -370,14 +370,14 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMajor(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_primaryMajorEngineVersionDynamic(rName, tfrds.InstanceEngineAuroraMySQL, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.test", "version_actual"),
 				),
 			},
 			{
 				Config: testAccGlobalClusterConfig_primaryMajorEngineVersionDynamic(rName, tfrds.InstanceEngineAuroraMySQL, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
 					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
@@ -416,14 +416,14 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMinorMultiRegion(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_engineVersionMinorUpgradeMultiRegionDynamic(rNameGlobal, rNamePrimary, rNameSecondary, tfrds.ClusterEngineAuroraPostgreSQL, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.test", "version_actual"),
 				),
 			},
 			{
 				Config: testAccGlobalClusterConfig_engineVersionMinorUpgradeMultiRegionDynamic(rNameGlobal, rNamePrimary, rNameSecondary, tfrds.ClusterEngineAuroraPostgreSQL, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
 					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
@@ -453,14 +453,14 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMajorMultiRegion(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_engineVersionMajorUpgradeMultiRegionDynamic(rNameGlobal, rNamePrimary, rNameSecondary, tfrds.InstanceEngineAuroraMySQL, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.test", "version_actual"),
 				),
 			},
 			{
 				Config: testAccGlobalClusterConfig_engineVersionMajorUpgradeMultiRegionDynamic(rNameGlobal, rNamePrimary, rNameSecondary, tfrds.InstanceEngineAuroraMySQL, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
 					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
@@ -484,7 +484,7 @@ func TestAccRDSGlobalCluster_EngineVersion_auroraMySQL(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_engineVersion(rName, tfrds.InstanceEngineAuroraMySQL),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.default", names.AttrVersion),
 				),
@@ -512,7 +512,7 @@ func TestAccRDSGlobalCluster_EngineVersion_auroraPostgreSQL(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_engineVersion(rName, "aurora-postgresql"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.default", names.AttrVersion),
 				),
@@ -540,7 +540,7 @@ func TestAccRDSGlobalCluster_forceDestroy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_forceDestroy(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrForceDestroy, acctest.CtTrue),
 				),
@@ -564,7 +564,7 @@ func TestAccRDSGlobalCluster_sourceDBClusterIdentifier(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_sourceClusterID(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, "source_db_cluster_identifier", clusterResourceName, names.AttrARN),
 				),
@@ -594,7 +594,7 @@ func TestAccRDSGlobalCluster_SourceDBClusterIdentifier_storageEncrypted(t *testi
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_sourceClusterIDStorageEncrypted(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, "source_db_cluster_identifier", clusterResourceName, names.AttrARN),
 				),
@@ -624,7 +624,7 @@ func TestAccRDSGlobalCluster_SourceDBClusterIdentifier_databaseName(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_sourceClusterIDDatabaseName(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDatabaseName, clusterResourceName, names.AttrDatabaseName),
 				),
@@ -653,7 +653,7 @@ func TestAccRDSGlobalCluster_storageEncrypted(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_storageEncrypted(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStorageEncrypted, acctest.CtTrue),
 				),
@@ -665,7 +665,7 @@ func TestAccRDSGlobalCluster_storageEncrypted(t *testing.T) {
 			},
 			{
 				Config: testAccGlobalClusterConfig_storageEncrypted(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &globalCluster2),
 					testAccCheckGlobalClusterRecreated(&globalCluster1, &globalCluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStorageEncrypted, acctest.CtFalse),
@@ -692,7 +692,7 @@ func TestAccRDSGlobalCluster_SourceDBClusterIdentifier_EngineVersion_updateMajor
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName, engineVersion),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, engineVersion),
 				),
@@ -704,7 +704,7 @@ func TestAccRDSGlobalCluster_SourceDBClusterIdentifier_EngineVersion_updateMajor
 			},
 			{
 				Config: testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName, engineVersionUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, engineVersionUpdated),
 				),


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds continuous occurence when waiting for deletion to prevent potential "already exists" error when re-creating reesource.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc make testacc PKG=rds TESTS='TestAccRDSGlobalCluster_'

--- PASS: TestAccRDSGlobalCluster_forceDestroy (65.35s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_auroraPostgreSQL (78.08s)
--- PASS: TestAccRDSGlobalCluster_engineLifecycleSupport_disabled (78.54s)
--- PASS: TestAccRDSGlobalCluster_Tags_DefaultTags_nullNonOverlappingResourceTag (91.11s)
--- PASS: TestAccRDSGlobalCluster_Tags_DefaultTags_nullOverlappingResourceTag (91.14s)
--- PASS: TestAccRDSGlobalCluster_Tags_DefaultTags_emptyProviderOnlyTag (91.26s)
--- PASS: TestAccRDSGlobalCluster_storageEncrypted (125.62s)
--- PASS: TestAccRDSGlobalCluster_Tags_DefaultTags_updateToProviderOnly (138.25s)
--- PASS: TestAccRDSGlobalCluster_Tags_ComputedTag_OnUpdate_replace (138.62s)
--- PASS: TestAccRDSGlobalCluster_databaseName (103.55s)
--- PASS: TestAccRDSGlobalCluster_disappears (46.67s)
--- PASS: TestAccRDSGlobalCluster_Tags_IgnoreTags_Overlap_resourceTag (185.49s)
--- PASS: TestAccRDSGlobalCluster_basic (49.66s)
--- PASS: TestAccRDSGlobalCluster_deletionProtection (128.00s)
--- PASS: TestAccRDSGlobalCluster_Tags_EmptyTag_OnUpdate_replace (97.86s)
--- PASS: TestAccRDSGlobalCluster_Tags_DefaultTags_emptyResourceTag (59.02s)
--- PASS: TestAccRDSGlobalCluster_Tags_EmptyTag_OnUpdate_add (151.40s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_auroraMySQL (52.42s)
--- PASS: TestAccRDSGlobalCluster_tags (243.05s)
--- PASS: TestAccRDSGlobalCluster_Tags_DefaultTags_nonOverlapping (168.48s)
--- PASS: TestAccRDSGlobalCluster_Tags_DefaultTags_overlapping (169.05s)
--- PASS: TestAccRDSGlobalCluster_Tags_addOnUpdate (92.73s)
--- PASS: TestAccRDSGlobalCluster_sourceDBClusterIdentifier (282.90s)
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_databaseName (282.96s)
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_storageEncrypted (283.55s)
--- PASS: TestAccRDSGlobalCluster_Tags_EmptyTag_onCreate (103.54s)
--- PASS: TestAccRDSGlobalCluster_Tags_DefaultTags_updateToResourceOnly (87.33s)
--- PASS: TestAccRDSGlobalCluster_Tags_ComputedTag_onCreate (58.33s)
--- PASS: TestAccRDSGlobalCluster_Tags_DefaultTags_providerOnly (208.97s)
--- PASS: TestAccRDSGlobalCluster_Tags_emptyMap (77.03s)
--- PASS: TestAccRDSGlobalCluster_Tags_ComputedTag_OnUpdate_add (81.02s)
--- PASS: TestAccRDSGlobalCluster_Tags_null (66.17s)
--- PASS: TestAccRDSGlobalCluster_Tags_IgnoreTags_Overlap_defaultTag (87.33s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMinor (1291.25s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_AuroraMySQL_updateMinor (1544.10s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMajor (1869.13s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMinorMultiRegion (3133.70s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMajorMultiRegion (5032.29s)
--- FAIL: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_EngineVersion_updateMajor (6447.64s)
```

`TestAccRDSGlobalCluster_SourceDBClusterIdentifier_EngineVersion_updateMajor` is a pre-existing failure

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>