### PR TITLE
Fix: Restore resource policy after body update when managed by aws_api_gateway_rest_api_policy

### DIFF
--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -836,10 +836,15 @@ func resourceRestAPIWithBodyUpdateOperations(d *schema.ResourceData, output *api
 		})
 	}
 
-	// Only re-apply policy after OpenAPI import when policy was configured
-	// explicitly. For Optional+Computed policy, GetOk can be true for a
-	// value that was read from the prior API state.
-	if v, ok := d.GetOk(names.AttrPolicy); ok && resourceRestAPIAttrConfigured(d, names.AttrPolicy) {
+	// Re-apply policy after OpenAPI import when:
+	// (a) policy was explicitly configured on this resource, or
+	// (b) PutRestApi wiped an existing policy — AWS clears the resource policy
+	//     on PutRestApi overwrite when x-amazon-apigateway-policy is absent from
+	//     the body, including policies set by aws_api_gateway_rest_api_policy.
+	// Checking output.Policy prevents re-applying stale state when the body
+	// itself already defines x-amazon-apigateway-policy (that result lands in
+	// output.Policy, making it non-empty).
+	if v, ok := d.GetOk(names.AttrPolicy); ok && (resourceRestAPIAttrConfigured(d, names.AttrPolicy) || aws.ToString(output.Policy) == "") {
 		if equivalent, err := awspolicy.PoliciesAreEquivalent(v.(string), aws.ToString(output.Policy)); err != nil || !equivalent {
 			policy, _ := structure.NormalizeJsonString(v.(string)) // validation covers error
 

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -1527,6 +1527,49 @@ func TestAccAPIGatewayRestAPI_Policy_setByBody(t *testing.T) {
 	})
 }
 
+// Regression test: a body-only update must not wipe a policy managed by
+// aws_api_gateway_rest_api_policy (regression introduced by #48118).
+func TestAccAPIGatewayRestAPI_Policy_setByPolicyResource(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf apigateway.GetRestApiOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_api_gateway_rest_api.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRestAPIConfig_policySetByPolicyResource(rName, "/test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					// aws_api_gateway_rest_api is read before aws_api_gateway_rest_api_policy
+					// runs, so check the policy resource's own attribute here.
+					resource.TestMatchResourceAttr("aws_api_gateway_rest_api_policy.test", names.AttrPolicy, regexache.MustCompile(`"Allow"`)),
+				),
+			},
+			// Body-only update must not wipe the policy set by aws_api_gateway_rest_api_policy.
+			// The inter-step refresh populates aws_api_gateway_rest_api.test.policy from AWS,
+			// which the fix then restores after PutRestApi clears it.
+			{
+				Config: testAccRestAPIConfig_policySetByPolicyResource(rName, "/test2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRESTAPIExists(ctx, t, resourceName, &conf),
+					testAccCheckRestAPIRoutes(ctx, t, &conf, []string{"/", "/test2"}),
+					resource.TestMatchResourceAttr(resourceName, names.AttrPolicy, regexache.MustCompile(`"Allow"`)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("aws_api_gateway_rest_api_policy.test", plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccAPIGatewayRestAPI_Description_updateAttributeAndBody(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -2895,6 +2938,67 @@ resource "aws_api_gateway_rest_api" "test" {
   })
 }
 `, rName, bodyPolicyEffect)
+}
+
+func testAccRestAPIConfig_policySetByPolicyResource(rName string, bodyPath string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
+
+  body = jsonencode({
+    swagger = "2.0"
+    info = {
+      title   = "test"
+      version = "2017-04-20T04:08:08Z"
+    }
+    schemes = ["https"]
+    paths = {
+      %[2]q = {
+        get = {
+          responses = {
+            "200" = {
+              description = "OK"
+            }
+          }
+          x-amazon-apigateway-integration = {
+            httpMethod = "GET"
+            type       = "HTTP"
+            responses = {
+              default = {
+                statusCode = 200
+              }
+            }
+            uri = "https://api.example.com/"
+          }
+        }
+      }
+    }
+  })
+}
+
+resource "aws_api_gateway_rest_api_policy" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "execute-api:Invoke"
+        Condition = {
+          IpAddress = {
+            "aws:SourceIp" = "123.123.123.123/32"
+          }
+        }
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Resource = "*"
+      }
+    ]
+  })
+}
+`, rName, bodyPath)
 }
 
 func testAccRestAPIConfig_failOnWarnings(rName string, title string, failOnWarnings string) string {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls. This fix prevents an unintended security exposure where a resource policy could be briefly wiped during a body-only update.   

### Description

When `aws_api_gateway_rest_api` updates the `body` attribute, it calls `PutRestApi` with overwrite mode, which clears the REST API's resource policy as a side effect even when the policy was not changed. The prior reconciliation logic only re-applied the policy if it was explicitly set on the `aws_api_gateway_rest_api` resource itself. This meant policies managed by a separate `aws_api_gateway_rest_api_policy` resource were permanently wiped after any body-only update.

The fix expands the re-apply condition to also trigger when `PutRestApi` returns an empty policy (`output.Policy == ""`),     restoring the previous policy from state regardless of how it was originally set.

### Relations

Closes #49672

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=apigateway T=TestAccAPIGatewayRestAPI_Policy               
=== RUN   TestAccAPIGatewayRestAPI_Policy_basic
=== PAUSE TestAccAPIGatewayRestAPI_Policy_basic
=== RUN   TestAccAPIGatewayRestAPI_Policy_order
=== PAUSE TestAccAPIGatewayRestAPI_Policy_order
=== RUN   TestAccAPIGatewayRestAPI_Policy_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_Policy_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_Policy_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_Policy_setByBody
=== RUN   TestAccAPIGatewayRestAPI_Policy_setByPolicyResource
=== PAUSE TestAccAPIGatewayRestAPI_Policy_setByPolicyResource
=== CONT  TestAccAPIGatewayRestAPI_Policy_basic
=== CONT  TestAccAPIGatewayRestAPI_Policy_setByBody
=== CONT  TestAccAPIGatewayRestAPI_Policy_overrideBody
=== CONT  TestAccAPIGatewayRestAPI_Policy_order
=== CONT  TestAccAPIGatewayRestAPI_Policy_setByPolicyResource
--- PASS: TestAccAPIGatewayRestAPI_Policy_order (36.18s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_basic (38.07s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_setByPolicyResource (39.50s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_setByBody (66.06s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_overrideBody (147.49s)
PASS
...
```
