### PR TITLE
r/aws_network_interface: add ena_queue_count

### DIFF
--- a/.changelog/49813.txt
+++ b/.changelog/49813.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_network_interface: Add `attachment.ena_queue_count` argument
+```
+
+```release-note:enhancement
+data-source/aws_network_interface: Add `attachment.ena_queue_count` attribute
+```

--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -70,6 +70,11 @@ func resourceNetworkInterface() *schema.Resource {
 								Type:     schema.TypeInt,
 								Required: true,
 							},
+							"ena_queue_count": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntInSlice([]int{1, 2, 4, 8, 16, 32, 64, 128}),
+							},
 							"instance": {
 								Type:     schema.TypeString,
 								Required: true,
@@ -532,6 +537,10 @@ func resourceNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 			DeviceIndex:        aws.Int32(int32(attachment["device_index"].(int))),
 		}
 
+		if v, ok := attachment["ena_queue_count"].(int); ok && v != 0 {
+			input.EnaQueueCount = aws.Int32(int32(v))
+		}
+
 		if v, ok := attachment["network_card_index"]; ok {
 			if v, ok := v.(int); ok {
 				input.NetworkCardIndex = aws.Int32(int32(v))
@@ -594,30 +603,70 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 
 	if d.HasChange("attachment") {
 		oa, na := d.GetChange("attachment")
-
-		if oa != nil && oa.(*schema.Set).Len() > 0 {
-			attachment := oa.(*schema.Set).List()[0].(map[string]any)
-
-			if err := detachNetworkInterface(ctx, conn, d.Id(), attachment["attachment_id"].(string), networkInterfaceDetachedTimeout); err != nil {
-				return sdkdiag.AppendFromErr(diags, err)
-			}
+		os, ns := new(schema.Set), new(schema.Set)
+		if oa != nil {
+			os = oa.(*schema.Set)
+		}
+		if na != nil {
+			ns = na.(*schema.Set)
 		}
 
-		if na != nil && na.(*schema.Set).Len() > 0 {
-			attachment := na.(*schema.Set).List()[0].(map[string]any)
-			input := ec2.AttachNetworkInterfaceInput{
-				NetworkInterfaceId: aws.String(d.Id()),
-				InstanceId:         aws.String(attachment["instance"].(string)),
-				DeviceIndex:        aws.Int32(int32(attachment["device_index"].(int))),
+		if networkInterfaceAttachmentCanUpdateEnaQueueCount(os, ns) {
+			oldAttachment := os.List()[0].(map[string]any)
+			newAttachment := ns.List()[0].(map[string]any)
+			oldEnaQueueCount := networkInterfaceAttachmentIntValue(oldAttachment, "ena_queue_count")
+			newEnaQueueCount := networkInterfaceAttachmentIntValue(newAttachment, "ena_queue_count")
+
+			if oldEnaQueueCount != newEnaQueueCount {
+				attachment := &awstypes.NetworkInterfaceAttachmentChanges{
+					AttachmentId: aws.String(oldAttachment["attachment_id"].(string)),
+				}
+
+				if newEnaQueueCount != 0 {
+					attachment.EnaQueueCount = aws.Int32(int32(newEnaQueueCount))
+				} else {
+					attachment.DefaultEnaQueueCount = aws.Bool(true)
+				}
+
+				input := ec2.ModifyNetworkInterfaceAttributeInput{
+					Attachment:         attachment,
+					NetworkInterfaceId: aws.String(d.Id()),
+				}
+
+				if _, err := conn.ModifyNetworkInterfaceAttribute(ctx, &input); err != nil {
+					return sdkdiag.AppendErrorf(diags, "modifying EC2 Network Interface (%s) attachment ENA queue count: %s", d.Id(), err)
+				}
 			}
-			if v, ok := attachment["network_card_index"]; ok {
-				if v, ok := v.(int); ok {
-					input.NetworkCardIndex = aws.Int32(int32(v))
+		} else {
+			if os.Len() > 0 {
+				attachment := os.List()[0].(map[string]any)
+
+				if err := detachNetworkInterface(ctx, conn, d.Id(), attachment["attachment_id"].(string), networkInterfaceDetachedTimeout); err != nil {
+					return sdkdiag.AppendFromErr(diags, err)
 				}
 			}
 
-			if _, err := attachNetworkInterface(ctx, conn, &input); err != nil {
-				return sdkdiag.AppendFromErr(diags, err)
+			if ns.Len() > 0 {
+				attachment := ns.List()[0].(map[string]any)
+				input := ec2.AttachNetworkInterfaceInput{
+					NetworkInterfaceId: aws.String(d.Id()),
+					InstanceId:         aws.String(attachment["instance"].(string)),
+					DeviceIndex:        aws.Int32(int32(attachment["device_index"].(int))),
+				}
+
+				if v, ok := attachment["ena_queue_count"].(int); ok && v != 0 {
+					input.EnaQueueCount = aws.Int32(int32(v))
+				}
+
+				if v, ok := attachment["network_card_index"]; ok {
+					if v, ok := v.(int); ok {
+						input.NetworkCardIndex = aws.Int32(int32(v))
+					}
+				}
+
+				if _, err := attachNetworkInterface(ctx, conn, &input); err != nil {
+					return sdkdiag.AppendFromErr(diags, err)
+				}
 			}
 		}
 	}
@@ -1252,6 +1301,10 @@ func flattenNetworkInterfaceAttachment(apiObject *awstypes.NetworkInterfaceAttac
 		tfMap["device_index"] = aws.ToInt32(v)
 	}
 
+	if v := apiObject.EnaQueueCount; v != nil {
+		tfMap["ena_queue_count"] = aws.ToInt32(v)
+	}
+
 	if v := apiObject.InstanceId; v != nil {
 		tfMap["instance"] = aws.ToString(v)
 	}
@@ -1261,6 +1314,36 @@ func flattenNetworkInterfaceAttachment(apiObject *awstypes.NetworkInterfaceAttac
 	}
 
 	return tfMap
+}
+
+func networkInterfaceAttachmentCanUpdateEnaQueueCount(oldAttachments, newAttachments *schema.Set) bool {
+	if oldAttachments.Len() != 1 || newAttachments.Len() != 1 {
+		return false
+	}
+
+	oldAttachment := oldAttachments.List()[0].(map[string]any)
+	newAttachment := newAttachments.List()[0].(map[string]any)
+
+	return oldAttachment["instance"] == newAttachment["instance"] &&
+		networkInterfaceAttachmentIntValue(oldAttachment, "device_index") == networkInterfaceAttachmentIntValue(newAttachment, "device_index") &&
+		networkInterfaceAttachmentIntValue(oldAttachment, "network_card_index") == networkInterfaceAttachmentIntValue(newAttachment, "network_card_index")
+}
+
+func networkInterfaceAttachmentIntValue(attachment map[string]any, key string) int {
+	if v, ok := attachment[key].(int); ok {
+		return v
+	}
+
+	return 0
+}
+
+func networkInterfaceAttachmentHasEnaQueueCount(v any) bool {
+	attachments, ok := v.(*schema.Set)
+	if !ok || attachments.Len() != 1 {
+		return false
+	}
+
+	return networkInterfaceAttachmentIntValue(attachments.List()[0].(map[string]any), "ena_queue_count") != 0
 }
 
 func expandPrivateIPAddressSpecification(tfString string) *awstypes.PrivateIpAddressSpecification {
@@ -1599,7 +1682,11 @@ func resourceNetworkInterfaceFlatten(ctx context.Context, awsClient *conns.AWSCl
 	ownerID := aws.ToString(eni.OwnerId)
 	d.Set(names.AttrARN, networkInterfaceARN(ctx, awsClient, ownerID, d.Id()))
 	if eni.Attachment != nil {
-		if err := d.Set("attachment", []any{flattenNetworkInterfaceAttachment(eni.Attachment)}); err != nil {
+		attachment := flattenNetworkInterfaceAttachment(eni.Attachment)
+		if !networkInterfaceAttachmentHasEnaQueueCount(d.Get("attachment")) {
+			delete(attachment, "ena_queue_count")
+		}
+		if err := d.Set("attachment", []any{attachment}); err != nil {
 			return fmt.Errorf("setting attachment: %w", err)
 		}
 	} else {

--- a/internal/service/ec2/vpc_network_interface_data_source.go
+++ b/internal/service/ec2/vpc_network_interface_data_source.go
@@ -87,6 +87,10 @@ func dataSourceNetworkInterface() *schema.Resource {
 								Type:     schema.TypeInt,
 								Computed: true,
 							},
+							"ena_queue_count": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
 							names.AttrInstanceID: {
 								Type:     schema.TypeString,
 								Computed: true,
@@ -275,6 +279,10 @@ func flattenNetworkInterfaceAttachmentForDataSource(apiObject *awstypes.NetworkI
 
 	if v := apiObject.DeviceIndex; v != nil {
 		tfMap["device_index"] = aws.ToInt32(v)
+	}
+
+	if v := apiObject.EnaQueueCount; v != nil {
+		tfMap["ena_queue_count"] = aws.ToInt32(v)
 	}
 
 	if v := apiObject.InstanceId; v != nil {

--- a/internal/service/ec2/vpc_network_interface_test.go
+++ b/internal/service/ec2/vpc_network_interface_test.go
@@ -443,6 +443,106 @@ func TestAccVPCNetworkInterface_attachment(t *testing.T) {
 	})
 }
 
+// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ena-queues.html.
+// This test requires an expensive instance type that supports configurable ENA queue allocation, such as "c6i.4xlarge".
+// Set the environment variable `VPC_NETWORK_INTERFACE_TEST_ENA_QUEUE_COUNT` to run this test.
+func TestAccVPCNetworkInterface_attachmentEnaQueueCount(t *testing.T) {
+	acctest.SkipIfEnvVarNotSet(t, "VPC_NETWORK_INTERFACE_TEST_ENA_QUEUE_COUNT")
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	var conf awstypes.NetworkInterface
+	var attachmentID string
+	resourceName := "aws_network_interface.test"
+	dataSourceName := "data.aws_network_interface.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNetworkInterfaceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCNetworkInterfaceConfig_attachmentEnaQueueCount(rName, "ena_queue_count = 4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkInterfaceExists(ctx, t, resourceName, &conf),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "attachment.*", map[string]string{
+						"device_index":    "1",
+						"ena_queue_count": "4",
+					}),
+					resource.TestCheckResourceAttr(dataSourceName, "attachment.0.ena_queue_count", "4"),
+					testAccCheckNetworkInterfaceAttachmentEnaQueueCount(&conf, 4),
+					testAccCheckNetworkInterfaceAttachmentIDStable(&conf, &attachmentID),
+				),
+			},
+			{
+				Config: testAccVPCNetworkInterfaceConfig_attachmentEnaQueueCount(rName, "ena_queue_count = 16"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkInterfaceExists(ctx, t, resourceName, &conf),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "attachment.*", map[string]string{
+						"device_index":    "1",
+						"ena_queue_count": "16",
+					}),
+					resource.TestCheckResourceAttr(dataSourceName, "attachment.0.ena_queue_count", "16"),
+					testAccCheckNetworkInterfaceAttachmentEnaQueueCount(&conf, 16),
+					testAccCheckNetworkInterfaceAttachmentIDStable(&conf, &attachmentID),
+				),
+			},
+			{
+				Config: testAccVPCNetworkInterfaceConfig_attachmentEnaQueueCount(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkInterfaceExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(dataSourceName, "attachment.0.ena_queue_count", "0"),
+					testAccCheckNetworkInterfaceAttachmentEnaQueueCount(&conf, 0),
+					testAccCheckNetworkInterfaceAttachmentIDStable(&conf, &attachmentID),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkInterfaceAttachmentEnaQueueCount(conf *awstypes.NetworkInterface, expected int32) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		if conf.Attachment == nil {
+			return fmt.Errorf("network interface attachment not found")
+		}
+
+		if got := aws.ToInt32(conf.Attachment.EnaQueueCount); got != expected {
+			return fmt.Errorf("expected ENA queue count %d, got %d", expected, got)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNetworkInterfaceAttachmentIDStable(conf *awstypes.NetworkInterface, attachmentID *string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		if conf.Attachment == nil {
+			return fmt.Errorf("network interface attachment not found")
+		}
+
+		got := aws.ToString(conf.Attachment.AttachmentId)
+		if *attachmentID == "" {
+			*attachmentID = got
+			return nil
+		}
+		if got != *attachmentID {
+			return fmt.Errorf("expected network interface attachment ID %s, got %s", *attachmentID, got)
+		}
+
+		return nil
+	}
+}
+
 func TestAccVPCNetworkInterface_enaSrdSpecification(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -1692,6 +1792,65 @@ resource "aws_network_interface" "test" {
   }
 }
 `, rName))
+}
+
+func testAccVPCNetworkInterfaceConfig_attachmentEnaQueueCount(rName, enaQueueCount string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.AvailableEC2InstanceTypeForRegion("c6i.4xlarge"),
+		testAccVPCNetworkInterfaceConfig_baseIPV4(rName),
+		fmt.Sprintf(`
+resource "aws_subnet" "test2" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "172.16.11.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami                         = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type               = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id                   = aws_subnet.test2.id
+  associate_public_ip_address = false
+  private_ip                  = "172.16.11.50"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_instance_state" "test" {
+  instance_id = aws_instance.test.id
+  state       = "stopped"
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id       = aws_subnet.test.id
+  private_ips     = ["172.16.10.100"]
+  security_groups = [aws_security_group.test.id]
+
+  attachment {
+    instance     = aws_instance.test.id
+    device_index = 1
+    %[2]s
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+
+  depends_on = [aws_ec2_instance_state.test]
+}
+
+data "aws_network_interface" "test" {
+  id = aws_network_interface.test.id
+
+  depends_on = [aws_network_interface.test]
+}
+`, rName, enaQueueCount))
 }
 
 func testAccVPCNetworkInterfaceConfig_enaSrdSpecification(rName string, enaSrdEnabled, enaSrdUdpEnabled bool) string {

--- a/internal/service/ec2/vpc_network_interface_test.go
+++ b/internal/service/ec2/vpc_network_interface_test.go
@@ -474,7 +474,7 @@ func TestAccVPCNetworkInterface_attachmentEnaQueueCount(t *testing.T) {
 						"ena_queue_count": "4",
 					}),
 					resource.TestCheckResourceAttr(dataSourceName, "attachment.0.ena_queue_count", "4"),
-					testAccCheckNetworkInterfaceAttachmentEnaQueueCount(&conf, 4),
+					testAccCheckNetworkInterfaceInlineAttachmentEnaQueueCount(&conf, 4),
 					testAccCheckNetworkInterfaceAttachmentIDStable(&conf, &attachmentID),
 				),
 			},
@@ -487,7 +487,7 @@ func TestAccVPCNetworkInterface_attachmentEnaQueueCount(t *testing.T) {
 						"ena_queue_count": "16",
 					}),
 					resource.TestCheckResourceAttr(dataSourceName, "attachment.0.ena_queue_count", "16"),
-					testAccCheckNetworkInterfaceAttachmentEnaQueueCount(&conf, 16),
+					testAccCheckNetworkInterfaceInlineAttachmentEnaQueueCount(&conf, 16),
 					testAccCheckNetworkInterfaceAttachmentIDStable(&conf, &attachmentID),
 				),
 			},
@@ -496,7 +496,7 @@ func TestAccVPCNetworkInterface_attachmentEnaQueueCount(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInterfaceExists(ctx, t, resourceName, &conf),
 					resource.TestCheckResourceAttr(dataSourceName, "attachment.0.ena_queue_count", "0"),
-					testAccCheckNetworkInterfaceAttachmentEnaQueueCount(&conf, 0),
+					testAccCheckNetworkInterfaceInlineAttachmentEnaQueueCount(&conf, 0),
 					testAccCheckNetworkInterfaceAttachmentIDStable(&conf, &attachmentID),
 				),
 			},
@@ -510,7 +510,7 @@ func TestAccVPCNetworkInterface_attachmentEnaQueueCount(t *testing.T) {
 	})
 }
 
-func testAccCheckNetworkInterfaceAttachmentEnaQueueCount(conf *awstypes.NetworkInterface, expected int32) resource.TestCheckFunc {
+func testAccCheckNetworkInterfaceInlineAttachmentEnaQueueCount(conf *awstypes.NetworkInterface, expected int32) resource.TestCheckFunc {
 	return func(*terraform.State) error {
 		if conf.Attachment == nil {
 			return fmt.Errorf("network interface attachment not found")

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -64,6 +64,7 @@ This data source exports the following attributes in addition to the arguments a
 
 * `attachment_id` - ID of the network interface attachment.
 * `device_index` - Device index of the network interface attachment on the instance.
+* `ena_queue_count` - Number of ENA queues allocated to the network interface attachment.
 * `instance_id` - ID of the instance.
 * `instance_owner_id` - AWS account ID of the owner of the instance.
 * `network_card_index` - Index of the network card.

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -78,6 +78,7 @@ The `attachment` block supports the following:
 
 * `instance` - (Required) ID of the instance to attach to.
 * `device_index` - (Required) Integer to define the devices index.
+* `ena_queue_count` - (Optional) Number of ENA queues to allocate to the network interface attachment. The value must be a power of two and is limited by the instance type. The instance must be stopped before updating this argument. Removing this argument resets the attachment to the default ENA queue count. For more information, see [ENA queues](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ena-queues.html).
 * `network_card_index` - (Optional) Index of the network card. Specify a value greater than 0 when using multiple network cards, which are supported by [some instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#network-cards). The default is 0.
 
 ### ENA SRD Specification


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This change exposes and manages ENA queue allocation on a network interface attachment without changing security groups, access controls, encryption, or logging.

### Description

Add `attachment.ena_queue_count` support to `aws_network_interface` and `data.aws_network_interface`.

The resource passes the value while attaching the ENI and uses `ModifyNetworkInterfaceAttribute` when only the queue count changes, preserving the attachment ID instead of detaching and reattaching the interface. Removing the argument restores EC2's default queue allocation. The data source reports the value returned in `NetworkInterfaceAttachment`.

Documentation and acceptance coverage include create, in-place update, reset-to-default, stable attachment identity, data-source readback, and import behavior.

### Relations

Relates #49810

### References

- [Amazon EC2 User Guide: ENA queues](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ena-queues.html)
- [AWS SDK for Go v2: `NetworkInterfaceAttachment`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2/types#NetworkInterfaceAttachment)
- [AWS SDK for Go v2: `NetworkInterfaceAttachmentChanges`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2/types#NetworkInterfaceAttachmentChanges)

### Output from Acceptance Testing

```console
% TF_ACC=1 VPC_NETWORK_INTERFACE_TEST_ENA_QUEUE_COUNT=1 go test ./internal/service/ec2 -run '^TestAccVPCNetworkInterface_attachmentEnaQueueCount$' -count=1 -parallel=1 -vet=off -timeout=60m -v
=== RUN   TestAccVPCNetworkInterface_attachmentEnaQueueCount
=== PAUSE TestAccVPCNetworkInterface_attachmentEnaQueueCount
=== CONT  TestAccVPCNetworkInterface_attachmentEnaQueueCount
--- PASS: TestAccVPCNetworkInterface_attachmentEnaQueueCount (556.52s)
PASS
ok  github.com/hashicorp/terraform-provider-aws/internal/service/ec2  556.691s
```
