### PR TITLE
r/`aws_fis_safety_lever_state`: New Resource

### DIFF
--- a/.changelog/49841.txt
+++ b/.changelog/49841.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_fis_safety_lever_state
+```
+
+```release-note:new-list-resource
+aws_fis_safety_lever_state
+```

--- a/internal/service/fis/exports_test.go
+++ b/internal/service/fis/exports_test.go
@@ -12,4 +12,8 @@ var (
 	ResourceTargetAccountConfiguration = newResourceTargetAccountConfiguration
 
 	FindTargetAccountConfigurationByID = findTargetAccountConfigurationByID
+
+	ResourceSafetyLeverState = newSafetyLeverStateResource
+
+	FindSafetyLever = findSafetyLever
 )

--- a/internal/service/fis/exports_test.go
+++ b/internal/service/fis/exports_test.go
@@ -5,15 +5,11 @@ package fis
 
 // Exports for use in tests only.
 var (
-	ResourceExperimentTemplate = resourceExperimentTemplate
-
-	FindExperimentTemplateByID = findExperimentTemplateByID
-
+	ResourceExperimentTemplate         = resourceExperimentTemplate
 	ResourceTargetAccountConfiguration = newResourceTargetAccountConfiguration
+	ResourceSafetyLeverState           = newSafetyLeverStateResource
 
+	FindExperimentTemplateByID         = findExperimentTemplateByID
 	FindTargetAccountConfigurationByID = findTargetAccountConfigurationByID
-
-	ResourceSafetyLeverState = newSafetyLeverStateResource
-
-	FindSafetyLever = findSafetyLever
+	FindSafetyLever                    = findSafetyLever
 )

--- a/internal/service/fis/safety_lever_state.go
+++ b/internal/service/fis/safety_lever_state.go
@@ -71,7 +71,7 @@ func (r *safetyLeverStateResource) Schema(ctx context.Context, req resource.Sche
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
-			"state": schema.ListNestedBlock{
+			names.AttrState: schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[safetyLeverStateStateModel](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeBetween(1, 1),
@@ -254,7 +254,7 @@ func findSafetyLever(ctx context.Context, conn *fis.Client, id string) (*awstype
 
 func waitSafetyLeverStatus(ctx context.Context, conn *fis.Client, id, target string, timeout time.Duration) (*awstypes.SafetyLever, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{string(awstypes.SafetyLeverStatusEngaging)},
+		Pending: enum.Slice(awstypes.SafetyLeverStatusEngaging),
 		Target:  []string{target},
 		Refresh: statusSafetyLever(conn, id),
 		Timeout: timeout,

--- a/internal/service/fis/safety_lever_state.go
+++ b/internal/service/fis/safety_lever_state.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -35,6 +35,9 @@ import (
 )
 
 // @FrameworkResource("aws_fis_safety_lever_state", name="Safety Lever State")
+// @SingletonIdentity
+// @Testing(hasNoPreExistingResource=true)
+// @Testing(identityTest=false)
 func newSafetyLeverStateResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &safetyLeverStateResource{}
 
@@ -47,21 +50,32 @@ func newSafetyLeverStateResource(_ context.Context) (resource.ResourceWithConfig
 const (
 	ResNameSafetyLeverState = "Safety Lever State"
 
-	// The FIS safety lever is an account/region singleton: AWS always exposes exactly one,
-	// its ID is the fixed literal "default"
+	// The FIS safety lever is an account/Region singleton: AWS always exposes exactly one,
+	// and every GetSafetyLever/UpdateSafetyLeverState call addresses it by the fixed literal
+	// "default". Terraform identifies it by resource identity ({account_id, region}) - see
+	// @SingletonIdentity - so there is no "id" attribute.
 	safetyLeverDefaultID = "default"
+
+	// Substring of the ConflictException AWS returns from UpdateSafetyLeverState when the
+	// requested status already matches the live status ("Cannot update Safety Lever reason
+	// without a status change").
+	safetyLeverReasonWithoutStatusChange = "without a status change"
 )
 
+// The safety lever has no Create or Delete API - it always exists. Delete is intentionally a
+// no-op (framework.WithNoOpDelete): it only stops Terraform tracking the lever and never
+// touches the live value, so destroying this resource can't silently disengage a safety control.
 type safetyLeverStateResource struct {
 	framework.ResourceWithModel[safetyLeverStateResourceModel]
 	framework.WithTimeouts
+	framework.WithNoOpDelete
+	framework.WithImportByIdentity
 }
 
 func (r *safetyLeverStateResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
-			names.AttrID:  framework.IDAttribute(),
 		},
 		Blocks: map[string]schema.Block{
 			"state": schema.ListNestedBlock{
@@ -72,9 +86,8 @@ func (r *safetyLeverStateResource) Schema(ctx context.Context, req resource.Sche
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"reason": schema.StringAttribute{
-							Required: true,
-							Description: "Reason for the current status of the safety lever. AWS only accepts a " +
-								"reason change together with an actual status transition; see the resource documentation.",
+							Required:    true,
+							Description: "Reason for the current status of the safety lever",
 							Validators: []validator.String{
 								stringvalidator.LengthBetween(1, 256),
 							},
@@ -98,68 +111,18 @@ func (r *safetyLeverStateResource) Schema(ctx context.Context, req resource.Sche
 }
 
 func (r *safetyLeverStateResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	conn := r.Meta().FISClient(ctx)
-
 	var plan safetyLeverStateResourceModel
 	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	planState, d := plan.State.ToPtr(ctx)
-	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+	r.upsert(ctx, &plan, r.CreateTimeout(ctx, plan.Timeouts), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	status := planState.Status.ValueString()
-	reason := planState.Reason.ValueString()
-
-	// The safety lever always exists (it predates Terraform managing it), so "create" is really
-	// "adopt". Check its live status first: AWS rejects UpdateSafetyLeverState with a
-	// ConflictException ("Cannot update Safety Lever reason without a status change") whenever the
-	// requested status already matches the current one. Terraform's protocol also does not allow a
-	// provider to silently substitute a value the practitioner explicitly configured (reason here),
-	// so when this happens the only honest option is to fail with actionable guidance rather than
-	// attempt - and fail - the API call, or silently ignore the configured reason.
-	current, err := findSafetyLever(ctx, conn, safetyLeverDefaultID)
-	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, safetyLeverDefaultID)
-		return
-	}
-
-	if current.State != nil && string(current.State.Status) == status {
-		resp.Diagnostics.AddError(
-			"FIS Safety Lever Already In Requested Status",
-			fmt.Sprintf("The account's FIS safety lever is already %q (reason: %q). AWS does not allow setting "+
-				"a reason without an accompanying status change, so this resource cannot be created while its "+
-				"configured status matches the account's current status.\n\n"+
-				"To bring the existing safety lever under Terraform management as-is, import it instead:\n"+
-				"  terraform import aws_fis_safety_lever_state.<name> %s",
-				status, aws.ToString(current.State.Reason), safetyLeverDefaultID),
-		)
-		return
-	}
-
-	_, err = updateSafetyLeverState(ctx, conn, safetyLeverDefaultID, status, reason)
-	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, safetyLeverDefaultID)
-		return
-	}
-
-	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
-	out, err := waitSafetyLeverStatus(ctx, conn, safetyLeverDefaultID, status, createTimeout)
-	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, safetyLeverDefaultID)
-		return
-	}
-
-	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out, &plan))
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
 }
 
 func (r *safetyLeverStateResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -171,14 +134,14 @@ func (r *safetyLeverStateResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	out, err := findSafetyLever(ctx, conn, state.ID.ValueString())
+	out, err := findSafetyLever(ctx, conn, safetyLeverDefaultID)
 	if retry.NotFound(err) {
 		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		resp.State.RemoveResource(ctx)
 		return
 	}
 	if err != nil {
-		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, safetyLeverDefaultID)
 		return
 	}
 
@@ -191,67 +154,89 @@ func (r *safetyLeverStateResource) Read(ctx context.Context, req resource.ReadRe
 }
 
 func (r *safetyLeverStateResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	conn := r.Meta().FISClient(ctx)
-
-	var plan, state safetyLeverStateResourceModel
+	var plan safetyLeverStateResourceModel
 	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
-	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	planState, d := plan.State.ToPtr(ctx)
-	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
-	priorState, d := state.State.ToPtr(ctx)
-	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+	r.upsert(ctx, &plan, r.UpdateTimeout(ctx, plan.Timeouts), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// AWS rejects a reason-only update (see the Create comment above), so a change is only ever
-	// sendable to AWS when status is actually transitioning.
-	if !planState.Status.Equal(priorState.Status) {
-		status := planState.Status.ValueString()
-		reason := planState.Reason.ValueString()
-
-		_, err := updateSafetyLeverState(ctx, conn, plan.ID.ValueString(), status, reason)
-		if err != nil {
-			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
-			return
-		}
-
-		updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
-		out, err := waitSafetyLeverStatus(ctx, conn, plan.ID.ValueString(), status, updateTimeout)
-		if err != nil {
-			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
-			return
-		}
-
-		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out, &plan))
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	} else if !planState.Reason.Equal(priorState.Reason) {
-		resp.Diagnostics.AddError(
-			"Cannot Update FIS Safety Lever Reason Without a Status Change",
-			fmt.Sprintf("AWS does not allow changing the safety lever's reason (from %q to %q) without also "+
-				"changing its status. The configured status (%q) matches the current status, so this change "+
-				"cannot be applied. Pair the reason change with an actual status transition, or set reason "+
-				"back to %q.",
-				priorState.Reason.ValueString(), planState.Reason.ValueString(), planState.Status.ValueString(), priorState.Reason.ValueString()),
-		)
 		return
 	}
 
 	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
 }
 
-// No Delete API. Delete simply stops Terraform from tracking it and leaves the live value untouched.
-func (r *safetyLeverStateResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-}
+// upsert is the single code path behind both Create and Update. The safety lever always
+// exists, so both operations are really "drive the lever to the configured state".
+//
+// AWS rejects UpdateSafetyLeverState with a ConflictException whenever the requested status
+// already matches the live status - it will not accept a reason-only change. Rather than read
+// first to avoid that call, upsert attempts it and interprets the conflict:
+//
+//   - configured reason already matches the live reason -> the declared config matches reality,
+//     so this is a legitimate provider no-op (mirrors how Delete swallows NotFound).
+//   - configured reason differs -> the change is genuinely unsatisfiable; fail with the live
+//     reason surfaced so the practitioner can reconcile their config. The configured value is
+//     never silently overwritten in state.
+func (r *safetyLeverStateResource) upsert(ctx context.Context, plan *safetyLeverStateResourceModel, timeout time.Duration, diags *diag.Diagnostics) {
+	conn := r.Meta().FISClient(ctx)
 
-func (r *safetyLeverStateResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrID), req, resp)
+	planState, d := plan.State.ToPtr(ctx)
+	smerr.AddEnrich(ctx, diags, d)
+	if diags.HasError() {
+		return
+	}
+
+	status := planState.Status.ValueString()
+	reason := planState.Reason.ValueString()
+
+	var out *awstypes.SafetyLever
+	_, err := updateSafetyLeverState(ctx, conn, safetyLeverDefaultID, status, reason)
+	switch {
+	case err == nil:
+		// A real status transition was accepted - wait out the transient "engaging" status
+		// so Terraform never persists a non-terminal value.
+		out, err = waitSafetyLeverStatus(ctx, conn, safetyLeverDefaultID, status, timeout)
+		if err != nil {
+			smerr.AddError(ctx, diags, err, smerr.ID, safetyLeverDefaultID)
+			return
+		}
+	case errs.IsAErrorMessageContains[*awstypes.ConflictException](err, safetyLeverReasonWithoutStatusChange):
+		current, findErr := findSafetyLever(ctx, conn, safetyLeverDefaultID)
+		if findErr != nil {
+			smerr.AddError(ctx, diags, findErr, smerr.ID, safetyLeverDefaultID)
+			return
+		}
+
+		var liveReason string
+		if current.State != nil {
+			liveReason = aws.ToString(current.State.Reason)
+		}
+
+		if liveReason != reason {
+			diags.AddError(
+				"Cannot Change FIS Safety Lever Reason Without a Status Change",
+				fmt.Sprintf("The account's safety lever is already %q, and AWS does not allow changing its "+
+					"reason without also changing its status.\n\n"+
+					"  configured reason: %q\n"+
+					"  actual reason:     %q\n\n"+
+					"Pair the reason change with an actual status transition, or set reason to %q to match "+
+					"the live value.",
+					status, reason, liveReason, liveReason),
+			)
+			return
+		}
+
+		// Configured status and reason already match reality: nothing to do.
+		out = current
+	default:
+		smerr.AddError(ctx, diags, err, smerr.ID, safetyLeverDefaultID)
+		return
+	}
+
+	smerr.AddEnrich(ctx, diags, fwflex.Flatten(ctx, out, plan))
 }
 
 func updateSafetyLeverState(ctx context.Context, conn *fis.Client, id, status, reason string) (*awstypes.SafetyLever, error) {
@@ -335,7 +320,6 @@ func statusSafetyLever(conn *fis.Client, id string) retry.StateRefreshFunc {
 type safetyLeverStateResourceModel struct {
 	framework.WithRegionModel
 	ARN      types.String                                                `tfsdk:"arn"`
-	ID       types.String                                                `tfsdk:"id"`
 	State    fwtypes.ListNestedObjectValueOf[safetyLeverStateStateModel] `tfsdk:"state"`
 	Timeouts timeouts.Value                                              `tfsdk:"timeouts"`
 }

--- a/internal/service/fis/safety_lever_state.go
+++ b/internal/service/fis/safety_lever_state.go
@@ -176,13 +176,10 @@ func (r *safetyLeverStateResource) upsert(ctx context.Context, plan tfsdk.Plan, 
 			return
 		}
 
-		var liveReason string
-		if current.State != nil {
-			liveReason = aws.ToString(current.State.Reason)
-		}
-
-		if liveReason != reason {
-			smerr.AddError(ctx, diags, fmt.Errorf("cannot change FIS safety lever reason without a status change (status %q): configured reason %q, actual reason %q; set reason to %q to match the live value or change status", status, reason, liveReason, liveReason), smerr.ID, safetyLeverDefaultID)
+		if current.State != nil && aws.ToString(current.State.Reason) != reason {
+			smerr.AddError(ctx, diags, fmt.Errorf("cannot change FIS safety lever reason without a status change (status %[1]q): "+
+				"configured reason %[2]q, actual reason %[3]q; set reason to %[3]q to match the live value or change status",
+				status, reason, aws.ToString(current.State.Reason)), smerr.ID, safetyLeverDefaultID)
 			return
 		}
 

--- a/internal/service/fis/safety_lever_state.go
+++ b/internal/service/fis/safety_lever_state.go
@@ -182,16 +182,7 @@ func (r *safetyLeverStateResource) upsert(ctx context.Context, plan tfsdk.Plan, 
 		}
 
 		if liveReason != reason {
-			diags.AddError(
-				"Cannot Change FIS Safety Lever Reason Without a Status Change",
-				fmt.Sprintf("The account's safety lever is already %q, and AWS does not allow changing its "+
-					"reason without also changing its status.\n\n"+
-					"  configured reason: %q\n"+
-					"  actual reason:     %q\n\n"+
-					"Pair the reason change with an actual status transition, or set reason to %q to match "+
-					"the live value.",
-					status, reason, liveReason, liveReason),
-			)
+			smerr.AddError(ctx, diags, fmt.Errorf("cannot change FIS safety lever reason without a status change (status %q): configured reason %q, actual reason %q; set reason to %q to match the live value or change status", status, reason, liveReason, liveReason), smerr.ID, safetyLeverDefaultID)
 			return
 		}
 

--- a/internal/service/fis/safety_lever_state.go
+++ b/internal/service/fis/safety_lever_state.go
@@ -1,0 +1,346 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
+
+package fis
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/YakDriver/smarterr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/fis"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/fis/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/smerr"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_fis_safety_lever_state", name="Safety Lever State")
+func newSafetyLeverStateResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &safetyLeverStateResource{}
+
+	r.SetDefaultCreateTimeout(5 * time.Minute)
+	r.SetDefaultUpdateTimeout(5 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameSafetyLeverState = "Safety Lever State"
+
+	// The FIS safety lever is an account/region singleton: AWS always exposes exactly one,
+	// its ID is the fixed literal "default"
+	safetyLeverDefaultID = "default"
+)
+
+type safetyLeverStateResource struct {
+	framework.ResourceWithModel[safetyLeverStateResourceModel]
+	framework.WithTimeouts
+}
+
+func (r *safetyLeverStateResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrARN: framework.ARNAttributeComputedOnly(),
+			names.AttrID:  framework.IDAttribute(),
+		},
+		Blocks: map[string]schema.Block{
+			"state": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[safetyLeverStateStateModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeBetween(1, 1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"reason": schema.StringAttribute{
+							Required: true,
+							Description: "Reason for the current status of the safety lever. AWS only accepts a " +
+								"reason change together with an actual status transition; see the resource documentation.",
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 256),
+							},
+						},
+						names.AttrStatus: schema.StringAttribute{
+							Required:    true,
+							Description: "State of the safety lever. Valid values: engaged, disengaged.",
+							Validators: []validator.String{
+								stringvalidator.OneOf(enum.Slice(awstypes.SafetyLeverStatusInputEngaged, awstypes.SafetyLeverStatusInputDisengaged)...),
+							},
+						},
+					},
+				},
+			},
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+			}),
+		},
+	}
+}
+
+func (r *safetyLeverStateResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().FISClient(ctx)
+
+	var plan safetyLeverStateResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	planState, d := plan.State.ToPtr(ctx)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	status := planState.Status.ValueString()
+	reason := planState.Reason.ValueString()
+
+	// The safety lever always exists (it predates Terraform managing it), so "create" is really
+	// "adopt". Check its live status first: AWS rejects UpdateSafetyLeverState with a
+	// ConflictException ("Cannot update Safety Lever reason without a status change") whenever the
+	// requested status already matches the current one. Terraform's protocol also does not allow a
+	// provider to silently substitute a value the practitioner explicitly configured (reason here),
+	// so when this happens the only honest option is to fail with actionable guidance rather than
+	// attempt - and fail - the API call, or silently ignore the configured reason.
+	current, err := findSafetyLever(ctx, conn, safetyLeverDefaultID)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, safetyLeverDefaultID)
+		return
+	}
+
+	if current.State != nil && string(current.State.Status) == status {
+		resp.Diagnostics.AddError(
+			"FIS Safety Lever Already In Requested Status",
+			fmt.Sprintf("The account's FIS safety lever is already %q (reason: %q). AWS does not allow setting "+
+				"a reason without an accompanying status change, so this resource cannot be created while its "+
+				"configured status matches the account's current status.\n\n"+
+				"To bring the existing safety lever under Terraform management as-is, import it instead:\n"+
+				"  terraform import aws_fis_safety_lever_state.<name> %s",
+				status, aws.ToString(current.State.Reason), safetyLeverDefaultID),
+		)
+		return
+	}
+
+	_, err = updateSafetyLeverState(ctx, conn, safetyLeverDefaultID, status, reason)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, safetyLeverDefaultID)
+		return
+	}
+
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	out, err := waitSafetyLeverStatus(ctx, conn, safetyLeverDefaultID, status, createTimeout)
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, safetyLeverDefaultID)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out, &plan))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, plan))
+}
+
+func (r *safetyLeverStateResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().FISClient(ctx)
+
+	var state safetyLeverStateResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findSafetyLever(ctx, conn, state.ID.ValueString())
+	if retry.NotFound(err) {
+		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, state.ID.String())
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &state))
+}
+
+func (r *safetyLeverStateResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().FISClient(ctx)
+
+	var plan, state safetyLeverStateResourceModel
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
+	smerr.AddEnrich(ctx, &resp.Diagnostics, req.State.Get(ctx, &state))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	planState, d := plan.State.ToPtr(ctx)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+	priorState, d := state.State.ToPtr(ctx)
+	smerr.AddEnrich(ctx, &resp.Diagnostics, d)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// AWS rejects a reason-only update (see the Create comment above), so a change is only ever
+	// sendable to AWS when status is actually transitioning.
+	if !planState.Status.Equal(priorState.Status) {
+		status := planState.Status.ValueString()
+		reason := planState.Reason.ValueString()
+
+		_, err := updateSafetyLeverState(ctx, conn, plan.ID.ValueString(), status, reason)
+		if err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
+			return
+		}
+
+		updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
+		out, err := waitSafetyLeverStatus(ctx, conn, plan.ID.ValueString(), status, updateTimeout)
+		if err != nil {
+			smerr.AddError(ctx, &resp.Diagnostics, err, smerr.ID, plan.ID.String())
+			return
+		}
+
+		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, out, &plan))
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	} else if !planState.Reason.Equal(priorState.Reason) {
+		resp.Diagnostics.AddError(
+			"Cannot Update FIS Safety Lever Reason Without a Status Change",
+			fmt.Sprintf("AWS does not allow changing the safety lever's reason (from %q to %q) without also "+
+				"changing its status. The configured status (%q) matches the current status, so this change "+
+				"cannot be applied. Pair the reason change with an actual status transition, or set reason "+
+				"back to %q.",
+				priorState.Reason.ValueString(), planState.Reason.ValueString(), planState.Status.ValueString(), priorState.Reason.ValueString()),
+		)
+		return
+	}
+
+	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
+}
+
+// No Delete API. Delete simply stops Terraform from tracking it and leaves the live value untouched.
+func (r *safetyLeverStateResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}
+
+func (r *safetyLeverStateResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrID), req, resp)
+}
+
+func updateSafetyLeverState(ctx context.Context, conn *fis.Client, id, status, reason string) (*awstypes.SafetyLever, error) {
+	input := fis.UpdateSafetyLeverStateInput{
+		Id: aws.String(id),
+		State: &awstypes.UpdateSafetyLeverStateInput{
+			Reason: aws.String(reason),
+			Status: awstypes.SafetyLeverStatusInput(status),
+		},
+	}
+
+	out, err := conn.UpdateSafetyLeverState(ctx, &input)
+	if err != nil {
+		return nil, smarterr.NewError(err)
+	}
+	if out == nil || out.SafetyLever == nil {
+		return nil, smarterr.NewError(tfresource.NewEmptyResultError())
+	}
+
+	return out.SafetyLever, nil
+}
+
+func findSafetyLever(ctx context.Context, conn *fis.Client, id string) (*awstypes.SafetyLever, error) {
+	input := fis.GetSafetyLeverInput{
+		Id: aws.String(id),
+	}
+
+	out, err := conn.GetSafetyLever(ctx, &input)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, smarterr.NewError(&retry.NotFoundError{
+				LastError: err,
+			})
+		}
+
+		return nil, smarterr.NewError(err)
+	}
+
+	if out == nil || out.SafetyLever == nil {
+		return nil, smarterr.NewError(tfresource.NewEmptyResultError())
+	}
+
+	return out.SafetyLever, nil
+}
+
+// waitSafetyLeverStatus waits out the transitional "engaging" status (see
+// awstypes.SafetyLeverStatusEngaging) so Terraform never persists a non-terminal value to state.
+func waitSafetyLeverStatus(ctx context.Context, conn *fis.Client, id, target string, timeout time.Duration) (*awstypes.SafetyLever, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{string(awstypes.SafetyLeverStatusEngaging)},
+		Target:  []string{target},
+		Refresh: statusSafetyLever(conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*awstypes.SafetyLever); ok {
+		return out, smarterr.NewError(err)
+	}
+
+	return nil, smarterr.NewError(err)
+}
+
+func statusSafetyLever(conn *fis.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
+		out, err := findSafetyLever(ctx, conn, id)
+		if retry.NotFound(err) {
+			return nil, "", nil
+		}
+		if err != nil {
+			return nil, "", err
+		}
+		if out.State == nil {
+			return out, "", nil
+		}
+
+		return out, string(out.State.Status), nil
+	}
+}
+
+type safetyLeverStateResourceModel struct {
+	framework.WithRegionModel
+	ARN      types.String                                                `tfsdk:"arn"`
+	ID       types.String                                                `tfsdk:"id"`
+	State    fwtypes.ListNestedObjectValueOf[safetyLeverStateStateModel] `tfsdk:"state"`
+	Timeouts timeouts.Value                                              `tfsdk:"timeouts"`
+}
+
+type safetyLeverStateStateModel struct {
+	Reason types.String `tfsdk:"reason"`
+	Status types.String `tfsdk:"status"`
+}

--- a/internal/service/fis/safety_lever_state.go
+++ b/internal/service/fis/safety_lever_state.go
@@ -48,8 +48,6 @@ func newSafetyLeverStateResource(_ context.Context) (resource.ResourceWithConfig
 }
 
 const (
-	ResNameSafetyLeverState = "Safety Lever State"
-
 	// The FIS safety lever is an account/Region singleton: AWS always exposes exactly one,
 	// and every GetSafetyLever/UpdateSafetyLeverState call addresses it by the fixed literal
 	// "default". Terraform identifies it by resource identity ({account_id, region}) - see

--- a/internal/service/fis/safety_lever_state.go
+++ b/internal/service/fis/safety_lever_state.go
@@ -38,9 +38,7 @@ import (
 // @FrameworkResource("aws_fis_safety_lever_state", name="Safety Lever State")
 // @SingletonIdentity
 // @Testing(hasNoPreExistingResource=true)
-// Generated identity tests use static testdata configs, which can't drive the live
-// status transition this resource requires (a fixed status would hit the "without a
-// status change" ConflictException); hand-written in safety_lever_state_identity_test.go.
+// Identity Tests are hand-written in safety_lever_state_identity_test.go.
 // @Testing(identityTest=false)
 func newSafetyLeverStateResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &safetyLeverStateResource{}

--- a/internal/service/fis/safety_lever_state.go
+++ b/internal/service/fis/safety_lever_state.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -109,18 +110,7 @@ func (r *safetyLeverStateResource) Schema(ctx context.Context, req resource.Sche
 }
 
 func (r *safetyLeverStateResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan safetyLeverStateResourceModel
-	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	r.upsert(ctx, &plan, r.CreateTimeout(ctx, plan.Timeouts), &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
+	r.upsert(ctx, req.Plan, &resp.State, &resp.Diagnostics, r.CreateTimeout)
 }
 
 func (r *safetyLeverStateResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -152,22 +142,12 @@ func (r *safetyLeverStateResource) Read(ctx context.Context, req resource.ReadRe
 }
 
 func (r *safetyLeverStateResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan safetyLeverStateResourceModel
-	smerr.AddEnrich(ctx, &resp.Diagnostics, req.Plan.Get(ctx, &plan))
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	r.upsert(ctx, &plan, r.UpdateTimeout(ctx, plan.Timeouts), &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	smerr.AddEnrich(ctx, &resp.Diagnostics, resp.State.Set(ctx, &plan))
+	r.upsert(ctx, req.Plan, &resp.State, &resp.Diagnostics, r.UpdateTimeout)
 }
 
-// upsert is the single code path behind both Create and Update. The safety lever always
-// exists, so both operations are really "drive the lever to the configured state".
+// upsert is the single code path behind both Create and Update - the safety lever always exists,
+// so both operations are really "drive the lever to the configured state". Create and Update stay
+// as thin wrappers only because the Framework requires distinct methods.
 //
 // AWS rejects UpdateSafetyLeverState with a ConflictException whenever the requested status
 // already matches the live status - it will not accept a reason-only change. Rather than read
@@ -178,10 +158,16 @@ func (r *safetyLeverStateResource) Update(ctx context.Context, req resource.Upda
 //   - configured reason differs -> the change is genuinely unsatisfiable; fail with the live
 //     reason surfaced so the practitioner can reconcile their config. The configured value is
 //     never silently overwritten in state.
-func (r *safetyLeverStateResource) upsert(ctx context.Context, plan *safetyLeverStateResourceModel, timeout time.Duration, diags *diag.Diagnostics) {
+func (r *safetyLeverStateResource) upsert(ctx context.Context, plan tfsdk.Plan, state *tfsdk.State, diags *diag.Diagnostics, resolveTimeout func(context.Context, timeouts.Value) time.Duration) {
 	conn := r.Meta().FISClient(ctx)
 
-	planState, d := plan.State.ToPtr(ctx)
+	var data safetyLeverStateResourceModel
+	smerr.AddEnrich(ctx, diags, plan.Get(ctx, &data))
+	if diags.HasError() {
+		return
+	}
+
+	planState, d := data.State.ToPtr(ctx)
 	smerr.AddEnrich(ctx, diags, d)
 	if diags.HasError() {
 		return
@@ -194,9 +180,7 @@ func (r *safetyLeverStateResource) upsert(ctx context.Context, plan *safetyLever
 	_, err := updateSafetyLeverState(ctx, conn, safetyLeverDefaultID, status, reason)
 	switch {
 	case err == nil:
-		// A real status transition was accepted - wait out the transient "engaging" status
-		// so Terraform never persists a non-terminal value.
-		out, err = waitSafetyLeverStatus(ctx, conn, safetyLeverDefaultID, status, timeout)
+		out, err = waitSafetyLeverStatus(ctx, conn, safetyLeverDefaultID, status, resolveTimeout(ctx, data.Timeouts))
 		if err != nil {
 			smerr.AddError(ctx, diags, err, smerr.ID, safetyLeverDefaultID)
 			return
@@ -227,14 +211,19 @@ func (r *safetyLeverStateResource) upsert(ctx context.Context, plan *safetyLever
 			return
 		}
 
-		// Configured status and reason already match reality: nothing to do.
+		// Configured status and reason already match reality - nothing to do.
 		out = current
 	default:
 		smerr.AddError(ctx, diags, err, smerr.ID, safetyLeverDefaultID)
 		return
 	}
 
-	smerr.AddEnrich(ctx, diags, fwflex.Flatten(ctx, out, plan))
+	smerr.AddEnrich(ctx, diags, fwflex.Flatten(ctx, out, &data))
+	if diags.HasError() {
+		return
+	}
+
+	smerr.AddEnrich(ctx, diags, state.Set(ctx, &data))
 }
 
 func updateSafetyLeverState(ctx context.Context, conn *fis.Client, id, status, reason string) (*awstypes.SafetyLever, error) {
@@ -280,8 +269,6 @@ func findSafetyLever(ctx context.Context, conn *fis.Client, id string) (*awstype
 	return out.SafetyLever, nil
 }
 
-// waitSafetyLeverStatus waits out the transitional "engaging" status (see
-// awstypes.SafetyLeverStatusEngaging) so Terraform never persists a non-terminal value to state.
 func waitSafetyLeverStatus(ctx context.Context, conn *fis.Client, id, target string, timeout time.Duration) (*awstypes.SafetyLever, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{string(awstypes.SafetyLeverStatusEngaging)},

--- a/internal/service/fis/safety_lever_state.go
+++ b/internal/service/fis/safety_lever_state.go
@@ -38,6 +38,9 @@ import (
 // @FrameworkResource("aws_fis_safety_lever_state", name="Safety Lever State")
 // @SingletonIdentity
 // @Testing(hasNoPreExistingResource=true)
+// Generated identity tests use static testdata configs, which can't drive the live
+// status transition this resource requires (a fixed status would hit the "without a
+// status change" ConflictException); hand-written in safety_lever_state_identity_test.go.
 // @Testing(identityTest=false)
 func newSafetyLeverStateResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &safetyLeverStateResource{}

--- a/internal/service/fis/safety_lever_state.go
+++ b/internal/service/fis/safety_lever_state.go
@@ -51,18 +51,12 @@ func newSafetyLeverStateResource(_ context.Context) (resource.ResourceWithConfig
 const (
 	// The FIS safety lever is an account/Region singleton: AWS always exposes exactly one,
 	// and every GetSafetyLever/UpdateSafetyLeverState call addresses it by the fixed literal
-	// "default". Terraform identifies it by resource identity ({account_id, region}) - see
-	// @SingletonIdentity - so there is no "id" attribute.
+	// "default".
 	safetyLeverDefaultID = "default"
-
-	// Substring of the ConflictException AWS returns from UpdateSafetyLeverState when the
-	// requested status already matches the live status ("Cannot update Safety Lever reason
-	// without a status change").
-	safetyLeverReasonWithoutStatusChange = "without a status change"
 )
 
 // The safety lever has no Create or Delete API - it always exists. Delete is intentionally a
-// no-op (framework.WithNoOpDelete): it only stops Terraform tracking the lever and never
+// no-op. It only stops Terraform tracking the lever and never
 // touches the live value, so destroying this resource can't silently disengage a safety control.
 type safetyLeverStateResource struct {
 	framework.ResourceWithModel[safetyLeverStateResourceModel]
@@ -146,18 +140,7 @@ func (r *safetyLeverStateResource) Update(ctx context.Context, req resource.Upda
 }
 
 // upsert is the single code path behind both Create and Update - the safety lever always exists,
-// so both operations are really "drive the lever to the configured state". Create and Update stay
-// as thin wrappers only because the Framework requires distinct methods.
-//
-// AWS rejects UpdateSafetyLeverState with a ConflictException whenever the requested status
-// already matches the live status - it will not accept a reason-only change. Rather than read
-// first to avoid that call, upsert attempts it and interprets the conflict:
-//
-//   - configured reason already matches the live reason -> the declared config matches reality,
-//     so this is a legitimate provider no-op (mirrors how Delete swallows NotFound).
-//   - configured reason differs -> the change is genuinely unsatisfiable; fail with the live
-//     reason surfaced so the practitioner can reconcile their config. The configured value is
-//     never silently overwritten in state.
+// so both operations are really "drive the lever to the configured state".
 func (r *safetyLeverStateResource) upsert(ctx context.Context, plan tfsdk.Plan, state *tfsdk.State, diags *diag.Diagnostics, resolveTimeout func(context.Context, timeouts.Value) time.Duration) {
 	conn := r.Meta().FISClient(ctx)
 
@@ -185,7 +168,7 @@ func (r *safetyLeverStateResource) upsert(ctx context.Context, plan tfsdk.Plan, 
 			smerr.AddError(ctx, diags, err, smerr.ID, safetyLeverDefaultID)
 			return
 		}
-	case errs.IsAErrorMessageContains[*awstypes.ConflictException](err, safetyLeverReasonWithoutStatusChange):
+	case errs.IsAErrorMessageContains[*awstypes.ConflictException](err, "without a status change"):
 		current, findErr := findSafetyLever(ctx, conn, safetyLeverDefaultID)
 		if findErr != nil {
 			smerr.AddError(ctx, diags, findErr, smerr.ID, safetyLeverDefaultID)

--- a/internal/service/fis/safety_lever_state.go
+++ b/internal/service/fis/safety_lever_state.go
@@ -66,6 +66,8 @@ type safetyLeverStateResource struct {
 	framework.WithImportByIdentity
 }
 
+var _ resource.ResourceWithModifyPlan = (*safetyLeverStateResource)(nil)
+
 func (r *safetyLeverStateResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
@@ -101,6 +103,16 @@ func (r *safetyLeverStateResource) Schema(ctx context.Context, req resource.Sche
 				Update: true,
 			}),
 		},
+	}
+}
+
+func (r *safetyLeverStateResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		resp.Diagnostics.AddWarning(
+			"Resource Destruction Considerations",
+			"Applying this resource destruction will only remove the safety lever state from Terraform state. "+
+				"The FIS safety lever remains unchanged because the API does not support deleting it.",
+		)
 	}
 }
 

--- a/internal/service/fis/safety_lever_state_identity_test.go
+++ b/internal/service/fis/safety_lever_state_identity_test.go
@@ -1,0 +1,143 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fis_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccFISSafetyLeverState_Identity_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_fis_safety_lever_state.test"
+	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t, acctest.Region())
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: create via a genuine status transition, then check resource identity.
+			{
+				Config: testAccSafetyLeverStateConfig_basic(startStatus, "Managed by Terraform acceptance test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(acctest.Region()),
+					}),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrRegion)),
+				},
+			},
+
+			// Step 2: import using the identity block - must produce a no-op plan.
+			{
+				ResourceName:    resourceName,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					},
+				},
+			},
+
+			// Step 3: import round-trip, matching the single instance on arn.
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+			},
+
+			// Step 4: leave the account's safety lever disengaged.
+			{
+				Config: testAccSafetyLeverStateConfig_basic("disengaged", "Managed by Terraform acceptance test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "state.0.status", "disengaged"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFISSafetyLeverState_Identity_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_fis_safety_lever_state.test"
+	altRegion := acctest.AlternateRegion()
+	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t, altRegion)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: create in the alternate Region, check identity carries that Region.
+			{
+				Config: testAccSafetyLeverStateConfig_region(altRegion, startStatus, "Managed by Terraform acceptance test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(altRegion)),
+					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrRegion:    knownvalue.StringExact(altRegion),
+					}),
+					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrRegion)),
+				},
+			},
+
+			// Step 2: import using the identity block - must produce a no-op plan in that Region.
+			{
+				ResourceName:    resourceName,
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(altRegion)),
+					},
+				},
+			},
+
+			// Step 3: leave the alternate Region's safety lever disengaged.
+			{
+				Config: testAccSafetyLeverStateConfig_region(altRegion, "disengaged", "Managed by Terraform acceptance test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "state.0.status", "disengaged"),
+				),
+			},
+		},
+	})
+}

--- a/internal/service/fis/safety_lever_state_identity_test.go
+++ b/internal/service/fis/safety_lever_state_identity_test.go
@@ -33,7 +33,7 @@ func testAccFISSafetyLeverState_Identity_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			// Step 1: create via a genuine status transition, then check resource identity.
 			{
@@ -115,7 +115,7 @@ func testAccFISSafetyLeverState_Identity_regionOverride(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			// Step 1: create in the alternate Region, check identity carries that Region.
 			{

--- a/internal/service/fis/safety_lever_state_identity_test.go
+++ b/internal/service/fis/safety_lever_state_identity_test.go
@@ -63,11 +63,12 @@ func testAccFISSafetyLeverState_Identity_basic(t *testing.T) {
 				},
 			},
 
-			// Step 3: import round-trip, matching the single instance on arn.
+			// Step 3: import round-trip by Region ID, matching the single instance on arn.
 			{
 				ResourceName:                         resourceName,
 				ImportState:                          true,
 				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrRegion),
 				ImportStateVerifyIdentifierAttribute: names.AttrARN,
 			},
 

--- a/internal/service/fis/safety_lever_state_identity_test.go
+++ b/internal/service/fis/safety_lever_state_identity_test.go
@@ -51,7 +51,30 @@ func testAccFISSafetyLeverState_Identity_basic(t *testing.T) {
 				},
 			},
 
-			// Step 2: import using the identity block - must produce a no-op plan.
+			// Step 2: import by Region ID and verify state round-trips (matched on arn).
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateKind:                      resource.ImportCommandWithID,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrRegion),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+			},
+
+			// Step 3: import block keyed by the Region ID - plan must be a clean no-op.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateKind:   resource.ImportBlockWithID,
+				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, names.AttrRegion),
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+					},
+				},
+			},
+
+			// Step 4: import block keyed by the resource identity - plan must be a clean no-op.
 			{
 				ResourceName:    resourceName,
 				ImportState:     true,
@@ -63,16 +86,7 @@ func testAccFISSafetyLeverState_Identity_basic(t *testing.T) {
 				},
 			},
 
-			// Step 3: import round-trip by Region ID, matching the single instance on arn.
-			{
-				ResourceName:                         resourceName,
-				ImportState:                          true,
-				ImportStateVerify:                    true,
-				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrRegion),
-				ImportStateVerifyIdentifierAttribute: names.AttrARN,
-			},
-
-			// Step 4: leave the account's safety lever disengaged.
+			// Step 5: leave the account's safety lever disengaged.
 			{
 				Config: testAccSafetyLeverStateConfig_basic(safetyLeverStatusDisengaged, "Managed by Terraform acceptance test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -119,7 +133,30 @@ func testAccFISSafetyLeverState_Identity_regionOverride(t *testing.T) {
 				},
 			},
 
-			// Step 2: import using the identity block - must produce a no-op plan in that Region.
+			// Step 2: import by "<region>@<region>" ID and verify state round-trips (matched on arn).
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateKind:                      resource.ImportCommandWithID,
+				ImportStateIdFunc:                    acctest.CrossRegionAttrImportStateIdFunc(resourceName, names.AttrRegion),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
+			},
+
+			// Step 3: import block keyed by the "<region>@<region>" ID - plan must be a clean no-op.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateKind:   resource.ImportBlockWithID,
+				ImportStateIdFunc: acctest.CrossRegionAttrImportStateIdFunc(resourceName, names.AttrRegion),
+				ImportPlanChecks: resource.ImportPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(altRegion)),
+					},
+				},
+			},
+
+			// Step 4: import block keyed by the resource identity - plan must be a clean no-op in that Region.
 			{
 				ResourceName:    resourceName,
 				ImportState:     true,
@@ -131,7 +168,7 @@ func testAccFISSafetyLeverState_Identity_regionOverride(t *testing.T) {
 				},
 			},
 
-			// Step 3: leave the alternate Region's safety lever disengaged.
+			// Step 5: leave the alternate Region's safety lever disengaged.
 			{
 				Config: testAccSafetyLeverStateConfig_region(altRegion, safetyLeverStatusDisengaged, "Managed by Terraform acceptance test"),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/service/fis/safety_lever_state_identity_test.go
+++ b/internal/service/fis/safety_lever_state_identity_test.go
@@ -74,10 +74,10 @@ func testAccFISSafetyLeverState_Identity_basic(t *testing.T) {
 
 			// Step 4: leave the account's safety lever disengaged.
 			{
-				Config: testAccSafetyLeverStateConfig_basic("disengaged", "Managed by Terraform acceptance test"),
+				Config: testAccSafetyLeverStateConfig_basic(safetyLeverStatusDisengaged, "Managed by Terraform acceptance test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "state.0.status", "disengaged"),
+					resource.TestCheckResourceAttr(resourceName, "state.0.status", safetyLeverStatusDisengaged),
 				),
 			},
 		},
@@ -133,10 +133,10 @@ func testAccFISSafetyLeverState_Identity_regionOverride(t *testing.T) {
 
 			// Step 3: leave the alternate Region's safety lever disengaged.
 			{
-				Config: testAccSafetyLeverStateConfig_region(altRegion, "disengaged", "Managed by Terraform acceptance test"),
+				Config: testAccSafetyLeverStateConfig_region(altRegion, safetyLeverStatusDisengaged, "Managed by Terraform acceptance test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "state.0.status", "disengaged"),
+					resource.TestCheckResourceAttr(resourceName, "state.0.status", safetyLeverStatusDisengaged),
 				),
 			},
 		},

--- a/internal/service/fis/safety_lever_state_list.go
+++ b/internal/service/fis/safety_lever_state_list.go
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fis
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+)
+
+// Function annotations are used for list resource registration to the Provider. DO NOT EDIT.
+// @FrameworkListResource("aws_fis_safety_lever_state")
+func newSafetyLeverStateResourceAsListResource() list.ListResourceWithConfigure {
+	return &safetyLeverStateListResource{}
+}
+
+var _ list.ListResource = &safetyLeverStateListResource{}
+
+type safetyLeverStateListResource struct {
+	safetyLeverStateResource
+	framework.WithList
+}
+
+func (l *safetyLeverStateListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().FISClient(ctx)
+
+	tflog.Info(ctx, "Listing FIS Safety Lever States")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		out, err := findSafetyLever(ctx, conn, safetyLeverDefaultID)
+		if retry.NotFound(err) {
+			return
+		}
+		if err != nil {
+			yield(fwdiag.NewListResultErrorDiagnostic(err))
+			return
+		}
+
+		result := request.NewListResult(ctx)
+		var data safetyLeverStateResourceModel
+
+		l.SetResult(ctx, l.Meta(), request.IncludeResource, &data, &result, func() {
+			if request.IncludeResource {
+				result.Diagnostics.Append(fwflex.Flatten(ctx, out, &data)...)
+				if result.Diagnostics.HasError() {
+					return
+				}
+			}
+
+			result.DisplayName = safetyLeverDefaultID
+		})
+
+		yield(result)
+	}
+}

--- a/internal/service/fis/safety_lever_state_list_test.go
+++ b/internal/service/fis/safety_lever_state_list_test.go
@@ -1,0 +1,206 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fis_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccFISSafetyLeverState_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_fis_safety_lever_state.test"
+	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t, acctest.Region())
+	identity := tfstatecheck.Identity()
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: create the singleton via a genuine status transition.
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_basic/"),
+				ConfigVariables: config.Variables{
+					names.AttrStatus: config.StringVariable(startStatus),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+				},
+			},
+
+			// Step 2: query - the single lever must appear with matching identity and no resource object.
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_basic/"),
+				ConfigVariables: config.Variables{
+					names.AttrStatus: config.StringVariable(startStatus),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc(resourceName, identity.Checks()),
+					querycheck.ExpectResourceDisplayName(resourceName, tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), knownvalue.StringExact("default")),
+					tfquerycheck.ExpectNoResourceObject(resourceName, tfqueryfilter.ByResourceIdentityFunc(identity.Checks())),
+				},
+			},
+
+			// Step 3: leave the account's safety lever disengaged.
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_basic/"),
+				ConfigVariables: config.Variables{
+					names.AttrStatus: config.StringVariable(safetyLeverStatusDisengaged),
+				},
+			},
+		},
+	})
+}
+
+func testAccFISSafetyLeverState_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_fis_safety_lever_state.test"
+	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t, acctest.Region())
+	identity := tfstatecheck.Identity()
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: create the singleton via a genuine status transition.
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					names.AttrStatus: config.StringVariable(startStatus),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+				},
+			},
+
+			// Step 2: query with include_resource - the resource object must be populated.
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					names.AttrStatus: config.StringVariable(startStatus),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc(resourceName, identity.Checks()),
+					querycheck.ExpectResourceDisplayName(resourceName, tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), knownvalue.StringExact("default")),
+					querycheck.ExpectResourceKnownValues(resourceName, tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNExact("fis", "safety-lever/default")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrState).AtSliceIndex(0).AtMapKey(names.AttrStatus), knownvalue.StringExact(startStatus)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrState).AtSliceIndex(0).AtMapKey("reason"), knownvalue.StringExact("Managed by Terraform acceptance test")),
+					}),
+				},
+			},
+
+			// Step 3: leave the account's safety lever disengaged.
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					names.AttrStatus: config.StringVariable(safetyLeverStatusDisengaged),
+				},
+			},
+		},
+	})
+}
+
+func testAccFISSafetyLeverState_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_fis_safety_lever_state.test"
+	altRegion := acctest.AlternateRegion()
+	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t, altRegion)
+	identity := tfstatecheck.Identity()
+
+	acctest.Test(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			// Step 1: create the lever in the alternate Region.
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_region_override/"),
+				ConfigVariables: config.Variables{
+					names.AttrRegion: config.StringVariable(altRegion),
+					names.AttrStatus: config.StringVariable(startStatus),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity.GetIdentity(resourceName),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(altRegion)),
+				},
+			},
+
+			// Step 2: query with config.region set to the alternate Region.
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_region_override/"),
+				ConfigVariables: config.Variables{
+					names.AttrRegion: config.StringVariable(altRegion),
+					names.AttrStatus: config.StringVariable(startStatus),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc(resourceName, identity.Checks()),
+					querycheck.ExpectResourceDisplayName(resourceName, tfqueryfilter.ByResourceIdentityFunc(identity.Checks()), knownvalue.StringExact("default")),
+				},
+			},
+
+			// Step 3: leave the alternate Region's safety lever disengaged.
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_region_override/"),
+				ConfigVariables: config.Variables{
+					names.AttrRegion: config.StringVariable(altRegion),
+					names.AttrStatus: config.StringVariable(safetyLeverStatusDisengaged),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/fis/safety_lever_state_list_test.go
+++ b/internal/service/fis/safety_lever_state_list_test.go
@@ -44,7 +44,7 @@ func testAccFISSafetyLeverState_List_basic(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_basic/"),
 				ConfigVariables: config.Variables{
-					names.AttrStatus: config.StringVariable(startStatus),
+					"status": config.StringVariable(startStatus),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
@@ -59,7 +59,7 @@ func testAccFISSafetyLeverState_List_basic(t *testing.T) {
 				Query:           true,
 				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_basic/"),
 				ConfigVariables: config.Variables{
-					names.AttrStatus: config.StringVariable(startStatus),
+					"status": config.StringVariable(startStatus),
 				},
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					tfquerycheck.ExpectIdentityFunc(resourceName, identity.Checks()),
@@ -72,7 +72,7 @@ func testAccFISSafetyLeverState_List_basic(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_basic/"),
 				ConfigVariables: config.Variables{
-					names.AttrStatus: config.StringVariable(safetyLeverStatusDisengaged),
+					"status": config.StringVariable(safetyLeverStatusDisengaged),
 				},
 			},
 		},
@@ -102,7 +102,7 @@ func testAccFISSafetyLeverState_List_includeResource(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_include_resource/"),
 				ConfigVariables: config.Variables{
-					names.AttrStatus: config.StringVariable(startStatus),
+					"status": config.StringVariable(startStatus),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
@@ -117,7 +117,7 @@ func testAccFISSafetyLeverState_List_includeResource(t *testing.T) {
 				Query:           true,
 				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_include_resource/"),
 				ConfigVariables: config.Variables{
-					names.AttrStatus: config.StringVariable(startStatus),
+					"status": config.StringVariable(startStatus),
 				},
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					tfquerycheck.ExpectIdentityFunc(resourceName, identity.Checks()),
@@ -135,7 +135,7 @@ func testAccFISSafetyLeverState_List_includeResource(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_include_resource/"),
 				ConfigVariables: config.Variables{
-					names.AttrStatus: config.StringVariable(safetyLeverStatusDisengaged),
+					"status": config.StringVariable(safetyLeverStatusDisengaged),
 				},
 			},
 		},
@@ -167,8 +167,8 @@ func testAccFISSafetyLeverState_List_regionOverride(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_region_override/"),
 				ConfigVariables: config.Variables{
-					names.AttrRegion: config.StringVariable(altRegion),
-					names.AttrStatus: config.StringVariable(startStatus),
+					"region": config.StringVariable(altRegion),
+					"status": config.StringVariable(startStatus),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
@@ -184,8 +184,8 @@ func testAccFISSafetyLeverState_List_regionOverride(t *testing.T) {
 				Query:           true,
 				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_region_override/"),
 				ConfigVariables: config.Variables{
-					names.AttrRegion: config.StringVariable(altRegion),
-					names.AttrStatus: config.StringVariable(startStatus),
+					"region": config.StringVariable(altRegion),
+					"status": config.StringVariable(startStatus),
 				},
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					tfquerycheck.ExpectIdentityFunc(resourceName, identity.Checks()),
@@ -197,8 +197,8 @@ func testAccFISSafetyLeverState_List_regionOverride(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/SafetyLeverState/list_region_override/"),
 				ConfigVariables: config.Variables{
-					names.AttrRegion: config.StringVariable(altRegion),
-					names.AttrStatus: config.StringVariable(safetyLeverStatusDisengaged),
+					"region": config.StringVariable(altRegion),
+					"status": config.StringVariable(safetyLeverStatusDisengaged),
 				},
 			},
 		},

--- a/internal/service/fis/safety_lever_state_list_test.go
+++ b/internal/service/fis/safety_lever_state_list_test.go
@@ -38,7 +38,7 @@ func testAccFISSafetyLeverState_List_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			// Step 1: create the singleton via a genuine status transition.
 			{
@@ -96,7 +96,7 @@ func testAccFISSafetyLeverState_List_includeResource(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			// Step 1: create the singleton via a genuine status transition.
 			{
@@ -161,7 +161,7 @@ func testAccFISSafetyLeverState_List_regionOverride(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			// Step 1: create the lever in the alternate Region.
 			{

--- a/internal/service/fis/safety_lever_state_test.go
+++ b/internal/service/fis/safety_lever_state_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/fis"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/fis/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tffis "github.com/hashicorp/terraform-provider-aws/internal/service/fis"
@@ -115,6 +116,11 @@ func testAccFISSafetyLeverState_update(t *testing.T) {
 			},
 			{
 				Config: testAccSafetyLeverStateConfig_basic(otherStatus, "Blocked for scheduled maintenance"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "state.0.status", otherStatus),

--- a/internal/service/fis/safety_lever_state_test.go
+++ b/internal/service/fis/safety_lever_state_test.go
@@ -53,7 +53,7 @@ func testAccFISSafetyLeverState_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSafetyLeverStateConfig_basic(startStatus, "Managed by Terraform acceptance test"),
@@ -105,7 +105,7 @@ func testAccFISSafetyLeverState_update(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSafetyLeverStateConfig_basic(startStatus, "Managed by Terraform acceptance test"),
@@ -136,13 +136,6 @@ func testAccFISSafetyLeverState_update(t *testing.T) {
 			},
 		},
 	})
-}
-
-// Delete is no-op
-func testAccCheckSafetyLeverStateDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		return nil
-	}
 }
 
 func testAccCheckSafetyLeverStateExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {

--- a/internal/service/fis/safety_lever_state_test.go
+++ b/internal/service/fis/safety_lever_state_test.go
@@ -31,6 +31,9 @@ func TestAccFISSafetyLeverState_serial(t *testing.T) {
 		"update":                  testAccFISSafetyLeverState_update,
 		"Identity_basic":          testAccFISSafetyLeverState_Identity_basic,
 		"Identity_regionOverride": testAccFISSafetyLeverState_Identity_regionOverride,
+		"List_basic":              testAccFISSafetyLeverState_List_basic,
+		"List_includeResource":    testAccFISSafetyLeverState_List_includeResource,
+		"List_regionOverride":     testAccFISSafetyLeverState_List_regionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)

--- a/internal/service/fis/safety_lever_state_test.go
+++ b/internal/service/fis/safety_lever_state_test.go
@@ -1,0 +1,211 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fis_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/fis"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/fis/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tffis "github.com/hashicorp/terraform-provider-aws/internal/service/fis"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// The FIS safety lever is an account/region singleton: it always exists, so no two tests in this
+// package can be allowed to mutate it concurrently - acctest.ParallelTest's default t.Parallel()
+// behavior would let TestAccFISSafetyLeverState_basic and _update race on the same "default"
+// lever, each seeing the other's in-flight changes. RunSerialTests1Level forces them to run one
+// at a time, exactly like TestAccEC2SerialConsoleAccess_serial does for the analogous singleton
+// EC2 setting.
+func TestAccFISSafetyLeverState_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basic":  testAccFISSafetyLeverState_basic,
+		"update": testAccFISSafetyLeverState_update,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+// It also cannot simply declare a fixed starting status: AWS's UpdateSafetyLeverState rejects a
+// call whenever the requested status already matches the account's live status ("Cannot update
+// Safety Lever reason without a status change"), so the resource's Create deliberately errors in
+// that case instead of silently no-op'ing. testAccSafetyLeverStateOppositeStatus reads the live
+// status first so the initial apply is always a genuine transition.
+func testAccFISSafetyLeverState_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var safetyLever awstypes.SafetyLever
+	resourceName := "aws_fis_safety_lever_state.test"
+	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t)
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSafetyLeverStateConfig_basic(startStatus, "Managed by Terraform acceptance test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName, &safetyLever),
+					resource.TestCheckResourceAttr(resourceName, names.AttrID, "default"),
+					resource.TestCheckResourceAttr(resourceName, "state.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "state.0.status", startStatus),
+					resource.TestCheckResourceAttr(resourceName, "state.0.reason", "Managed by Terraform acceptance test"),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "fis", "safety-lever/default"),
+				),
+			},
+			{
+				// Always leave the account's safety lever disengaged when the test finishes. A
+				// no-op (no diff, no API call) if startStatus was already "disengaged".
+				Config: testAccSafetyLeverStateConfig_basic("disengaged", "Managed by Terraform acceptance test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName, &safetyLever),
+					resource.TestCheckResourceAttr(resourceName, "state.0.status", "disengaged"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccFISSafetyLeverState_update(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var before, after awstypes.SafetyLever
+	resourceName := "aws_fis_safety_lever_state.test"
+	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t)
+	otherStatus := "engaged"
+	if startStatus == "engaged" {
+		otherStatus = "disengaged"
+	}
+	// If otherStatus is already "disengaged", the final cleanup step below is a same-status no-op,
+	// so its reason must match what step 2 actually applied - AWS rejects a reason-only change.
+	cleanupReason := "Managed by Terraform acceptance test"
+	if otherStatus == "disengaged" {
+		cleanupReason = "Blocked for scheduled maintenance"
+	}
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.FISServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSafetyLeverStateDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSafetyLeverStateConfig_basic(startStatus, "Managed by Terraform acceptance test"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "state.0.status", startStatus),
+				),
+			},
+			{
+				Config: testAccSafetyLeverStateConfig_basic(otherStatus, "Blocked for scheduled maintenance"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "state.0.status", otherStatus),
+					resource.TestCheckResourceAttr(resourceName, "state.0.reason", "Blocked for scheduled maintenance"),
+				),
+			},
+			{
+				// Always leave the account's safety lever disengaged when the test finishes. If
+				// otherStatus was already "disengaged" this must be a true no-op (same status AND
+				// same reason as the prior step) - reusing a different reason string here would
+				// itself be an invalid reason-only change, since status wouldn't be transitioning.
+				Config: testAccSafetyLeverStateConfig_basic("disengaged", cleanupReason),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "state.0.status", "disengaged"),
+				),
+			},
+		},
+	})
+}
+
+// There is no DeleteSafetyLever API and the resource's Delete implementation intentionally makes
+// no AWS API call (see the comment on safetyLeverStateResource.Delete), so there is nothing to
+// verify here beyond the state being removed from Terraform.
+func testAccCheckSafetyLeverStateDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return nil
+	}
+}
+
+func testAccCheckSafetyLeverStateExists(ctx context.Context, t *testing.T, name string, safetyLever *awstypes.SafetyLever) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.FIS, create.ErrActionCheckingExistence, tffis.ResNameSafetyLeverState, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.FIS, create.ErrActionCheckingExistence, tffis.ResNameSafetyLeverState, name, errors.New("not set"))
+		}
+
+		conn := acctest.ProviderMeta(ctx, t).FISClient(ctx)
+
+		resp, err := tffis.FindSafetyLever(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.FIS, create.ErrActionCheckingExistence, tffis.ResNameSafetyLeverState, rs.Primary.ID, err)
+		}
+
+		*safetyLever = *resp
+
+		return nil
+	}
+}
+
+// testAccSafetyLeverStateOppositeStatus reads the account's live safety lever status using a
+// standalone SDK client (rather than acctest.ProviderMeta, which is not guaranteed configured
+// this early - before resource.ParallelTest has run) and returns the opposite value, so the
+// caller's first apply is guaranteed to be a genuine status transition.
+func testAccSafetyLeverStateOppositeStatus(ctx context.Context, t *testing.T) string {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(acctest.Region()))
+	if err != nil {
+		t.Fatalf("loading AWS config: %s", err)
+	}
+
+	conn := fis.NewFromConfig(cfg)
+	current, err := tffis.FindSafetyLever(ctx, conn, "default")
+	if err != nil {
+		t.Fatalf("reading FIS safety lever: %s", err)
+	}
+
+	if string(current.State.Status) == "engaged" {
+		return "disengaged"
+	}
+	return "engaged"
+}
+
+func testAccSafetyLeverStateConfig_basic(status, reason string) string {
+	return `
+resource "aws_fis_safety_lever_state" "test" {
+  state {
+    status = "` + status + `"
+    reason = "` + reason + `"
+  }
+}
+`
+}

--- a/internal/service/fis/safety_lever_state_test.go
+++ b/internal/service/fis/safety_lever_state_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/fis"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/fis/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -17,12 +18,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// The FIS safety lever is an account/region singleton: it always exists, so no two tests in this
-// package can be allowed to mutate it concurrently - acctest.ParallelTest's default t.Parallel()
-// behavior would let TestAccFISSafetyLeverState_basic and _update race on the same "default"
-// lever, each seeing the other's in-flight changes. RunSerialTests1Level forces them to run one
-// at a time, exactly like TestAccEC2SerialConsoleAccess_serial does for the analogous singleton
-// EC2 setting.
+const (
+	safetyLeverStatusEngaged    = string(awstypes.SafetyLeverStatusInputEngaged)
+	safetyLeverStatusDisengaged = string(awstypes.SafetyLeverStatusInputDisengaged)
+)
+
 func TestAccFISSafetyLeverState_serial(t *testing.T) {
 	t.Parallel()
 
@@ -36,10 +36,6 @@ func TestAccFISSafetyLeverState_serial(t *testing.T) {
 	acctest.RunSerialTests1Level(t, testCases, 0)
 }
 
-// AWS's UpdateSafetyLeverState rejects any call whose requested status already matches the
-// account's live status ("Cannot update Safety Lever reason without a status change"), so
-// testAccSafetyLeverStateOppositeStatus reads the live status first and the initial apply is
-// always a genuine transition.
 func testAccFISSafetyLeverState_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -66,12 +62,10 @@ func testAccFISSafetyLeverState_basic(t *testing.T) {
 				),
 			},
 			{
-				// Always leave the account's safety lever disengaged when the test finishes. A
-				// no-op (no diff, no API call) if startStatus was already "disengaged".
-				Config: testAccSafetyLeverStateConfig_basic("disengaged", "Managed by Terraform acceptance test"),
+				Config: testAccSafetyLeverStateConfig_basic(safetyLeverStatusDisengaged, "Managed by Terraform acceptance test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "state.0.status", "disengaged"),
+					resource.TestCheckResourceAttr(resourceName, "state.0.status", safetyLeverStatusDisengaged),
 				),
 			},
 			{
@@ -90,14 +84,13 @@ func testAccFISSafetyLeverState_update(t *testing.T) {
 
 	resourceName := "aws_fis_safety_lever_state.test"
 	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t, acctest.Region())
-	otherStatus := "engaged"
-	if startStatus == "engaged" {
-		otherStatus = "disengaged"
+	otherStatus := safetyLeverStatusEngaged
+	if startStatus == safetyLeverStatusEngaged {
+		otherStatus = safetyLeverStatusDisengaged
 	}
-	// If otherStatus is already "disengaged", the final cleanup step below is a same-status no-op,
-	// so its reason must match what step 2 actually applied - AWS rejects a reason-only change.
+
 	cleanupReason := "Managed by Terraform acceptance test"
-	if otherStatus == "disengaged" {
+	if otherStatus == safetyLeverStatusDisengaged {
 		cleanupReason = "Blocked for scheduled maintenance"
 	}
 
@@ -126,22 +119,17 @@ func testAccFISSafetyLeverState_update(t *testing.T) {
 				),
 			},
 			{
-				// Always leave the account's safety lever disengaged when the test finishes. If
-				// otherStatus was already "disengaged" this must be a true no-op (same status AND
-				// same reason as the prior step) - reusing a different reason string here would
-				// itself be an invalid reason-only change, since status wouldn't be transitioning.
-				Config: testAccSafetyLeverStateConfig_basic("disengaged", cleanupReason),
+				Config: testAccSafetyLeverStateConfig_basic(safetyLeverStatusDisengaged, cleanupReason),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "state.0.status", "disengaged"),
+					resource.TestCheckResourceAttr(resourceName, "state.0.status", safetyLeverStatusDisengaged),
 				),
 			},
 		},
 	})
 }
 
-// There is no DeleteSafetyLever API and the resource's Delete is a no-op (framework.WithNoOpDelete),
-// so there is nothing to verify here beyond the state being removed from Terraform.
+// Delete is no-op
 func testAccCheckSafetyLeverStateDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		return nil
@@ -156,18 +144,12 @@ func testAccCheckSafetyLeverStateExists(ctx context.Context, t *testing.T, n str
 
 		conn := acctest.ProviderMeta(ctx, t).FISClient(ctx)
 
-		// The safety lever is a singleton addressed by the fixed literal "default"; the resource
-		// carries no "id" attribute (identity is {account_id, region}).
 		_, err := tffis.FindSafetyLever(ctx, conn, "default")
 
 		return err
 	}
 }
 
-// testAccSafetyLeverStateOppositeStatus reads the live safety lever status in the given Region
-// using a standalone SDK client (rather than acctest.ProviderMeta, which is not guaranteed
-// configured this early - before resource.ParallelTest has run) and returns the opposite value,
-// so the caller's first apply is guaranteed to be a genuine status transition.
 func testAccSafetyLeverStateOppositeStatus(ctx context.Context, t *testing.T, region string) string {
 	t.Helper()
 
@@ -182,10 +164,10 @@ func testAccSafetyLeverStateOppositeStatus(ctx context.Context, t *testing.T, re
 		t.Fatalf("reading FIS safety lever: %s", err)
 	}
 
-	if string(current.State.Status) == "engaged" {
-		return "disengaged"
+	if current.State.Status == awstypes.SafetyLeverStatusEngaged {
+		return safetyLeverStatusDisengaged
 	}
-	return "engaged"
+	return safetyLeverStatusEngaged
 }
 
 func testAccSafetyLeverStateConfig_basic(status, reason string) string {

--- a/internal/service/fis/safety_lever_state_test.go
+++ b/internal/service/fis/safety_lever_state_test.go
@@ -27,7 +27,7 @@ func TestAccFISSafetyLeverState_serial(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]func(t *testing.T){
-		"basic":                   testAccFISSafetyLeverState_basic,
+		acctest.CtBasic:           testAccFISSafetyLeverState_basic,
 		"update":                  testAccFISSafetyLeverState_update,
 		"Identity_basic":          testAccFISSafetyLeverState_Identity_basic,
 		"Identity_regionOverride": testAccFISSafetyLeverState_Identity_regionOverride,
@@ -189,25 +189,25 @@ func testAccSafetyLeverStateOppositeStatus(ctx context.Context, t *testing.T, re
 }
 
 func testAccSafetyLeverStateConfig_basic(status, reason string) string {
-	return `
+	return fmt.Sprintf(`
 resource "aws_fis_safety_lever_state" "test" {
   state {
-    status = "` + status + `"
-    reason = "` + reason + `"
+    status = %[1]q
+    reason = %[2]q
   }
 }
-`
+`, status, reason)
 }
 
 func testAccSafetyLeverStateConfig_region(region, status, reason string) string {
-	return `
+	return fmt.Sprintf(`
 resource "aws_fis_safety_lever_state" "test" {
-  region = "` + region + `"
+  region = %[1]q
 
   state {
-    status = "` + status + `"
-    reason = "` + reason + `"
+    status = %[2]q
+    reason = %[3]q
   }
 }
-`
+`, region, status, reason)
 }

--- a/internal/service/fis/safety_lever_state_test.go
+++ b/internal/service/fis/safety_lever_state_test.go
@@ -76,8 +76,6 @@ func testAccFISSafetyLeverState_basic(t *testing.T) {
 				),
 			},
 			{
-				// The safety lever has no "id" attribute: the import ID is the Region (consumed
-				// by the RegionalSingleton importer), and verify matches the single instance on arn.
 				ResourceName:                         resourceName,
 				ImportState:                          true,
 				ImportStateVerify:                    true,

--- a/internal/service/fis/safety_lever_state_test.go
+++ b/internal/service/fis/safety_lever_state_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/fis"
-	awstypes "github.com/aws/aws-sdk-go-v2/service/fis/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -29,24 +28,24 @@ func TestAccFISSafetyLeverState_serial(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]func(t *testing.T){
-		"basic":  testAccFISSafetyLeverState_basic,
-		"update": testAccFISSafetyLeverState_update,
+		"basic":                   testAccFISSafetyLeverState_basic,
+		"update":                  testAccFISSafetyLeverState_update,
+		"Identity_basic":          testAccFISSafetyLeverState_Identity_basic,
+		"Identity_regionOverride": testAccFISSafetyLeverState_Identity_regionOverride,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
 }
 
-// It also cannot simply declare a fixed starting status: AWS's UpdateSafetyLeverState rejects a
-// call whenever the requested status already matches the account's live status ("Cannot update
-// Safety Lever reason without a status change"), so the resource's Create deliberately errors in
-// that case instead of silently no-op'ing. testAccSafetyLeverStateOppositeStatus reads the live
-// status first so the initial apply is always a genuine transition.
+// AWS's UpdateSafetyLeverState rejects any call whose requested status already matches the
+// account's live status ("Cannot update Safety Lever reason without a status change"), so
+// testAccSafetyLeverStateOppositeStatus reads the live status first and the initial apply is
+// always a genuine transition.
 func testAccFISSafetyLeverState_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	var safetyLever awstypes.SafetyLever
 	resourceName := "aws_fis_safety_lever_state.test"
-	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t)
+	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t, acctest.Region())
 
 	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
@@ -60,8 +59,7 @@ func testAccFISSafetyLeverState_basic(t *testing.T) {
 			{
 				Config: testAccSafetyLeverStateConfig_basic(startStatus, "Managed by Terraform acceptance test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSafetyLeverStateExists(ctx, t, resourceName, &safetyLever),
-					resource.TestCheckResourceAttr(resourceName, names.AttrID, "default"),
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "state.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "state.0.status", startStatus),
 					resource.TestCheckResourceAttr(resourceName, "state.0.reason", "Managed by Terraform acceptance test"),
@@ -73,14 +71,17 @@ func testAccFISSafetyLeverState_basic(t *testing.T) {
 				// no-op (no diff, no API call) if startStatus was already "disengaged".
 				Config: testAccSafetyLeverStateConfig_basic("disengaged", "Managed by Terraform acceptance test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSafetyLeverStateExists(ctx, t, resourceName, &safetyLever),
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "state.0.status", "disengaged"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				// The safety lever has no "id" attribute; import resolves it from resource
+				// identity ({account_id, region}), and verify matches the single instance on arn.
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrARN,
 			},
 		},
 	})
@@ -89,9 +90,8 @@ func testAccFISSafetyLeverState_basic(t *testing.T) {
 func testAccFISSafetyLeverState_update(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	var before, after awstypes.SafetyLever
 	resourceName := "aws_fis_safety_lever_state.test"
-	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t)
+	startStatus := testAccSafetyLeverStateOppositeStatus(ctx, t, acctest.Region())
 	otherStatus := "engaged"
 	if startStatus == "engaged" {
 		otherStatus = "disengaged"
@@ -115,14 +115,14 @@ func testAccFISSafetyLeverState_update(t *testing.T) {
 			{
 				Config: testAccSafetyLeverStateConfig_basic(startStatus, "Managed by Terraform acceptance test"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSafetyLeverStateExists(ctx, t, resourceName, &before),
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "state.0.status", startStatus),
 				),
 			},
 			{
 				Config: testAccSafetyLeverStateConfig_basic(otherStatus, "Blocked for scheduled maintenance"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSafetyLeverStateExists(ctx, t, resourceName, &after),
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "state.0.status", otherStatus),
 					resource.TestCheckResourceAttr(resourceName, "state.0.reason", "Blocked for scheduled maintenance"),
 				),
@@ -134,7 +134,7 @@ func testAccFISSafetyLeverState_update(t *testing.T) {
 				// itself be an invalid reason-only change, since status wouldn't be transitioning.
 				Config: testAccSafetyLeverStateConfig_basic("disengaged", cleanupReason),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSafetyLeverStateExists(ctx, t, resourceName, &after),
+					testAccCheckSafetyLeverStateExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "state.0.status", "disengaged"),
 				),
 			},
@@ -142,47 +142,40 @@ func testAccFISSafetyLeverState_update(t *testing.T) {
 	})
 }
 
-// There is no DeleteSafetyLever API and the resource's Delete implementation intentionally makes
-// no AWS API call (see the comment on safetyLeverStateResource.Delete), so there is nothing to
-// verify here beyond the state being removed from Terraform.
+// There is no DeleteSafetyLever API and the resource's Delete is a no-op (framework.WithNoOpDelete),
+// so there is nothing to verify here beyond the state being removed from Terraform.
 func testAccCheckSafetyLeverStateDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		return nil
 	}
 }
 
-func testAccCheckSafetyLeverStateExists(ctx context.Context, t *testing.T, name string, safetyLever *awstypes.SafetyLever) resource.TestCheckFunc {
+func testAccCheckSafetyLeverStateExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
+		if _, ok := s.RootModule().Resources[name]; !ok {
 			return create.Error(names.FIS, create.ErrActionCheckingExistence, tffis.ResNameSafetyLeverState, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.FIS, create.ErrActionCheckingExistence, tffis.ResNameSafetyLeverState, name, errors.New("not set"))
 		}
 
 		conn := acctest.ProviderMeta(ctx, t).FISClient(ctx)
 
-		resp, err := tffis.FindSafetyLever(ctx, conn, rs.Primary.ID)
-		if err != nil {
-			return create.Error(names.FIS, create.ErrActionCheckingExistence, tffis.ResNameSafetyLeverState, rs.Primary.ID, err)
+		// The safety lever is a singleton addressed by the fixed literal "default"; the resource
+		// carries no "id" attribute (identity is {account_id, region}).
+		if _, err := tffis.FindSafetyLever(ctx, conn, "default"); err != nil {
+			return create.Error(names.FIS, create.ErrActionCheckingExistence, tffis.ResNameSafetyLeverState, name, err)
 		}
-
-		*safetyLever = *resp
 
 		return nil
 	}
 }
 
-// testAccSafetyLeverStateOppositeStatus reads the account's live safety lever status using a
-// standalone SDK client (rather than acctest.ProviderMeta, which is not guaranteed configured
-// this early - before resource.ParallelTest has run) and returns the opposite value, so the
-// caller's first apply is guaranteed to be a genuine status transition.
-func testAccSafetyLeverStateOppositeStatus(ctx context.Context, t *testing.T) string {
+// testAccSafetyLeverStateOppositeStatus reads the live safety lever status in the given Region
+// using a standalone SDK client (rather than acctest.ProviderMeta, which is not guaranteed
+// configured this early - before resource.ParallelTest has run) and returns the opposite value,
+// so the caller's first apply is guaranteed to be a genuine status transition.
+func testAccSafetyLeverStateOppositeStatus(ctx context.Context, t *testing.T, region string) string {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(acctest.Region()))
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
 		t.Fatalf("loading AWS config: %s", err)
 	}
@@ -202,6 +195,19 @@ func testAccSafetyLeverStateOppositeStatus(ctx context.Context, t *testing.T) st
 func testAccSafetyLeverStateConfig_basic(status, reason string) string {
 	return `
 resource "aws_fis_safety_lever_state" "test" {
+  state {
+    status = "` + status + `"
+    reason = "` + reason + `"
+  }
+}
+`
+}
+
+func testAccSafetyLeverStateConfig_region(region, status, reason string) string {
+	return `
+resource "aws_fis_safety_lever_state" "test" {
+  region = "` + region + `"
+
   state {
     status = "` + status + `"
     reason = "` + reason + `"

--- a/internal/service/fis/safety_lever_state_test.go
+++ b/internal/service/fis/safety_lever_state_test.go
@@ -76,11 +76,12 @@ func testAccFISSafetyLeverState_basic(t *testing.T) {
 				),
 			},
 			{
-				// The safety lever has no "id" attribute; import resolves it from resource
-				// identity ({account_id, region}), and verify matches the single instance on arn.
+				// The safety lever has no "id" attribute: the import ID is the Region (consumed
+				// by the RegionalSingleton importer), and verify matches the single instance on arn.
 				ResourceName:                         resourceName,
 				ImportState:                          true,
 				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrRegion),
 				ImportStateVerifyIdentifierAttribute: names.AttrARN,
 			},
 		},

--- a/internal/service/fis/safety_lever_state_test.go
+++ b/internal/service/fis/safety_lever_state_test.go
@@ -5,7 +5,7 @@ package fis_test
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tffis "github.com/hashicorp/terraform-provider-aws/internal/service/fis"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -149,21 +148,19 @@ func testAccCheckSafetyLeverStateDestroy(ctx context.Context, t *testing.T) reso
 	}
 }
 
-func testAccCheckSafetyLeverStateExists(ctx context.Context, t *testing.T, name string) resource.TestCheckFunc {
+func testAccCheckSafetyLeverStateExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if _, ok := s.RootModule().Resources[name]; !ok {
-			return create.Error(names.FIS, create.ErrActionCheckingExistence, tffis.ResNameSafetyLeverState, name, errors.New("not found"))
+		if _, ok := s.RootModule().Resources[n]; !ok {
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.ProviderMeta(ctx, t).FISClient(ctx)
 
 		// The safety lever is a singleton addressed by the fixed literal "default"; the resource
 		// carries no "id" attribute (identity is {account_id, region}).
-		if _, err := tffis.FindSafetyLever(ctx, conn, "default"); err != nil {
-			return create.Error(names.FIS, create.ErrActionCheckingExistence, tffis.ResNameSafetyLeverState, name, err)
-		}
+		_, err := tffis.FindSafetyLever(ctx, conn, "default")
 
-		return nil
+		return err
 	}
 }
 

--- a/internal/service/fis/service_package_gen.go
+++ b/internal/service/fis/service_package_gen.go
@@ -34,6 +34,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {
 	return []*inttypes.ServicePackageFrameworkResource{
 		{
+			Factory:  newSafetyLeverStateResource,
+			TypeName: "aws_fis_safety_lever_state",
+			Name:     "Safety Lever State",
+			Region:   inttypes.ResourceRegionDefault(),
+		},
+		{
 			Factory:  newResourceTargetAccountConfiguration,
 			TypeName: "aws_fis_target_account_configuration",
 			Name:     "Target Account Configuration",

--- a/internal/service/fis/service_package_gen.go
+++ b/internal/service/fis/service_package_gen.go
@@ -38,6 +38,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			TypeName: "aws_fis_safety_lever_state",
 			Name:     "Safety Lever State",
 			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalSingletonIdentity(),
+			Import: inttypes.FrameworkImport{
+				WrappedImport: true,
+			},
 		},
 		{
 			Factory:  newResourceTargetAccountConfiguration,

--- a/internal/service/fis/service_package_gen.go
+++ b/internal/service/fis/service_package_gen.go
@@ -7,6 +7,8 @@ package fis
 
 import (
 	"context"
+	"iter"
+	"slices"
 	"unique"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -50,6 +52,18 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Region:   inttypes.ResourceRegionDefault(),
 		},
 	}
+}
+
+func (p *servicePackage) FrameworkListResources(ctx context.Context) iter.Seq[*inttypes.ServicePackageFrameworkListResource] {
+	return slices.Values([]*inttypes.ServicePackageFrameworkListResource{
+		{
+			Factory:  newSafetyLeverStateResourceAsListResource,
+			TypeName: "aws_fis_safety_lever_state",
+			Name:     "Safety Lever State",
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalSingletonIdentity(),
+		},
+	})
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*inttypes.ServicePackageSDKDataSource {

--- a/internal/service/fis/testdata/SafetyLeverState/list_basic/main.tf
+++ b/internal/service/fis/testdata/SafetyLeverState/list_basic/main.tf
@@ -1,0 +1,15 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_fis_safety_lever_state" "test" {
+  state {
+    status = var.status
+    reason = "Managed by Terraform acceptance test"
+  }
+}
+
+variable "status" {
+  description = "Safety lever status to set"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/fis/testdata/SafetyLeverState/list_basic/query.tfquery.hcl
+++ b/internal/service/fis/testdata/SafetyLeverState/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_fis_safety_lever_state" "test" {
+  provider = aws
+}

--- a/internal/service/fis/testdata/SafetyLeverState/list_include_resource/main.tf
+++ b/internal/service/fis/testdata/SafetyLeverState/list_include_resource/main.tf
@@ -1,0 +1,15 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_fis_safety_lever_state" "test" {
+  state {
+    status = var.status
+    reason = "Managed by Terraform acceptance test"
+  }
+}
+
+variable "status" {
+  description = "Safety lever status to set"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/fis/testdata/SafetyLeverState/list_include_resource/query.tfquery.hcl
+++ b/internal/service/fis/testdata/SafetyLeverState/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_fis_safety_lever_state" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/fis/testdata/SafetyLeverState/list_region_override/main.tf
+++ b/internal/service/fis/testdata/SafetyLeverState/list_region_override/main.tf
@@ -1,0 +1,23 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_fis_safety_lever_state" "test" {
+  region = var.region
+
+  state {
+    status = var.status
+    reason = "Managed by Terraform acceptance test"
+  }
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}
+
+variable "status" {
+  description = "Safety lever status to set"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/fis/testdata/SafetyLeverState/list_region_override/query.tfquery.hcl
+++ b/internal/service/fis/testdata/SafetyLeverState/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_fis_safety_lever_state" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/website/docs/list-resources/fis_safety_lever_state.html.markdown
+++ b/website/docs/list-resources/fis_safety_lever_state.html.markdown
@@ -1,0 +1,28 @@
+---
+subcategory: "FIS (Fault Injection Simulator)"
+layout: "aws"
+page_title: "AWS: aws_fis_safety_lever_state"
+description: |-
+  Lists the FIS (Fault Injection Simulator) safety lever state.
+---
+
+# List Resource: aws_fis_safety_lever_state
+
+Lists the FIS (Fault Injection Simulator) safety lever state.
+
+The safety lever is an account- and Region-level singleton, so a query returns at
+most one result per queried Region.
+
+## Example Usage
+
+```terraform
+list "aws_fis_safety_lever_state" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.

--- a/website/docs/r/fis_safety_lever_state.html.markdown
+++ b/website/docs/r/fis_safety_lever_state.html.markdown
@@ -12,10 +12,7 @@ Manages the state of the AWS FIS (Fault Injection Simulator) safety lever for th
 
 There is exactly one safety lever per account and Region, and it always exists — AWS does not provide APIs to create or delete it. Because of this, deleting this resource only removes it from Terraform state; it does not change the live value in AWS, so it never risks silently disengaging a safety control.
 
-~> **Note:** AWS rejects a `reason` change unless `status` is also actually transitioning (for example, `engaged` to `disengaged`). This means:
->
-> * Creating this resource fails with an error if the safety lever's live status already matches the configured `status`. Use [`terraform import`](#import) instead to bring an existing safety lever under management without changing its status.
-> * Changing only `reason` while `status` stays the same fails at apply time. Pair a `reason` change with an actual `status` change.
+~> **Note:** AWS rejects a `reason` change unless `status` is also actually transitioning (for example, `engaged` to `disengaged`). Creating or updating this resource with a `status` that already matches the live safety lever succeeds only if the configured `reason` also matches the live `reason`; otherwise it fails at apply time. Pair a `reason` change with an actual `status` change.
 
 ## Example Usage
 
@@ -48,7 +45,6 @@ The following arguments are optional:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the safety lever.
-* `id` - ID of the safety lever. Always `default`.
 
 ## Timeouts
 
@@ -59,17 +55,39 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import the FIS safety lever state using `default`. For example:
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute. For example:
 
 ```terraform
 import {
   to = aws_fis_safety_lever_state.example
-  id = "default"
+  identity = {
+    region = "us-west-2"
+  }
+}
+
+resource "aws_fis_safety_lever_state" "example" {
+  ### Configuration omitted for brevity ###
 }
 ```
 
-Using `terraform import`, import the FIS safety lever state using `default`. For example:
+### Identity Schema
+
+#### Optional
+
+* `account_id` (String) AWS Account where this resource is managed.
+* `region` (String) Region where this resource is managed.
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import the FIS safety lever state using the Region. For example:
+
+```terraform
+import {
+  to = aws_fis_safety_lever_state.example
+  id = "us-west-2"
+}
+```
+
+Using `terraform import`, import the FIS safety lever state using the Region. For example:
 
 ```console
-% terraform import aws_fis_safety_lever_state.example default
+% terraform import aws_fis_safety_lever_state.example us-west-2
 ```

--- a/website/docs/r/fis_safety_lever_state.html.markdown
+++ b/website/docs/r/fis_safety_lever_state.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "FIS (Fault Injection Simulator)"
+layout: "aws"
+page_title: "AWS: aws_fis_safety_lever_state"
+description: |-
+  Manages the state of an AWS FIS (Fault Injection Simulator) account safety lever.
+---
+
+# Resource: aws_fis_safety_lever_state
+
+Manages the state of the AWS FIS (Fault Injection Simulator) safety lever for the account and Region. The safety lever is a single, account/Region-wide emergency stop: engaging it immediately stops all running experiments and blocks new ones from starting.
+
+There is exactly one safety lever per account and Region, and it always exists — AWS does not provide APIs to create or delete it. Because of this, deleting this resource only removes it from Terraform state; it does not change the live value in AWS, so it never risks silently disengaging a safety control.
+
+~> **Note:** AWS rejects a `reason` change unless `status` is also actually transitioning (for example, `engaged` to `disengaged`). This means:
+>
+> * Creating this resource fails with an error if the safety lever's live status already matches the configured `status`. Use [`terraform import`](#import) instead to bring an existing safety lever under management without changing its status.
+> * Changing only `reason` while `status` stays the same fails at apply time. Pair a `reason` change with an actual `status` change.
+
+## Example Usage
+
+```terraform
+resource "aws_fis_safety_lever_state" "example" {
+  state {
+    status = "disengaged"
+    reason = "Managed by Terraform"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `state` - (Required) State of the safety lever. [See below](#state).
+
+The following arguments are optional:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
+### `state`
+
+* `reason` - (Required) Reason for the current status of the safety lever.
+* `status` - (Required) Status of the safety lever. Valid values: `engaged`, `disengaged`. Engaging the lever immediately stops all running experiments in the account and Region, and prevents new ones from starting.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the safety lever.
+* `id` - ID of the safety lever. Always `default`.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `5m`)
+* `update` - (Default `5m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import the FIS safety lever state using `default`. For example:
+
+```terraform
+import {
+  to = aws_fis_safety_lever_state.example
+  id = "default"
+}
+```
+
+Using `terraform import`, import the FIS safety lever state using `default`. For example:
+
+```console
+% terraform import aws_fis_safety_lever_state.example default
+```


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`aws_fis_safety_lever_state` : New Resource With RI and LIst.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make t K=fis T=TestAccFISSafetyLeverState_serial
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-new-resource-safety-lever 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/fis/... -v -count 1 -parallel 20 -run='TestAccFISSafetyLeverState_serial'  -timeout 360m -vet=off -buildvcs=false
2026/09/04 02:48:01 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/04 02:48:01 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccFISSafetyLeverState_serial
=== PAUSE TestAccFISSafetyLeverState_serial
=== CONT  TestAccFISSafetyLeverState_serial
=== RUN   TestAccFISSafetyLeverState_serial/List_includeResource
=== RUN   TestAccFISSafetyLeverState_serial/List_regionOverride
=== RUN   TestAccFISSafetyLeverState_serial/basic
=== RUN   TestAccFISSafetyLeverState_serial/update
=== RUN   TestAccFISSafetyLeverState_serial/Identity_basic
=== RUN   TestAccFISSafetyLeverState_serial/Identity_regionOverride
=== RUN   TestAccFISSafetyLeverState_serial/List_basic
--- PASS: TestAccFISSafetyLeverState_serial (576.47s)
    --- PASS: TestAccFISSafetyLeverState_serial/List_includeResource (96.74s)
    --- PASS: TestAccFISSafetyLeverState_serial/List_regionOverride (105.32s)
    --- PASS: TestAccFISSafetyLeverState_serial/basic (84.84s)
    --- PASS: TestAccFISSafetyLeverState_serial/update (61.59s)
    --- PASS: TestAccFISSafetyLeverState_serial/Identity_basic (68.33s)
    --- PASS: TestAccFISSafetyLeverState_serial/Identity_regionOverride (97.66s)
    --- PASS: TestAccFISSafetyLeverState_serial/List_basic (62.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fis        584.403s
```
