### PR TITLE
chore(synthetic-canary): add additional `memory_in_mb` validation

### DIFF
--- a/.changelog/49826.txt
+++ b/.changelog/49826.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/synthetics: Add additional validation to `memory_in_mb`
+resource/aws_synthetics_canary: Add additional validation to `memory_in_mb`
 ```

--- a/.changelog/49826.txt
+++ b/.changelog/49826.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/synthetics: Add additional validation to `memory_in_mb`
+```

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -155,6 +155,7 @@ func ResourceCanary() *schema.Resource {
 								ValidateFunc: validation.All(
 									validation.IntDivisibleBy(64),
 									validation.IntAtLeast(960),
+									validation.IntAtMost(3008),
 								),
 							},
 							"timeout_in_seconds": {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

- If a change needs to be reverted, we will publish an updated version of the library. This is a minimal addition that shouldn't require rollback

## Changes to Security Controls

- There are no changes to the security controls

### Description

- Per the Canary Run Configuration documentation, this adds an additional validation layer for the `memory_in_mb`

<img width="739" height="206" alt="image" src="https://github.com/user-attachments/assets/e32a39f3-f8d9-4115-a75e-b8721ab9a8e2" />

### References

- [CanaryRunConfigInput](https://docs.aws.amazon.com/AmazonSynthetics/latest/APIReference/API_CanaryRunConfigInput.html)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
❯ make testacc TESTS=TestAccSyntheticsCanary_basic PKG=synthetics
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 add-additional-canary-memory-in-mb-validation 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/synthetics/... -v -count 1 -parallel 20 -run='TestAccSyntheticsCanary_basic'  -timeout 360m -vet=off -buildvcs=false
2026/09/03 08:48:05 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/03 08:48:05 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSyntheticsCanary_basic
=== PAUSE TestAccSyntheticsCanary_basic
=== CONT  TestAccSyntheticsCanary_basic
--- PASS: TestAccSyntheticsCanary_basic (70.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/synthetics 75.646s
```
