### PR TITLE
🤖🤖🤖 d/aws_route53_zones: Add `zones` attribute

### DIFF
--- a/.changelog/49830.txt
+++ b/.changelog/49830.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_route53_zones: Add `zones` attribute
+```

--- a/internal/service/route53/zones_data_source.go
+++ b/internal/service/route53/zones_data_source.go
@@ -39,6 +39,7 @@ func (d *zonesDataSource) Schema(ctx context.Context, request datasource.SchemaR
 				ElementType: types.StringType,
 				Computed:    true,
 			},
+			"zones": framework.DataSourceComputedListOfObjectAttribute[hostedZoneSummaryModel](ctx),
 		},
 	}
 }
@@ -65,13 +66,37 @@ func (d *zonesDataSource) Read(ctx context.Context, request datasource.ReadReque
 		return cleanZoneID(aws.ToString(v.Id))
 	})
 
+	zones := tfslices.ApplyToAll(output, func(v awstypes.HostedZone) hostedZoneSummaryModel {
+		return hostedZoneSummaryModel{
+			Name:                   types.StringValue(normalizeDomainName(aws.ToString(v.Name))),
+			PrivateZone:            types.BoolValue(v.Config != nil && v.Config.PrivateZone),
+			ResourceRecordSetCount: types.Int64PointerValue(v.ResourceRecordSetCount),
+			ZoneID:                 types.StringValue(cleanZoneID(aws.ToString(v.Id))),
+		}
+	})
+
+	zonesValue, diags := fwtypes.NewListNestedObjectValueOfValueSlice(ctx, zones)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
 	data.ID = types.StringValue(d.Meta().Region(ctx))
 	data.ZoneIDs = fwflex.FlattenFrameworkStringValueListOfString(ctx, zoneIDs)
+	data.Zones = zonesValue
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
 type zonesDataSourceModel struct {
-	ID      types.String         `tfsdk:"id"`
-	ZoneIDs fwtypes.ListOfString `tfsdk:"ids"`
+	ID      types.String                                            `tfsdk:"id"`
+	ZoneIDs fwtypes.ListOfString                                    `tfsdk:"ids"`
+	Zones   fwtypes.ListNestedObjectValueOf[hostedZoneSummaryModel] `tfsdk:"zones"`
+}
+
+type hostedZoneSummaryModel struct {
+	Name                   types.String `tfsdk:"name"`
+	PrivateZone            types.Bool   `tfsdk:"private_zone"`
+	ResourceRecordSetCount types.Int64  `tfsdk:"resource_record_set_count"`
+	ZoneID                 types.String `tfsdk:"zone_id"`
 }

--- a/internal/service/route53/zones_data_source_test.go
+++ b/internal/service/route53/zones_data_source_test.go
@@ -26,6 +26,11 @@ func TestAccRoute53ZonesDataSource_basic(t *testing.T) {
 				Config: testAccZonesDataSourceConfig_basic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "ids.#", 1),
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "zones.#", 1),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "zones.*", map[string]string{
+						names.AttrName: zoneName,
+						"private_zone": acctest.CtFalse,
+					}),
 				),
 			},
 		},

--- a/website/docs/d/route53_zones.html.markdown
+++ b/website/docs/d/route53_zones.html.markdown
@@ -22,6 +22,31 @@ output "example" {
 }
 ```
 
+### Look Up Zone IDs By Name
+
+The `zones` attribute includes the name of each hosted zone, so a single read of this data source can resolve many domain names to their zone IDs. This avoids one [`aws_route53_zone`](/docs/providers/aws/d/route53_zone.html) data source per domain, each of which lists all of the hosted zones in the account.
+
+```terraform
+data "aws_route53_zones" "all" {}
+
+locals {
+  zone_ids = {
+    for zone in data.aws_route53_zones.all.zones :
+    zone.name => zone.zone_id if !zone.private_zone
+  }
+}
+
+resource "aws_route53_record" "www" {
+  for_each = toset(["example.com", "example.net"])
+
+  zone_id = local.zone_ids[each.value]
+  name    = "www.${each.value}"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["example.org"]
+}
+```
+
 ## Argument Reference
 
 This data source does not support any arguments.
@@ -31,3 +56,11 @@ This data source does not support any arguments.
 This data source exports the following attributes in addition to the arguments above:
 
 * `ids` - A list of all the Route53 Hosted Zone IDs found.
+* `zones` - A list of all the Route53 Hosted Zones found. See [`zones`](#zones) below.
+
+### `zones`
+
+* `name` - Name of the hosted zone, without a trailing period.
+* `private_zone` - Whether this is a private hosted zone.
+* `resource_record_set_count` - Number of resource record sets in the hosted zone.
+* `zone_id` - Hosted zone ID.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. The change adds fields to the response of a data source that already calls `ListHostedZones`. It reads no new API and grants no new permission.

### Description

`aws_route53_zones` calls `ListHostedZones` and returns only `ids`. The API response already carries the name, the private flag and the record count for every zone, and `zonesDataSource.Read` discards all of it:

```go
zoneIDs := tfslices.ApplyToAll(output, func(v awstypes.HostedZone) string {
	return cleanZoneID(aws.ToString(v.Id))
})
```

This PR adds a computed `zones` attribute carrying `name`, `private_zone`, `resource_record_set_count` and `zone_id`. `ids` is unchanged, and the attribute is computed and additive, so no existing configuration changes behaviour. No additional API call is made.

**Why this matters**

Callers who know a domain name and want its zone ID currently have to use the singular `aws_route53_zone` data source with `name`, and its cost scales with the size of the account rather than with the configuration. `dataSourceZoneRead` lists every hosted zone and does not exit the loop when it finds a match, because it asserts a single result afterwards:

```go
// As name is not unique, we need to list all zones and filter
input := &route53.ListHostedZonesInput{}
pages := route53.NewListHostedZonesPaginator(conn, input)
for pages.HasMorePages() {
```

Measured against an account with 186 hosted zones, each `data "aws_route53_zone"` with `name` costs 4 Route 53 API calls: 2 `ListHostedZones` pages, 1 `GetHostedZone` for the name servers, and 1 `ListTagsForResource`. Twenty of them in one `for_each` cost 82 calls, counted as distinct `x-amzn-requestid` values in a `TF_LOG=debug` plan. Past 300 zones in the account the same twenty lookups cost more again, without the configuration changing.

Route 53 is rate limited to five requests per second per AWS account, so this is the dominant cost of a plan for anyone managing DNS for many domains. With `zones`, the whole account resolves in the one `ListHostedZones` pass the data source already makes:

```terraform
data "aws_route53_zones" "all" {}

locals {
  zone_ids = {
    for zone in data.aws_route53_zones.all.zones :
    zone.name => zone.zone_id if !zone.private_zone
  }
}
```

`name` is normalized with `normalizeDomainName`, so it has no trailing period and matches the value `aws_route53_zone.name` exports.

### AI Usage

Disclosed per [docs/ai-usage.md](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/ai-usage.md). This pull request was prepared with an LLM agent (Claude Code), so the title carries `🤖🤖🤖`.

What the agent did:

* Read `zones_data_source.go`, `zone_data_source.go` and `record.go` to find where the call cost comes from, and produced the measurements in the description by instrumenting real `terraform plan` runs with `TF_LOG=debug` against a live account with 186 hosted zones, counting distinct `x-amzn-requestid` values per operation.
* Wrote the `zones` attribute, the model, the acceptance test assertions and the documentation page, following the conventions in the neighbouring `records_data_source.go`.

What it did not do: decide the design. The shape of the attribute, the choice to extend `aws_route53_zones` rather than add a new data source, and the decision to open this PR are mine. I have read the diff and can explain it. The change came out of a performance review of our own Route 53 estate, where the by-name zone lookup was the dominant cost of every plan.

### Relations

Relates #40466
Closes #44020

### References

* [ListHostedZones API reference](https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListHostedZones.html), which documents the `Name`, `Config.PrivateZone` and `ResourceRecordSetCount` fields this PR surfaces.
* [Throttling for Amazon Route 53 API requests](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/throttling-api-requests.html), for the five requests per second per account limit.

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccRoute53ZonesDataSource PKG=route53

2026/09/03 15:55:36 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/03 15:55:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53ZonesDataSource_basic
=== PAUSE TestAccRoute53ZonesDataSource_basic
=== CONT  TestAccRoute53ZonesDataSource_basic
--- PASS: TestAccRoute53ZonesDataSource_basic (90.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	90.631s
```
