### PR TITLE
[chore] Fix aws_vpclattice_domain_verification CI Failures by running suite serially

### DIFF
--- a/internal/service/vpclattice/domain_verification.go
+++ b/internal/service/vpclattice/domain_verification.go
@@ -34,6 +34,7 @@ import (
 // @FrameworkResource("aws_vpclattice_domain_verification", name="Domain Verification")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/vpclattice;vpclattice.GetDomainVerificationOutput")
+// @Testing(serialize=true)
 func newDomainVerificationResource(context.Context) (resource.ResourceWithConfigure, error) {
 	return &domainVerificationResource{}, nil
 }

--- a/internal/service/vpclattice/domain_verification_tags_gen_test.go
+++ b/internal/service/vpclattice/domain_verification_tags_gen_test.go
@@ -20,14 +20,43 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVPCLatticeDomainVerification_tags(t *testing.T) {
+func testAccVPCLatticeDomainVerification_tagsSerial(t *testing.T) {
+	t.Helper()
+
+	testCases := map[string]func(t *testing.T){
+		acctest.CtBasic:                             testAccVPCLatticeDomainVerification_tags,
+		"null":                                      testAccVPCLatticeDomainVerification_Tags_null,
+		"EmptyMap":                                  testAccVPCLatticeDomainVerification_Tags_emptyMap,
+		"AddOnUpdate":                               testAccVPCLatticeDomainVerification_Tags_addOnUpdate,
+		"EmptyTag_OnCreate":                         testAccVPCLatticeDomainVerification_Tags_EmptyTag_onCreate,
+		"EmptyTag_OnUpdate_Add":                     testAccVPCLatticeDomainVerification_Tags_EmptyTag_OnUpdate_add,
+		"EmptyTag_OnUpdate_Replace":                 testAccVPCLatticeDomainVerification_Tags_EmptyTag_OnUpdate_replace,
+		"DefaultTags_providerOnly":                  testAccVPCLatticeDomainVerification_Tags_DefaultTags_providerOnly,
+		"DefaultTags_nonOverlapping":                testAccVPCLatticeDomainVerification_Tags_DefaultTags_nonOverlapping,
+		"DefaultTags_overlapping":                   testAccVPCLatticeDomainVerification_Tags_DefaultTags_overlapping,
+		"DefaultTags_updateToProviderOnly":          testAccVPCLatticeDomainVerification_Tags_DefaultTags_updateToProviderOnly,
+		"DefaultTags_updateToResourceOnly":          testAccVPCLatticeDomainVerification_Tags_DefaultTags_updateToResourceOnly,
+		"DefaultTags_emptyResourceTag":              testAccVPCLatticeDomainVerification_Tags_DefaultTags_emptyResourceTag,
+		"DefaultTags_nullOverlappingResourceTag":    testAccVPCLatticeDomainVerification_Tags_DefaultTags_nullOverlappingResourceTag,
+		"DefaultTags_nullNonOverlappingResourceTag": testAccVPCLatticeDomainVerification_Tags_DefaultTags_nullNonOverlappingResourceTag,
+		"ComputedTag_OnCreate":                      testAccVPCLatticeDomainVerification_Tags_ComputedTag_onCreate,
+		"ComputedTag_OnUpdate_Add":                  testAccVPCLatticeDomainVerification_Tags_ComputedTag_OnUpdate_add,
+		"ComputedTag_OnUpdate_Replace":              testAccVPCLatticeDomainVerification_Tags_ComputedTag_OnUpdate_replace,
+		"IgnoreTags_Overlap_DefaultTag":             testAccVPCLatticeDomainVerification_Tags_IgnoreTags_Overlap_defaultTag,
+		"IgnoreTags_Overlap_ResourceTag":            testAccVPCLatticeDomainVerification_Tags_IgnoreTags_Overlap_resourceTag,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccVPCLatticeDomainVerification_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -206,14 +235,14 @@ func TestAccVPCLatticeDomainVerification_tags(t *testing.T) {
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_null(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -272,14 +301,14 @@ func TestAccVPCLatticeDomainVerification_Tags_null(t *testing.T) {
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_emptyMap(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_emptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -326,14 +355,14 @@ func TestAccVPCLatticeDomainVerification_Tags_emptyMap(t *testing.T) {
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_addOnUpdate(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_addOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -410,14 +439,14 @@ func TestAccVPCLatticeDomainVerification_Tags_addOnUpdate(t *testing.T) {
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_EmptyTag_onCreate(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_EmptyTag_onCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -504,14 +533,14 @@ func TestAccVPCLatticeDomainVerification_Tags_EmptyTag_onCreate(t *testing.T) {
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_EmptyTag_OnUpdate_add(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -647,14 +676,14 @@ func TestAccVPCLatticeDomainVerification_Tags_EmptyTag_OnUpdate_add(t *testing.T
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_EmptyTag_OnUpdate_replace(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -741,14 +770,14 @@ func TestAccVPCLatticeDomainVerification_Tags_EmptyTag_OnUpdate_replace(t *testi
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_providerOnly(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -926,14 +955,14 @@ func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_providerOnly(t *testin
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_nonOverlapping(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -1090,14 +1119,14 @@ func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_nonOverlapping(t *test
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_overlapping(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -1270,14 +1299,14 @@ func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_overlapping(t *testing
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -1364,14 +1393,14 @@ func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_updateToProviderOnly(t
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -1457,14 +1486,14 @@ func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_updateToResourceOnly(t
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_emptyResourceTag(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -1527,14 +1556,14 @@ func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_emptyResourceTag(t *te
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -1589,14 +1618,14 @@ func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_emptyProviderOnlyTag(t
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -1662,14 +1691,14 @@ func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_nullOverlappingResourc
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -1737,14 +1766,14 @@ func TestAccVPCLatticeDomainVerification_Tags_DefaultTags_nullNonOverlappingReso
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_ComputedTag_onCreate(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_ComputedTag_onCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -1796,14 +1825,14 @@ func TestAccVPCLatticeDomainVerification_Tags_ComputedTag_onCreate(t *testing.T)
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_ComputedTag_OnUpdate_add(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -1897,14 +1926,14 @@ func TestAccVPCLatticeDomainVerification_Tags_ComputedTag_OnUpdate_add(t *testin
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_ComputedTag_OnUpdate_replace(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -1988,14 +2017,14 @@ func TestAccVPCLatticeDomainVerification_Tags_ComputedTag_OnUpdate_replace(t *te
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_IgnoreTags_Overlap_defaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},
@@ -2154,14 +2183,14 @@ func TestAccVPCLatticeDomainVerification_Tags_IgnoreTags_Overlap_defaultTag(t *t
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
+func testAccVPCLatticeDomainVerification_Tags_IgnoreTags_Overlap_resourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var v vpclattice.GetDomainVerificationOutput
 	resourceName := "aws_vpclattice_domain_verification.test"
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_1_0),
 		},

--- a/internal/service/vpclattice/domain_verification_test.go
+++ b/internal/service/vpclattice/domain_verification_test.go
@@ -19,14 +19,26 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVPCLatticeDomainVerification_basic(t *testing.T) {
+func TestAccVPCLatticeDomainVerification_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		acctest.CtBasic:      testAccVPCLatticeDomainVerification_basic,
+		acctest.CtDisappears: testAccVPCLatticeDomainVerification_disappears,
+		"tags":               testAccVPCLatticeDomainVerification_tagsSerial,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccVPCLatticeDomainVerification_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainVerification vpclattice.GetDomainVerificationOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	domainName := fmt.Sprintf("%s.example.com", rName)
 	resourceName := "aws_vpclattice_domain_verification.test"
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -54,14 +66,14 @@ func TestAccVPCLatticeDomainVerification_basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCLatticeDomainVerification_disappears(t *testing.T) {
+func testAccVPCLatticeDomainVerification_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domainVerification vpclattice.GetDomainVerificationOutput
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	domainName := fmt.Sprintf("%s.example.com", rName)
 	resourceName := "aws_vpclattice_domain_verification.test"
 
-	acctest.ParallelTest(ctx, t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/vpclattice/sweep.go
+++ b/internal/service/vpclattice/sweep.go
@@ -16,6 +16,7 @@ import (
 )
 
 func RegisterSweepers() {
+	awsv2.Register("aws_vpclattice_domain_verification", sweepDomainVerifications)
 	awsv2.Register("aws_vpclattice_resource_configuration", sweepResourceConfigurations, "aws_vpclattice_service_network_resource_association")
 	awsv2.Register("aws_vpclattice_resource_gateway", sweepResourceGateways, "aws_vpclattice_resource_configuration")
 	awsv2.Register("aws_vpclattice_service", sweepServices)
@@ -23,6 +24,28 @@ func RegisterSweepers() {
 	awsv2.Register("aws_vpclattice_service_network_resource_association", sweepServiceNetworkResourceAssociations)
 	awsv2.Register("aws_vpclattice_target_group", sweepTargetGroups, "aws_vpclattice_target_group_attachment")
 	awsv2.Register("aws_vpclattice_target_group_attachment", sweepTargetGroupAttachments)
+}
+
+func sweepDomainVerifications(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	conn := client.VPCLatticeClient(ctx)
+	input := &vpclattice.ListDomainVerificationsInput{}
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	pages := vpclattice.NewListDomainVerificationsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.Items {
+			sweepResources = append(sweepResources, framework.NewSweepResource(newDomainVerificationResource, client,
+				framework.NewAttribute(names.AttrID, aws.ToString(v.Id))))
+		}
+	}
+
+	return sweepResources, nil
 }
 
 func sweepResourceConfigurations(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Only 5 domain verifications are allowed per account, Running tests serially will allow this tests to pass in CI. Also added a missing sweeper.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=vpclattice T=TestAccVPCLatticeDomainVerification_serial 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	8.718s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	8.816s
make: Running acceptance tests on branch: 🌿 t-textfix-latticedverification 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='TestAccVPCLatticeDomainVerification_serial'  -timeout 360m -vet=off -buildvcs=false
2026/09/02 15:26:44 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 15:26:44 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCLatticeDomainVerification_serial
=== PAUSE TestAccVPCLatticeDomainVerification_serial
=== CONT  TestAccVPCLatticeDomainVerification_serial
=== RUN   TestAccVPCLatticeDomainVerification_serial/basic
=== RUN   TestAccVPCLatticeDomainVerification_serial/disappears
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_overlapping
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/null
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_providerOnly
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/ComputedTag_OnCreate
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/ComputedTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/basic
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/EmptyTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/EmptyTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/ComputedTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/EmptyMap
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/AddOnUpdate
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/EmptyTag_OnCreate
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_nonOverlapping
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_emptyResourceTag
=== RUN   TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccVPCLatticeDomainVerification_serial (719.33s)
    --- PASS: TestAccVPCLatticeDomainVerification_serial/basic (17.17s)
    --- PASS: TestAccVPCLatticeDomainVerification_serial/disappears (14.62s)
    --- PASS: TestAccVPCLatticeDomainVerification_serial/tags (687.54s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_overlapping (50.69s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_updateToResourceOnly (29.33s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/IgnoreTags_Overlap_DefaultTag (38.43s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/IgnoreTags_Overlap_ResourceTag (43.20s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/null (18.24s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_providerOnly (64.43s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_updateToProviderOnly (29.84s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/ComputedTag_OnCreate (22.29s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/ComputedTag_OnUpdate_Add (33.31s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/basic (63.72s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/EmptyTag_OnUpdate_Add (44.66s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/EmptyTag_OnUpdate_Replace (29.53s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_nullOverlappingResourceTag (18.42s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/ComputedTag_OnUpdate_Replace (33.48s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/EmptyMap (18.05s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/AddOnUpdate (29.70s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/EmptyTag_OnCreate (32.72s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_nonOverlapping (49.35s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_emptyResourceTag (19.36s)
        --- PASS: TestAccVPCLatticeDomainVerification_serial/tags/DefaultTags_nullNonOverlappingResourceTag (18.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice	728.283s

...
```
