### PR TITLE
CI: Prevent `errexit` from terminating smoke test script

### DIFF
--- a/.teamcity/scripts/sanity.sh
+++ b/.teamcity/scripts/sanity.sh
@@ -43,8 +43,13 @@ function tester {
 
     # When `-json` flag is set, some error conditions show no output if output is captured and then `echo`ed.
     # `tee` results to a temp file so that the "text file busy" error case can be handled correctly.
+    #
+    # Disable errexit around the pipeline so that a non-zero exit from `go test` does not
+    # abort the script before PIPESTATUS can be read and handled explicitly below.
+    set +e
     TF_ACC=1 go test ./"${pkg}"/... -v -json -parallel 4 -run="${tests}" -timeout 60m -count 1 -vet=off -buildvcs=false 2>&1 | tee "${tmp}"
     local exit_code=${PIPESTATUS[0]}
+    set -e
 
     if grep -qF "text file busy" "${tmp}"; then
         rm -f "${tmp}"


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Prevent `errexit` from terminating smoke test script
