### PR TITLE
[chore] vpclattice: Fix TestAccVPCLatticeServiceDataSource_shared RAM princip…

### DIFF
--- a/internal/service/vpclattice/service_data_source_test.go
+++ b/internal/service/vpclattice/service_data_source_test.go
@@ -170,7 +170,7 @@ resource "aws_ram_resource_association" "test" {
 }
 
 resource "aws_ram_principal_association" "test" {
-  principal          = data.aws_caller_identity.target.arn
+  principal          = data.aws_caller_identity.target.account_id
   resource_share_arn = aws_ram_resource_share.test.arn
 }
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The test config passed the alternate account's caller identity ARN as the RAM principal association's principal, but `aws_ram_principal_association` requires an AWS account ID (or an Organizations org/OU ARN), not an IAM/STS ARN. This caused every run to fail with:

  InvalidParameterException: Principal ID is malformed.

Use `data.aws_caller_identity.target.account_id` instead, matching the convention used in internal/service/ram/principal_association_test.go.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccVPCLatticeServiceDataSource_shared PKG=vpclattice 2>&1 | tail -150
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	8.695s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	8.724s
make: Running acceptance tests on branch: 🌿 testfix-vpclattice-shared 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='TestAccVPCLatticeServiceDataSource_shared'  -timeout 360m -vet=off -buildvcs=false
2026/09/03 09:55:12 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/03 09:55:12 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCLatticeServiceDataSource_shared
=== PAUSE TestAccVPCLatticeServiceDataSource_shared
=== CONT  TestAccVPCLatticeServiceDataSource_shared
--- PASS: TestAccVPCLatticeServiceDataSource_shared (33.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice	42.368s
...
```
