### PR TITLE
d/aws_ec2_instance_type: add ENA queue capabilities

### DIFF
--- a/.changelog/49815.txt
+++ b/.changelog/49815.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ec2_instance_type: Add ENA queue capability attributes to `network_cards`
+```

--- a/internal/service/ec2/ec2_instance_type_data_source.go
+++ b/internal/service/ec2/ec2_instance_type_data_source.go
@@ -296,11 +296,27 @@ func dataSourceInstanceType() *schema.Resource {
 					Computed: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
+							"additional_flexible_network_interfaces": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
 							"baseline_bandwidth": {
 								Type:     schema.TypeFloat,
 								Computed: true,
 							},
+							"default_ena_queue_count_per_interface": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
 							"index": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"maximum_ena_queue_count": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"maximum_ena_queue_count_per_interface": {
 								Type:     schema.TypeInt,
 								Computed: true,
 							},
@@ -595,11 +611,15 @@ func dataSourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, met
 		tfList := make([]any, len(v.NetworkCards))
 		for i, v := range v.NetworkCards {
 			tfMap := map[string]any{
-				"baseline_bandwidth": aws.ToFloat64(v.BaselineBandwidthInGbps),
-				"index":              aws.ToInt32(v.NetworkCardIndex),
-				"maximum_interfaces": aws.ToInt32(v.MaximumNetworkInterfaces),
-				"peak_bandwidth":     aws.ToFloat64(v.PeakBandwidthInGbps),
-				"performance":        aws.ToString(v.NetworkPerformance),
+				"additional_flexible_network_interfaces": aws.ToInt32(v.AdditionalFlexibleNetworkInterfaces),
+				"baseline_bandwidth":                     aws.ToFloat64(v.BaselineBandwidthInGbps),
+				"default_ena_queue_count_per_interface":  aws.ToInt32(v.DefaultEnaQueueCountPerInterface),
+				"index":                                  aws.ToInt32(v.NetworkCardIndex),
+				"maximum_ena_queue_count":                aws.ToInt32(v.MaximumEnaQueueCount),
+				"maximum_ena_queue_count_per_interface":  aws.ToInt32(v.MaximumEnaQueueCountPerInterface),
+				"maximum_interfaces":                     aws.ToInt32(v.MaximumNetworkInterfaces),
+				"peak_bandwidth":                         aws.ToFloat64(v.PeakBandwidthInGbps),
+				"performance":                            aws.ToString(v.NetworkPerformance),
 			}
 			tfList[i] = tfMap
 		}

--- a/internal/service/ec2/ec2_instance_type_data_source_test.go
+++ b/internal/service/ec2/ec2_instance_type_data_source_test.go
@@ -94,6 +94,30 @@ func TestAccEC2InstanceTypeDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccEC2InstanceTypeDataSource_enaQueueCapabilities(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ec2_instance_type.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceTypeDataSourceConfig_enaQueueCapabilities,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrInstanceType, "c6i.4xlarge"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_cards.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_cards.0.additional_flexible_network_interfaces"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_cards.0.default_ena_queue_count_per_interface", "8"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_cards.0.maximum_ena_queue_count", "64"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_cards.0.maximum_ena_queue_count_per_interface", "16"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEC2InstanceTypeDataSource_metal(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ec2_instance_type.test"
@@ -233,6 +257,12 @@ func TestAccEC2InstanceTypeDataSource_media_accelerator(t *testing.T) {
 		},
 	})
 }
+
+const testAccInstanceTypeDataSourceConfig_enaQueueCapabilities = `
+data "aws_ec2_instance_type" "test" {
+  instance_type = "c6i.4xlarge"
+}
+`
 
 const testAccInstanceTypeDataSourceConfig_basic = `
 data "aws_ec2_instance_type" "test" {

--- a/website/docs/d/ec2_instance_type.html.markdown
+++ b/website/docs/d/ec2_instance_type.html.markdown
@@ -92,9 +92,13 @@ This data source exports the following attributes in addition to the arguments a
     * `media_accelerators.#.name` - The name of the media accelerator.
 * `memory_size` - Size of the instance memory, in MiB.
 * `network_cards` - Describes the network cards for the instance type.
+    * `network_cards.#.additional_flexible_network_interfaces` - Number of additional network interfaces supported when using flexible ENA queue allocation.
     * `network_cards.#.baseline_bandwidth` - The baseline network performance (in Gbps) of the network card.
+    * `network_cards.#.default_ena_queue_count_per_interface` - Default number of ENA queues allocated to each network interface.
     * `network_cards.#.index` - The index of the network card.
-    * `network_cards.#.maximum_interfaces` - The maximum number of network interfaces for the /network card.
+    * `network_cards.#.maximum_ena_queue_count` - Maximum total number of ENA queues supported by the network card.
+    * `network_cards.#.maximum_ena_queue_count_per_interface` - Maximum number of ENA queues supported by each network interface.
+    * `network_cards.#.maximum_interfaces` - The maximum number of network interfaces for the network card.
     * `network_cards.#.performance` - Describes the network performance of the network card.
     * `network_cards.#.peak_bandwidth` - The peak (burst) network performance (in Gbps) of the network card.
 * `network_performance` - Describes the network performance.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This data-source-only change reports EC2 instance-type network capabilities and does not modify any AWS resource or security control.

### Description

Expose EC2 configurable ENA queue capabilities in each `data.aws_ec2_instance_type.network_cards` element:

- `additional_flexible_network_interfaces`
- `default_ena_queue_count_per_interface`
- `maximum_ena_queue_count`
- `maximum_ena_queue_count_per_interface`

These values come directly from the EC2 `NetworkCardInfo` response and allow configurations to discover valid queue allocations for an instance type.

### Relations

Relates #49810

### References

- [Amazon EC2 User Guide: ENA queues](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ena-queues.html)
- [AWS SDK for Go v2: `NetworkCardInfo`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2/types#NetworkCardInfo)
- [EC2 `NetworkCardInfo` API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_NetworkCardInfo.html)

### Output from Acceptance Testing

```console
% TF_ACC=1 go test ./internal/service/ec2 -run '^TestAccEC2InstanceTypeDataSource_enaQueueCapabilities$' -count=1 -parallel=1 -vet=off -timeout=30m -v
=== RUN   TestAccEC2InstanceTypeDataSource_enaQueueCapabilities
=== PAUSE TestAccEC2InstanceTypeDataSource_enaQueueCapabilities
=== CONT  TestAccEC2InstanceTypeDataSource_enaQueueCapabilities
--- PASS: TestAccEC2InstanceTypeDataSource_enaQueueCapabilities (16.30s)
PASS
ok  github.com/hashicorp/terraform-provider-aws/internal/service/ec2  16.476s
```
