### PR TITLE
Feat: msk_cluster client zookeeper access configuration 

### DIFF
--- a/.changelog/99999.txt
+++ b/.changelog/99999.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_msk_cluster: Add `zookeeper_client_access` argument to the `broker_node_group_info.connectivity_info` configuration block
+```

--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
 	"github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -61,6 +62,31 @@ func resourceCluster() *schema.Resource {
 			customdiff.ForceNewIfChange("storage_mode", func(_ context.Context, old, new, meta any) bool {
 				return types.StorageMode(new.(string)) == types.StorageModeLocal
 			}),
+			func(_ context.Context, d *schema.ResourceDiff, meta any) error {
+				// ZooKeeper is not part of the architecture for KRaft or Kafka 4.0+
+				// versions, so zookeeper_client_access cannot be configured.
+				version := d.Get("kafka_version").(string)
+				if version == "" || kafkaVersionHasZooKeeper(version) {
+					return nil
+				}
+
+				raw := d.GetRawConfig()
+				if raw.IsNull() || !raw.IsKnown() {
+					return nil
+				}
+				bngi := raw.GetAttr("broker_node_group_info")
+				if bngi.IsNull() || !bngi.IsKnown() || bngi.LengthInt() == 0 {
+					return nil
+				}
+				ci := bngi.Index(cty.NumberIntVal(0)).GetAttr("connectivity_info")
+				if ci.IsNull() || !ci.IsKnown() || ci.LengthInt() == 0 {
+					return nil
+				}
+				if za := ci.Index(cty.NumberIntVal(0)).GetAttr("zookeeper_client_access"); !za.IsNull() && za.IsKnown() {
+					return fmt.Errorf("broker_node_group_info.0.connectivity_info.0.zookeeper_client_access: ZooKeeper is not part of the cluster architecture for Kafka version %q (KRaft or 4.0+); remove this attribute", version)
+				}
+				return nil
+			},
 		),
 
 		SchemaFunc: func() map[string]*schema.Schema {
@@ -154,6 +180,11 @@ func resourceCluster() *schema.Resource {
 								MaxItems: 1,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
+										"zookeeper_client_access": {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Computed: true,
+										},
 										"network_type": {
 											Type:             schema.TypeString,
 											Optional:         true,
@@ -713,6 +744,37 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 	}
 
+	if v := d.GetRawConfig().GetAttr("broker_node_group_info"); !v.IsNull() && v.IsKnown() && v.LengthInt() > 0 {
+		if ci := v.Index(cty.NumberIntVal(0)).GetAttr("connectivity_info"); !ci.IsNull() && ci.IsKnown() && ci.LengthInt() > 0 {
+			// ZooKeeper client access cannot be set on CreateCluster; it is only
+			// controlled via UpdateConnectivity. Enabled is the AWS default, so only
+			// issue an update when the operator explicitly disables it.
+			if za := ci.Index(cty.NumberIntVal(0)).GetAttr("zookeeper_client_access"); !za.IsNull() && za.IsKnown() && za.False() {
+				input := kafka.UpdateConnectivityInput{
+					ClusterArn:      aws.String(d.Id()),
+					CurrentVersion:  aws.String(d.Get("current_version").(string)),
+					ZookeeperAccess: &types.ZookeeperAccess{Enabled: aws.Bool(false)},
+				}
+
+				output, err := conn.UpdateConnectivity(ctx, &input)
+
+				if err != nil {
+					return sdkdiag.AppendErrorf(diags, "updating MSK Cluster (%s) ZooKeeper client access: %s", d.Id(), err)
+				}
+
+				clusterOperationARN := aws.ToString(output.ClusterOperationArn)
+
+				if _, err := waitClusterOperationCompleted(ctx, conn, clusterOperationARN, d.Timeout(schema.TimeoutCreate)); err != nil {
+					return sdkdiag.AppendErrorf(diags, "waiting for MSK Cluster (%s) operation (%s) complete: %s", d.Id(), clusterOperationARN, err)
+				}
+
+				if err := refreshClusterVersion(ctx, d, meta); err != nil {
+					return sdkdiag.AppendFromErr(diags, err)
+				}
+			}
+		}
+	}
+
 	return append(diags, resourceClusterRead(ctx, d, meta)...)
 }
 
@@ -825,6 +887,33 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating MSK Cluster (%s) broker connectivity: %s", d.Id(), err)
+		}
+
+		clusterOperationARN := aws.ToString(output.ClusterOperationArn)
+
+		if _, err := waitClusterOperationCompleted(ctx, conn, clusterOperationARN, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for MSK Cluster (%s) operation (%s) complete: %s", d.Id(), clusterOperationARN, err)
+		}
+
+		// refresh the current_version attribute after each update
+		if err := refreshClusterVersion(ctx, d, meta); err != nil {
+			return sdkdiag.AppendFromErr(diags, err)
+		}
+	}
+
+	if d.HasChange("broker_node_group_info.0.connectivity_info.0.zookeeper_client_access") {
+		input := kafka.UpdateConnectivityInput{
+			ClusterArn:     aws.String(d.Id()),
+			CurrentVersion: aws.String(d.Get("current_version").(string)),
+			ZookeeperAccess: &types.ZookeeperAccess{
+				Enabled: aws.Bool(d.Get("broker_node_group_info.0.connectivity_info.0.zookeeper_client_access").(bool)),
+			},
+		}
+
+		output, err := conn.UpdateConnectivity(ctx, &input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating MSK Cluster (%s) ZooKeeper client access: %s", d.Id(), err)
 		}
 
 		clusterOperationARN := aws.ToString(output.ClusterOperationArn)
@@ -1184,7 +1273,14 @@ func resourceClusterFlatten(ctx context.Context, cluster *types.ClusterInfo, out
 	d.Set("bootstrap_brokers_sasl_scram_ipv6", sortEndpointsString(aws.ToString(outputGBB.BootstrapBrokerStringSaslScramIpv6)))
 	d.Set("bootstrap_brokers_tls_ipv6", sortEndpointsString(aws.ToString(outputGBB.BootstrapBrokerStringTlsIpv6)))
 	if cluster.BrokerNodeGroupInfo != nil {
-		if err := d.Set("broker_node_group_info", []any{flattenBrokerNodeGroupInfo(cluster.BrokerNodeGroupInfo)}); err != nil {
+		bngi := flattenBrokerNodeGroupInfo(cluster.BrokerNodeGroupInfo)
+		// zookeeper_client_access is not returned by DescribeClusterV2 (the API only
+		// exposes it via a cluster operation's MutableClusterInfo), so preserve the
+		// value already in state to avoid spurious diffs.
+		if ci, ok := bngi["connectivity_info"].([]any); ok && len(ci) > 0 && ci[0] != nil {
+			ci[0].(map[string]any)["zookeeper_client_access"] = d.Get("broker_node_group_info.0.connectivity_info.0.zookeeper_client_access")
+		}
+		if err := d.Set("broker_node_group_info", []any{bngi}); err != nil {
 			return fmt.Errorf("setting broker_node_group_info: %w", err)
 		}
 	} else {
@@ -1485,6 +1581,16 @@ func normalizeKafkaVersion(version string) string { // nosemgrep:ci.kafka-in-fun
 		return version
 	}
 	return version[:loc[0]]
+}
+
+// kafkaVersionHasZooKeeper reports whether the given Kafka version runs with
+// ZooKeeper. KRaft-mode versions (".kraft" suffix) and Kafka 4.0+ do not include
+// ZooKeeper in the architecture.
+func kafkaVersionHasZooKeeper(version string) bool { // nosemgrep:ci.kafka-in-func-name
+	if strings.Contains(strings.ToLower(version), "kraft") {
+		return false
+	}
+	return !semver.GreaterThanOrEqual(normalizeKafkaVersion(version), "4.0")
 }
 
 func expandBrokerNodeGroupInfo(tfMap map[string]any) *types.BrokerNodeGroupInfo {

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -1100,6 +1100,48 @@ func TestAccKafkaCluster_EncryptionInfoEncryptionInTransit_inCluster(t *testing.
 	})
 }
 
+func TestAccKafkaCluster_ZookeeperClientAccess(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster1 types.ClusterInfo
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_msk_cluster.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KafkaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_zookeeperClientAccess(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.zookeeper_client_access", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"current_version",
+					// Not returned by DescribeClusterV2, so it cannot be verified on import.
+					"broker_node_group_info.0.connectivity_info.0.zookeeper_client_access",
+				},
+			},
+			{
+				Config: testAccClusterConfig_zookeeperClientAccess(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.connectivity_info.0.zookeeper_client_access", acctest.CtFalse),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKafkaCluster_enhancedMonitoring(t *testing.T) {
 	ctx := acctest.Context(t)
 	var cluster1, cluster2 types.ClusterInfo
@@ -2058,6 +2100,32 @@ resource "aws_msk_cluster" "test" {
   }
 }
 `, rName))
+}
+
+func testAccClusterConfig_zookeeperClientAccess(rName string, zkClientAccess bool) string {
+	return acctest.ConfigCompose(testAccClusterConfig_base(rName), fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "3.9.x"
+  number_of_broker_nodes = 3
+
+  broker_node_group_info {
+    client_subnets  = aws_subnet.test[*].id
+    instance_type   = "kafka.t3.small"
+    security_groups = [aws_security_group.test.id]
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = 10
+      }
+    }
+
+    connectivity_info {
+      zookeeper_client_access = %[2]t
+    }
+  }
+}
+`, rName, zkClientAccess))
 }
 
 func testAccClusterConfig_brokerNodeGroupInfoPublicAccessSASLIAM(rName string, pa string) string {

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -232,6 +232,7 @@ This resource supports the following arguments:
 * `network_type` - (Optional) Network type of the cluster. Valid values are: `IPV4` or `DUAL`. Default value: `IPV4`. Only updating from `IPV4` to `DUAL` is allowed.
 * `public_access` - (Optional) Access control settings for brokers. See [connectivity_info public_access Argument Reference](#connectivity_info-public_access-argument-reference) below.
 * `vpc_connectivity` - (Optional) VPC connectivity access control for brokers. See [connectivity_info vpc_connectivity Argument Reference](#connectivity_info-vpc_connectivity-argument-reference) below.
+* `zookeeper_client_access` - (Optional) Whether ZooKeeper client access is enabled. Defaults to `true`. Only applicable to Apache Kafka versions that use ZooKeeper. Note that because the value is not returned by the MSK API, it is not refreshed from AWS and cannot be verified on import.
 
 ### connectivity_info public_access Argument Reference
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

This allows disabling client access to the zookeeper backend for MSK clusters using that.

### Description
The current msk_cluster resource has no way to configure the zookeeper client access.

This adds functionality to be able to toggle this setting.

The CreateCluster(V2) API has no property to do this as part of create and DescribeCluster does not return the current value. On testing manually a fresh Zookeeper enabled cluster (so one with a version not suffixed by `.kraft` or less than 4.0.X) has this property enabled. Because of this the assumption is that it is true on creation and we trust tfstate as to whether it needs to be changed, and then maintain our change there.

This does mean that it cannot be picked up on import and manual changes will not show drift, however this is a limitation of the AWS SDK and given this is a one-time change in the process AWS sets out for the Zookeeper to Kraft conversion I feel is an acceptable tradeoff.

AI Disclosure: I added the acceptance test, updated the schema and laid out the logic. Then I made use of OpenCode with the Github Copilot engine and used the Claude Opus 4.8 model to wire in the changes to the Create/Update functions. I have reviewed the generated code and have tested against my own AWS account with the include acceptance test.

This is my first PR to the project and look forward to comments and any changes needed to get this functionality added.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49772

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The intent behind adding this is to be able to carry out step 1 in the published AWS migration steps to convert form Zookeeper to Kraft in an IaC manner.

https://aws.amazon.com/blogs/big-data/announcing-in-place-zookeeper-to-kraft-cluster-upgrades-for-amazon-msk/

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccKafkaCluster_ZookeeperClientAccess PKG=kafka
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	5.469s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	5.427s
make: Running acceptance tests on branch: 🌿 main 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/kafka/... -v -count 1 -parallel 20 -run='TestAccKafkaCluster_ZookeeperClientAccess'  -timeout 360m -vet=off -buildvcs=false
2026/09/02 16:39:37 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 16:39:37 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKafkaCluster_ZookeeperClientAccess
=== PAUSE TestAccKafkaCluster_ZookeeperClientAccess
=== CONT  TestAccKafkaCluster_ZookeeperClientAccess
2026-09-02T16:39:37.211+0100 [INFO]  acctest.aws-base: Retrieved credentials: test_name=TestAccKafkaCluster_ZookeeperClientAccess tf_aws.credentials_source=EnvConfigCredentials
2026-09-02T16:39:37.930+0100 [INFO]  acctest.aws-base: Retrieved caller identity from STS: test_name=TestAccKafkaCluster_ZookeeperClientAccess
2026/09/02 16:39:38 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 16:39:38 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 16:39:38 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 16:39:38 Initializing Terraform AWS Provider (Framework-style)...
2026/09/02 16:39:38 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 16:39:38 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 16:39:38 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 16:39:38 Initializing Terraform AWS Provider (Framework-style)...
2026-09-02T16:39:39.874+0100 [INFO]  aws.aws-base: Retrieved credentials: tf_rpc=ConfigureProvider tf_mux_provider="*schema.GRPCProviderServer" tf_req_id=58a0e881-9029-588c-6543-a77727efe901 tf_aws.credentials_source=EnvConfigCredentials tf_provider_addr=registry.terraform.io/hashicorp/aws
2026-09-02T16:39:40.305+0100 [INFO]  aws.aws-base: Retrieved caller identity from STS: tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider tf_mux_provider="*schema.GRPCProviderServer" tf_req_id=58a0e881-9029-588c-6543-a77727efe901
2026/09/02 16:39:42 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 16:39:42 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 16:39:42 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 16:39:42 Initializing Terraform AWS Provider (Framework-style)...
2026-09-02T16:39:43.563+0100 [INFO]  aws.aws-base: Retrieved credentials: tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider tf_req_id=bd9eb7dc-b53d-e77b-b51e-2eaf49c6d35a tf_mux_provider="*schema.GRPCProviderServer" tf_aws.credentials_source=EnvConfigCredentials
2026-09-02T16:39:43.918+0100 [INFO]  aws.aws-base: Retrieved caller identity from STS: tf_mux_provider="*schema.GRPCProviderServer" tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider tf_req_id=bd9eb7dc-b53d-e77b-b51e-2eaf49c6d35a
2026/09/02 17:10:44 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:44 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:44 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:44 Initializing Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:45 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:45 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:45 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:45 Initializing Terraform AWS Provider (Framework-style)...
2026-09-02T17:10:46.901+0100 [INFO]  aws.aws-base: Retrieved credentials: tf_aws.credentials_source=EnvConfigCredentials tf_rpc=ConfigureProvider tf_req_id=8e88b188-7b11-fbd3-c156-3cca9569ada7 tf_provider_addr=registry.terraform.io/hashicorp/aws tf_mux_provider="*schema.GRPCProviderServer"
2026-09-02T17:10:47.279+0100 [INFO]  aws.aws-base: Retrieved caller identity from STS: tf_provider_addr=registry.terraform.io/hashicorp/aws tf_mux_provider="*schema.GRPCProviderServer" tf_rpc=ConfigureProvider tf_req_id=8e88b188-7b11-fbd3-c156-3cca9569ada7
2026-09-02T17:10:48.828+0100 [WARN]  sdk.helper_schema: unable to require attribute replacement: tf_attribute_path=storage_mode tf_mux_provider="*schema.GRPCProviderServer" tf_rpc=PlanResourceChange tf_resource_type=aws_msk_cluster tf_req_id=23bc5dd8-23f7-d7e1-f7a4-80af663bcc61 tf_provider_addr=registry.terraform.io/hashicorp/aws error="ForceNew: No changes for storage_mode"
2026/09/02 17:10:48 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:48 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:48 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:48 Initializing Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:49 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:49 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:49 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:49 Initializing Terraform AWS Provider (Framework-style)...
2026-09-02T17:10:50.609+0100 [INFO]  aws.aws-base: Retrieved credentials: tf_mux_provider="*schema.GRPCProviderServer" tf_provider_addr=registry.terraform.io/hashicorp/aws tf_aws.credentials_source=EnvConfigCredentials tf_rpc=ConfigureProvider tf_req_id=6c476b2d-240d-26d6-8ca4-6472dd2ac762
2026-09-02T17:10:50.951+0100 [INFO]  aws.aws-base: Retrieved caller identity from STS: tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider tf_req_id=6c476b2d-240d-26d6-8ca4-6472dd2ac762 tf_mux_provider="*schema.GRPCProviderServer"
2026-09-02T17:10:53.556+0100 [WARN]  sdk.helper_schema: unable to require attribute replacement: tf_resource_type=aws_msk_cluster tf_req_id=bfb3fc80-8289-9910-f61c-82c167568dda tf_mux_provider="*schema.GRPCProviderServer" tf_provider_addr=registry.terraform.io/hashicorp/aws tf_attribute_path=storage_mode error="ForceNew: No changes for storage_mode" tf_rpc=PlanResourceChange
2026/09/02 17:10:53 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:53 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:53 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:53 Initializing Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:54 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:54 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:54 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:54 Initializing Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:55 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:55 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:55 Initializing Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:55 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:55 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:55 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:55 Initializing Terraform AWS Provider (Framework-style)...
2026-09-02T17:10:56.195+0100 [INFO]  aws.aws-base: Retrieved credentials: tf_mux_provider="*schema.GRPCProviderServer" tf_req_id=33d04a7b-617a-581e-9f27-b5b707a664b8 tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider tf_aws.credentials_source=EnvConfigCredentials
2026-09-02T17:10:56.561+0100 [INFO]  aws.aws-base: Retrieved caller identity from STS: tf_req_id=33d04a7b-617a-581e-9f27-b5b707a664b8 tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider tf_mux_provider="*schema.GRPCProviderServer"
2026/09/02 17:10:58 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:58 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:58 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:58 Initializing Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:59 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:59 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:10:59 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:10:59 Initializing Terraform AWS Provider (Framework-style)...
2026-09-02T17:11:00.452+0100 [INFO]  aws.aws-base: Retrieved credentials: tf_req_id=4c21de8c-9d5c-cbd6-86d3-7e7f561ca98b tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider tf_mux_provider="*schema.GRPCProviderServer" tf_aws.credentials_source=EnvConfigCredentials
2026-09-02T17:11:00.889+0100 [INFO]  aws.aws-base: Retrieved caller identity from STS: tf_mux_provider="*schema.GRPCProviderServer" tf_req_id=4c21de8c-9d5c-cbd6-86d3-7e7f561ca98b tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider
2026-09-02T17:11:03.492+0100 [WARN]  sdk.helper_schema: unable to require attribute replacement: tf_req_id=415c7bbf-44b9-a10a-983a-47eee9dbdccd error="ForceNew: No changes for storage_mode" tf_attribute_path=storage_mode tf_mux_provider="*schema.GRPCProviderServer" tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=PlanResourceChange tf_resource_type=aws_msk_cluster
2026/09/02 17:11:04 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:11:04 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:11:04 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:11:04 Initializing Terraform AWS Provider (Framework-style)...
2026-09-02T17:11:05.300+0100 [INFO]  aws.aws-base: Retrieved credentials: tf_rpc=ConfigureProvider tf_aws.credentials_source=EnvConfigCredentials tf_mux_provider="*schema.GRPCProviderServer" tf_req_id=dd3abbec-006a-6e34-e7fb-39103b410f41 tf_provider_addr=registry.terraform.io/hashicorp/aws
2026-09-02T17:11:05.637+0100 [INFO]  aws.aws-base: Retrieved caller identity from STS: tf_rpc=ConfigureProvider tf_mux_provider="*schema.GRPCProviderServer" tf_req_id=dd3abbec-006a-6e34-e7fb-39103b410f41 tf_provider_addr=registry.terraform.io/hashicorp/aws
2026-09-02T17:11:05.655+0100 [WARN]  sdk.helper_schema: unable to require attribute replacement: tf_req_id=d6851451-035d-7a1d-2919-10c59a56fcbd tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=PlanResourceChange tf_mux_provider="*schema.GRPCProviderServer" tf_attribute_path=storage_mode error="ForceNew: No changes for storage_mode" tf_resource_type=aws_msk_cluster
2026/09/02 17:17:15 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:15 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:15 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:17:15 Initializing Terraform AWS Provider (Framework-style)...
2026/09/02 17:17:17 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:17 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:17 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:17:17 Initializing Terraform AWS Provider (Framework-style)...
2026-09-02T17:17:18.034+0100 [INFO]  aws.aws-base: Retrieved credentials: tf_aws.credentials_source=EnvConfigCredentials tf_provider_addr=registry.terraform.io/hashicorp/aws tf_mux_provider="*schema.GRPCProviderServer" tf_rpc=ConfigureProvider tf_req_id=327c3a21-322c-8537-5e9b-c71de1037fdb
2026-09-02T17:17:18.405+0100 [INFO]  aws.aws-base: Retrieved caller identity from STS: tf_provider_addr=registry.terraform.io/hashicorp/aws tf_mux_provider="*schema.GRPCProviderServer" tf_rpc=ConfigureProvider tf_req_id=327c3a21-322c-8537-5e9b-c71de1037fdb
2026-09-02T17:17:19.911+0100 [WARN]  sdk.helper_schema: unable to require attribute replacement: tf_provider_addr=registry.terraform.io/hashicorp/aws error="ForceNew: No changes for storage_mode" tf_attribute_path=storage_mode tf_rpc=PlanResourceChange tf_resource_type=aws_msk_cluster tf_mux_provider="*schema.GRPCProviderServer" tf_req_id=80a6f5b3-fa16-50b6-7dec-c2ea8601582a
2026/09/02 17:17:20 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:20 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:20 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:17:20 Initializing Terraform AWS Provider (Framework-style)...
2026/09/02 17:17:20 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:20 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:20 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:17:20 Initializing Terraform AWS Provider (Framework-style)...
2026-09-02T17:17:21.784+0100 [INFO]  aws.aws-base: Retrieved credentials: tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider tf_mux_provider="*schema.GRPCProviderServer" tf_aws.credentials_source=EnvConfigCredentials tf_req_id=70745ef8-d1a8-c6de-4037-8f21d71d397e
2026-09-02T17:17:22.150+0100 [INFO]  aws.aws-base: Retrieved caller identity from STS: tf_req_id=70745ef8-d1a8-c6de-4037-8f21d71d397e tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider tf_mux_provider="*schema.GRPCProviderServer"
2026-09-02T17:17:24.455+0100 [WARN]  sdk.helper_schema: unable to require attribute replacement: tf_rpc=PlanResourceChange tf_attribute_path=storage_mode error="ForceNew: No changes for storage_mode" tf_resource_type=aws_msk_cluster tf_req_id=699a768b-299b-ad0b-8ff5-1fd0c0a7cd3b tf_provider_addr=registry.terraform.io/hashicorp/aws tf_mux_provider="*schema.GRPCProviderServer"
2026/09/02 17:17:24 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:24 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:24 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:17:24 Initializing Terraform AWS Provider (Framework-style)...
2026/09/02 17:17:25 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:25 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:25 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:17:25 Initializing Terraform AWS Provider (Framework-style)...
2026/09/02 17:17:26 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:26 Initializing Terraform AWS Provider (SDKv2-style)...
2026/09/02 17:17:26 Creating Terraform AWS Provider (Framework-style)...
2026/09/02 17:17:26 Initializing Terraform AWS Provider (Framework-style)...
2026-09-02T17:17:27.167+0100 [INFO]  aws.aws-base: Retrieved credentials: tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ConfigureProvider tf_req_id=12e0b4f4-00a4-65b3-630c-6c13b68611df tf_mux_provider="*schema.GRPCProviderServer" tf_aws.credentials_source=EnvConfigCredentials
2026-09-02T17:17:27.508+0100 [INFO]  aws.aws-base: Retrieved caller identity from STS: tf_rpc=ConfigureProvider tf_req_id=12e0b4f4-00a4-65b3-630c-6c13b68611df tf_mux_provider="*schema.GRPCProviderServer" tf_provider_addr=registry.terraform.io/hashicorp/aws
2026-09-02T17:17:27.690+0100 [WARN]  sdk.helper_schema: Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.: tf_rpc=ConfigureProvider tf_mux_provider="*schema.GRPCProviderServer" tf_req_id=7c18dd0c-3be2-6505-a02b-acbde43f5598 tf_provider_addr=registry.terraform.io/hashicorp/aws
2026-09-02T17:17:27.691+0100 [INFO]  aws.aws-base: Retrieved credentials: tf_req_id=7c18dd0c-3be2-6505-a02b-acbde43f5598 tf_mux_provider="*schema.GRPCProviderServer" tf_rpc=ConfigureProvider tf_provider_addr=registry.terraform.io/hashicorp/aws tf_aws.credentials_source=EnvConfigCredentials
2026-09-02T17:17:28.033+0100 [INFO]  aws.aws-base: Retrieved caller identity from STS: tf_mux_provider="*schema.GRPCProviderServer" tf_rpc=ConfigureProvider tf_provider_addr=registry.terraform.io/hashicorp/aws tf_req_id=7c18dd0c-3be2-6505-a02b-acbde43f5598
2026-09-02T17:18:25.434+0100 [INFO]  aws: Deleting EC2 Security Group: tf_req_id=f03e9794-ecc7-3a2f-f725-87a40f3707b2 tf_mux_provider="*schema.GRPCProviderServer" tf_aws.resource_attribute.id=sg-03b9cee11544f0aba vpc_id=vpc-00e18840a17c7c64c tf_provider_addr=registry.terraform.io/hashicorp/aws tf_resource_type=aws_security_group tf_rpc=ApplyResourceChange
--- PASS: TestAccKafkaCluster_ZookeeperClientAccess (2329.20s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafka	2334.719s
...
```
