### PR TITLE
r/aws_network_interface_attachment: add ena_queue_count

### DIFF
--- a/.changelog/49812.txt
+++ b/.changelog/49812.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_network_interface_attachment: Add `ena_queue_count` argument
+```

--- a/internal/service/ec2/vpc_network_interface_attachment.go
+++ b/internal/service/ec2/vpc_network_interface_attachment.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
@@ -24,6 +26,7 @@ func resourceNetworkInterfaceAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceNetworkInterfaceAttachmentCreate,
 		ReadWithoutTimeout:   resourceNetworkInterfaceAttachmentRead,
+		UpdateWithoutTimeout: resourceNetworkInterfaceAttachmentUpdate,
 		DeleteWithoutTimeout: resourceNetworkInterfaceAttachmentDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -40,6 +43,11 @@ func resourceNetworkInterfaceAttachment() *schema.Resource {
 					Type:     schema.TypeInt,
 					Required: true,
 					ForceNew: true,
+				},
+				"ena_queue_count": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntInSlice([]int{1, 2, 4, 8, 16, 32, 64, 128}),
 				},
 				names.AttrInstanceID: {
 					Type:     schema.TypeString,
@@ -74,6 +82,10 @@ func resourceNetworkInterfaceAttachmentCreate(ctx context.Context, d *schema.Res
 		NetworkInterfaceId: aws.String(d.Get(names.AttrNetworkInterfaceID).(string)),
 		InstanceId:         aws.String(d.Get(names.AttrInstanceID).(string)),
 		DeviceIndex:        aws.Int32(int32(d.Get("device_index").(int))),
+	}
+
+	if v, ok := d.GetOk("ena_queue_count"); ok {
+		input.EnaQueueCount = aws.Int32(int32(v.(int)))
 	}
 
 	if v, ok := d.GetOk("network_card_index"); ok {
@@ -114,12 +126,45 @@ func resourceNetworkInterfaceAttachmentRead(ctx context.Context, d *schema.Resou
 	attachment := eni.Attachment
 	d.Set("attachment_id", attachment.AttachmentId)
 	d.Set("device_index", attachment.DeviceIndex)
+	if _, ok := d.GetOk("ena_queue_count"); ok {
+		d.Set("ena_queue_count", attachment.EnaQueueCount)
+	}
 	d.Set(names.AttrInstanceID, attachment.InstanceId)
 	d.Set("network_card_index", attachment.NetworkCardIndex)
 	d.Set(names.AttrNetworkInterfaceID, eni.NetworkInterfaceId)
 	d.Set(names.AttrStatus, eni.Attachment.Status)
 
 	return diags
+}
+
+func resourceNetworkInterfaceAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Client(ctx)
+
+	if d.HasChange("ena_queue_count") {
+		attachment := &awstypes.NetworkInterfaceAttachmentChanges{
+			AttachmentId: aws.String(d.Id()),
+		}
+
+		if v, ok := d.GetOk("ena_queue_count"); ok {
+			attachment.EnaQueueCount = aws.Int32(int32(v.(int)))
+		} else {
+			attachment.DefaultEnaQueueCount = aws.Bool(true)
+		}
+
+		input := ec2.ModifyNetworkInterfaceAttributeInput{
+			Attachment:         attachment,
+			NetworkInterfaceId: aws.String(d.Get(names.AttrNetworkInterfaceID).(string)),
+		}
+
+		_, err := conn.ModifyNetworkInterfaceAttribute(ctx, &input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "modifying EC2 Network Interface Attachment (%s) ENA queue count: %s", d.Id(), err)
+		}
+	}
+
+	return append(diags, resourceNetworkInterfaceAttachmentRead(ctx, d, meta)...)
 }
 
 func resourceNetworkInterfaceAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/ec2/vpc_network_interface_attachment_test.go
+++ b/internal/service/ec2/vpc_network_interface_attachment_test.go
@@ -53,6 +53,10 @@ func TestAccVPCNetworkInterfaceAttachment_basic(t *testing.T) {
 // Set the environment variable `VPC_NETWORK_INTERFACE_TEST_ENA_QUEUE_COUNT` to run this test.
 func TestAccVPCNetworkInterfaceAttachment_enaQueueCount(t *testing.T) {
 	acctest.SkipIfEnvVarNotSet(t, "VPC_NETWORK_INTERFACE_TEST_ENA_QUEUE_COUNT")
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	ctx := acctest.Context(t)
 	var conf awstypes.NetworkInterface
 	resourceName := "aws_network_interface_attachment.test"

--- a/internal/service/ec2/vpc_network_interface_attachment_test.go
+++ b/internal/service/ec2/vpc_network_interface_attachment_test.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -44,6 +46,70 @@ func TestAccVPCNetworkInterfaceAttachment_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ena-queues.html.
+// This test requires an expensive instance type that supports configurable ENA queue allocation, such as "c6i.4xlarge".
+// Set the environment variable `VPC_NETWORK_INTERFACE_TEST_ENA_QUEUE_COUNT` to run this test.
+func TestAccVPCNetworkInterfaceAttachment_enaQueueCount(t *testing.T) {
+	acctest.SkipIfEnvVarNotSet(t, "VPC_NETWORK_INTERFACE_TEST_ENA_QUEUE_COUNT")
+	ctx := acctest.Context(t)
+	var conf awstypes.NetworkInterface
+	resourceName := "aws_network_interface_attachment.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNetworkInterfaceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCNetworkInterfaceAttachmentConfig_enaQueueCount(rName, "ena_queue_count = 4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkInterfaceExists(ctx, t, "aws_network_interface.test", &conf),
+					resource.TestCheckResourceAttr(resourceName, "ena_queue_count", "4"),
+					testAccCheckNetworkInterfaceAttachmentEnaQueueCount(&conf, 4),
+				),
+			},
+			{
+				Config: testAccVPCNetworkInterfaceAttachmentConfig_enaQueueCount(rName, "ena_queue_count = 16"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkInterfaceExists(ctx, t, "aws_network_interface.test", &conf),
+					resource.TestCheckResourceAttr(resourceName, "ena_queue_count", "16"),
+					testAccCheckNetworkInterfaceAttachmentEnaQueueCount(&conf, 16),
+				),
+			},
+			{
+				Config: testAccVPCNetworkInterfaceAttachmentConfig_enaQueueCount(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkInterfaceExists(ctx, t, "aws_network_interface.test", &conf),
+					resource.TestCheckResourceAttr(resourceName, "ena_queue_count", "0"),
+					testAccCheckNetworkInterfaceAttachmentEnaQueueCount(&conf, 0),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ena_queue_count"},
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkInterfaceAttachmentEnaQueueCount(conf *awstypes.NetworkInterface, expected int32) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		if conf.Attachment == nil {
+			return fmt.Errorf("network interface attachment not found")
+		}
+
+		if got := aws.ToInt32(conf.Attachment.EnaQueueCount); got != expected {
+			return fmt.Errorf("expected ENA queue count %d, got %d", expected, got)
+		}
+
+		return nil
+	}
 }
 
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#network-cards.
@@ -145,6 +211,78 @@ resource "aws_network_interface_attachment" "test" {
   network_interface_id = aws_network_interface.test.id
 }
 `, rName))
+}
+
+func testAccVPCNetworkInterfaceAttachmentConfig_enaQueueCount(rName, enaQueueCount string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.AvailableEC2InstanceTypeForRegion("c6i.4xlarge"),
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "172.16.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "172.16.10.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+  name   = %[1]q
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id       = aws_subnet.test.id
+  private_ips     = ["172.16.10.100"]
+  security_groups = [aws_security_group.test.id]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_instance_state" "test" {
+  instance_id = aws_instance.test.id
+  state       = "stopped"
+}
+
+resource "aws_network_interface_attachment" "test" {
+  device_index         = 1
+  instance_id          = aws_instance.test.id
+  network_interface_id = aws_network_interface.test.id
+  %[2]s
+
+  depends_on = [aws_ec2_instance_state.test]
+}
+`, rName, enaQueueCount))
 }
 
 func testAccVPCNetworkInterfaceAttachmentConfig_networkCardIndex(rName string, networkCardIndex int) string {

--- a/website/docs/r/network_interface_attachment.html.markdown
+++ b/website/docs/r/network_interface_attachment.html.markdown
@@ -28,6 +28,7 @@ This resource supports the following arguments:
 * `instance_id` - (Required) Instance ID to attach.
 * `network_interface_id` - (Required) ENI ID to attach.
 * `device_index` - (Required) Network interface index (int).
+* `ena_queue_count` - (Optional) Number of ENA queues to allocate to the network interface attachment. The value must be a power of two and is limited by the instance type. The instance must be stopped before updating this argument. Removing this argument resets the attachment to the default ENA queue count. For more information, see [ENA queues](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ena-queues.html).
 * `network_card_index` - (Optional) Index of the network card. Specify a value greater than 0 when using multiple network cards, which are supported by [some instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#network-cards). The default is 0.
 
 ## Attribute Reference


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This change only controls ENA queue allocation for an existing network interface attachment and does not modify access controls, security groups, encryption, or logging.

### Description

Add the optional `ena_queue_count` argument to `aws_network_interface_attachment`.

The value is passed to `AttachNetworkInterface` during creation and read from the network interface attachment. Updates use `ModifyNetworkInterfaceAttribute` without replacing the attachment. Removing the argument sends `DefaultEnaQueueCount` to restore EC2's default queue allocation.

The argument accepts the power-of-two values currently supported by EC2. Documentation and acceptance coverage include create, in-place update, reset-to-default, and import behavior.

### Relations

Relates #49810

### References

- [Amazon EC2 User Guide: ENA queues](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ena-queues.html)
- [AWS SDK for Go v2: `AttachNetworkInterfaceInput`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2#AttachNetworkInterfaceInput)
- [AWS SDK for Go v2: `NetworkInterfaceAttachmentChanges`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2/types#NetworkInterfaceAttachmentChanges)

### Output from Acceptance Testing

```console
% TF_ACC=1 VPC_NETWORK_INTERFACE_TEST_ENA_QUEUE_COUNT=1 go test ./internal/service/ec2 -run '^TestAccVPCNetworkInterfaceAttachment_enaQueueCount$' -count=1 -parallel=1 -vet=off -timeout=60m -v
=== RUN   TestAccVPCNetworkInterfaceAttachment_enaQueueCount
=== PAUSE TestAccVPCNetworkInterfaceAttachment_enaQueueCount
=== CONT  TestAccVPCNetworkInterfaceAttachment_enaQueueCount
--- PASS: TestAccVPCNetworkInterfaceAttachment_enaQueueCount (302.16s)
PASS
ok  github.com/hashicorp/terraform-provider-aws/internal/service/ec2  302.328s
```
