### PR TITLE
cognitoidp: Do not retry on LimitExceededException

### DIFF
--- a/.changelog/49837.txt
+++ b/.changelog/49837.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+provider: Do not retry on Cognito Identity Provider `LimitExceededException`, which always indicates a non-retryable service quota (e.g. groups per user pool, user pool clients per user pool). Affects `aws_cognito_user_group`, `aws_cognito_user_pool_client`, `aws_cognito_identity_provider`, `aws_cognito_resource_server`, `aws_cognito_user_pool`, `aws_cognito_user_pool_domain`, and `aws_cognito_managed_login_branding`.
+```
+

--- a/internal/service/cognitoidp/service_package.go
+++ b/internal/service/cognitoidp/service_package.go
@@ -1,0 +1,53 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package cognitoidp
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
+)
+
+func (p *servicePackage) withExtraOptions(ctx context.Context, config map[string]any) []func(*cognitoidentityprovider.Options) {
+	cfg := *(config["aws_sdkv2_config"].(*aws.Config))
+
+	return []func(*cognitoidentityprovider.Options){
+		func(o *cognitoidentityprovider.Options) {
+			retryables := []retry.IsErrorRetryable{
+				retry.IsErrorRetryableFunc(func(err error) aws.Ternary {
+					// Cognito Identity Provider's LimitExceededException always indicates a hard,
+					// per-account or per-user-pool quota (e.g. groups per user pool, user pool
+					// clients per user pool) that will never succeed on retry with the same
+					// input. It is distinct from, and should not be confused with, the service's
+					// dedicated throttling error, TooManyRequestsException, which is left to the
+					// configured Retryer. Without this override, the generated client's default
+					// retryer treats LimitExceededException as retryable/throttling (its modeled
+					// error code, in the absence of an explicit override, falls back to the
+					// exception's shape name, which happens to collide with a fixed list of
+					// generically-throttling error codes), causing resource creation to retry with
+					// exponential backoff for many minutes before finally surfacing the
+					// non-retryable quota error.
+					if errs.IsA[*awstypes.LimitExceededException](err) {
+						return aws.FalseTernary
+					}
+					return aws.UnknownTernary // Delegate to configured Retryer.
+				}),
+			}
+			// Include go-vcr retryable to prevent generated client retryer from being overridden
+			if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+				tflog.Info(ctx, "overriding retry behavior to immediately return VCR errors")
+				retryables = append(retryables, vcr.InteractionNotFoundRetryableFunc)
+			}
+
+			o.Retryer = conns.AddIsErrorRetryables(cfg.Retryer().(aws.RetryerV2), retryables...)
+		},
+	}
+}


### PR DESCRIPTION
### Description

Adds an `internal/service/cognitoidp/service_package.go` retry override so Cognito Identity Provider's `LimitExceededException` is never retried, mirroring the fix already shipped for `aws_cloudwatch_event_rule` in #44477 / #44489.

`LimitExceededException` in this service always represents a hard, per-account/per-user-pool quota (e.g. groups per user pool, user pool clients per user pool) — retrying with the same input can never succeed. The service already has a dedicated, distinct throttling error (`TooManyRequestsException`), which this change does not touch and which is left to the configured `Retryer`.

Without this override, the generated client's default retryer treats `LimitExceededException` as retryable, because its modeled error code has no explicit override in the API model and therefore falls back to the exception's shape name — which happens to collide with the SDKs' generic, service-agnostic list of throttling error codes (`aws-sdk-go-v2`: `aws/retry/standard.go`, `DefaultThrottleErrorCodes`). This causes affected resources (e.g. `aws_cognito_user_group`, `aws_cognito_user_pool_client`, `aws_cognito_identity_provider`, `aws_cognito_resource_server`, `aws_cognito_user_pool`, `aws_cognito_user_pool_domain`, `aws_cognito_managed_login_branding`) to retry with exponential backoff for many minutes before finally surfacing the non-retryable quota error, instead of failing on the first attempt.

### Relations

Closes #49836

### Output from Acceptance Testing

Validated via `go build ./internal/service/cognitoidp/...` and `go vet ./internal/service/cognitoidp/...` (both clean). No behavioral acceptance test is included, following the same precedent as #44489, which did not add one either (the failure mode requires actually exhausting an account-level service quota).

