### PR TITLE
Sweepers: Some BedRock Agent APIs return `InternalServerException` in unsupported regions

### DIFF
--- a/internal/service/bedrockagent/sweep.go
+++ b/internal/service/bedrockagent/sweep.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagent"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagent/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
@@ -52,6 +55,14 @@ func sweepDataSources(ctx context.Context, client *conns.AWSClient) ([]sweep.Swe
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
+		// The BedRock Agent API returns an InternalServerException in unsupported regions
+		if errs.IsA[*types.InternalServerException](err) {
+			tflog.Warn(ctx, "Skipping sweeper", map[string]any{
+				"skip_reason": "Unsupported region",
+				"error":       err.Error(),
+			})
+			return sweepResources, nil
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/service/bedrockagent/sweep.go
+++ b/internal/service/bedrockagent/sweep.go
@@ -27,7 +27,7 @@ func RegisterSweepers() {
 func sweepAgents(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	input := &bedrockagent.ListAgentsInput{}
 	conn := client.BedrockAgentClient(ctx)
-	sweepResources := make([]sweep.Sweepable, 0)
+	var sweepResources []sweep.Sweepable
 
 	pages := bedrockagent.NewListAgentsPaginator(conn, input)
 	for pages.HasMorePages() {
@@ -49,7 +49,7 @@ func sweepAgents(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepabl
 func sweepDataSources(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	input := &bedrockagent.ListKnowledgeBasesInput{}
 	conn := client.BedrockAgentClient(ctx)
-	sweepResources := make([]sweep.Sweepable, 0)
+	var sweepResources []sweep.Sweepable
 
 	pages := bedrockagent.NewListKnowledgeBasesPaginator(conn, input)
 	for pages.HasMorePages() {
@@ -94,7 +94,7 @@ func sweepDataSources(ctx context.Context, client *conns.AWSClient) ([]sweep.Swe
 func sweepKnowledgeBases(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	input := &bedrockagent.ListKnowledgeBasesInput{}
 	conn := client.BedrockAgentClient(ctx)
-	sweepResources := make([]sweep.Sweepable, 0)
+	var sweepResources []sweep.Sweepable
 
 	pages := bedrockagent.NewListKnowledgeBasesPaginator(conn, input)
 	for pages.HasMorePages() {

--- a/internal/service/bedrockagent/sweep.go
+++ b/internal/service/bedrockagent/sweep.go
@@ -100,6 +100,14 @@ func sweepKnowledgeBases(ctx context.Context, client *conns.AWSClient) ([]sweep.
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
+		// The BedRock Agent API returns an InternalServerException in unsupported regions
+		if errs.IsA[*types.InternalServerException](err) {
+			tflog.Warn(ctx, "Skipping sweeper", map[string]any{
+				"skip_reason": "Unsupported region",
+				"error":       err.Error(),
+			})
+			return sweepResources, nil
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/service/bedrockagent/sweep.go
+++ b/internal/service/bedrockagent/sweep.go
@@ -25,11 +25,10 @@ func RegisterSweepers() {
 }
 
 func sweepAgents(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
-	input := &bedrockagent.ListAgentsInput{}
 	conn := client.BedrockAgentClient(ctx)
 	var sweepResources []sweep.Sweepable
 
-	pages := bedrockagent.NewListAgentsPaginator(conn, input)
+	pages := bedrockagent.NewListAgentsPaginator(conn, &bedrockagent.ListAgentsInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
@@ -47,11 +46,10 @@ func sweepAgents(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepabl
 }
 
 func sweepDataSources(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
-	input := &bedrockagent.ListKnowledgeBasesInput{}
 	conn := client.BedrockAgentClient(ctx)
 	var sweepResources []sweep.Sweepable
 
-	pages := bedrockagent.NewListKnowledgeBasesPaginator(conn, input)
+	pages := bedrockagent.NewListKnowledgeBasesPaginator(conn, &bedrockagent.ListKnowledgeBasesInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
@@ -92,11 +90,10 @@ func sweepDataSources(ctx context.Context, client *conns.AWSClient) ([]sweep.Swe
 }
 
 func sweepKnowledgeBases(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
-	input := &bedrockagent.ListKnowledgeBasesInput{}
 	conn := client.BedrockAgentClient(ctx)
 	var sweepResources []sweep.Sweepable
 
-	pages := bedrockagent.NewListKnowledgeBasesPaginator(conn, input)
+	pages := bedrockagent.NewListKnowledgeBasesPaginator(conn, &bedrockagent.ListKnowledgeBasesInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Some BedRock Agent APIs return `InternalServerException` in unsupported regions. Updates sweepers to skip sweeper.
