### PR TITLE
resource/aws_ecs_express_gateway_service: Fix scaling target default consistency

### DIFF
--- a/.changelog/49511.txt
+++ b/.changelog/49511.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_express_gateway_service: Fix "Provider produced inconsistent result after apply" errors when omitting `auto_scaling_metric` and `auto_scaling_target_value` in the `scaling_target` block
+```

--- a/internal/service/ecs/express_gateway_service.go
+++ b/internal/service/ecs/express_gateway_service.go
@@ -281,6 +281,7 @@ func (r *expressGatewayServiceResource) Create(ctx context.Context, req resource
 		// Save plan's env/secret ordering before flattening (API may reorder).
 		planEnv, planSecrets := preservePlanContainerOrdering(ctx, plan.PrimaryContainer)
 		planNetworkConfiguration := plan.NetworkConfiguration
+		planScalingTarget := plan.ScalingTarget
 
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, waitOut.ActiveConfigurations[0], &plan))
 		if resp.Diagnostics.HasError() {
@@ -289,6 +290,7 @@ func (r *expressGatewayServiceResource) Create(ctx context.Context, req resource
 
 		restorePlanContainerOrdering(ctx, &plan.PrimaryContainer, planEnv, planSecrets)
 		restorePlanNetworkConfigurationSecurityGroups(ctx, &plan.NetworkConfiguration, planNetworkConfiguration)
+		restorePlanScalingTarget(ctx, &plan.ScalingTarget, planScalingTarget)
 	}
 	normalizeIngressPathEndpoints(ctx, &plan.IngressPaths)
 
@@ -331,6 +333,7 @@ func (r *expressGatewayServiceResource) Read(ctx context.Context, req resource.R
 	if len(out.ActiveConfigurations) > 0 {
 		// Save state's env/secret ordering before flattening (API may reorder).
 		stateEnv, stateSecrets := preservePlanContainerOrdering(ctx, state.PrimaryContainer)
+		stateScalingTarget := state.ScalingTarget
 
 		// Sort alphabetically as canonical ordering (used as default during import).
 		orderExpressGatewayContainerEnvironmentVariables(&out.ActiveConfigurations[0])
@@ -344,6 +347,7 @@ func (r *expressGatewayServiceResource) Read(ctx context.Context, req resource.R
 
 		// Restore state ordering if env vars are unchanged (no-op during import).
 		restoreContainerOrderingIfUnchanged(ctx, &state.PrimaryContainer, stateEnv, stateSecrets)
+		restorePlanScalingTarget(ctx, &state.ScalingTarget, stateScalingTarget)
 	}
 	normalizeIngressPathEndpoints(ctx, &state.IngressPaths)
 
@@ -450,6 +454,7 @@ func (r *expressGatewayServiceResource) Update(ctx context.Context, req resource
 		// Save plan's env/secret ordering before flattening (API may reorder).
 		planEnv, planSecrets := preservePlanContainerOrdering(ctx, plan.PrimaryContainer)
 		planNetworkConfiguration := plan.NetworkConfiguration
+		planScalingTarget := plan.ScalingTarget
 
 		orderExpressGatewayContainerEnvironmentVariables(&waitOut.ActiveConfigurations[0])
 		smerr.AddEnrich(ctx, &resp.Diagnostics, fwflex.Flatten(ctx, waitOut.ActiveConfigurations[0], &plan))
@@ -459,6 +464,7 @@ func (r *expressGatewayServiceResource) Update(ctx context.Context, req resource
 
 		restorePlanContainerOrdering(ctx, &plan.PrimaryContainer, planEnv, planSecrets)
 		restorePlanNetworkConfigurationSecurityGroups(ctx, &plan.NetworkConfiguration, planNetworkConfiguration)
+		restorePlanScalingTarget(ctx, &plan.ScalingTarget, planScalingTarget)
 	}
 	normalizeIngressPathEndpoints(ctx, &plan.IngressPaths)
 
@@ -985,6 +991,37 @@ func normalizeIngressPathEndpoints(ctx context.Context, ingressPaths *fwtypes.Li
 	}
 
 	*ingressPaths = updated
+}
+
+func restorePlanScalingTarget(
+	ctx context.Context,
+	scalingTarget *fwtypes.ListNestedObjectValueOf[expressGatewayScalingTargetModel],
+	planScalingTarget fwtypes.ListNestedObjectValueOf[expressGatewayScalingTargetModel],
+) {
+	planTarget, diags := planScalingTarget.ToPtr(ctx)
+	if diags.HasError() || planTarget == nil {
+		return
+	}
+
+	currentTarget, diags := scalingTarget.ToPtr(ctx)
+	if diags.HasError() || currentTarget == nil {
+		return
+	}
+
+	if planTarget.AutoScalingMetric.IsNull() || planTarget.AutoScalingMetric.IsUnknown() {
+		currentTarget.AutoScalingMetric = planTarget.AutoScalingMetric
+	}
+
+	if planTarget.AutoScalingTargetValue.IsNull() || planTarget.AutoScalingTargetValue.IsUnknown() {
+		currentTarget.AutoScalingTargetValue = planTarget.AutoScalingTargetValue
+	}
+
+	updated, diags := fwtypes.NewListNestedObjectValueOfPtr(ctx, currentTarget)
+	if diags.HasError() {
+		return
+	}
+
+	*scalingTarget = updated
 }
 
 // envListsEquivalent returns true if two environment variable lists contain the same

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -369,6 +369,35 @@ func TestAccECSExpressGatewayService_checkIdempotency(t *testing.T) {
 	})
 }
 
+func TestAccECSExpressGatewayService_scalingTargetDefaults(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var service awstypes.ECSExpressGatewayService
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_ecs_express_gateway_service.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.ECSEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExpressGatewayServiceDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExpressGatewayServiceConfig_scalingTargetDefaults(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckExpressGatewayServiceExists(ctx, t, resourceName, &service),
+				),
+			},
+		},
+	})
+}
+
 // TestAccECSExpressGatewayService_environmentVariableOrdering verifies that
 // non-alphabetical environment variables don't cause inconsistent apply errors.
 // See: https://github.com/hashicorp/terraform-provider-aws/issues/45792
@@ -1086,4 +1115,28 @@ resource "aws_ecs_express_gateway_service" "test" {
   ]
 }
 `)
+}
+
+func testAccExpressGatewayServiceConfig_scalingTargetDefaults(rName string) string {
+	return acctest.ConfigCompose(testAccExpressGatewayServiceConfig_base(rName, false), fmt.Sprintf(`
+resource "aws_ecs_express_gateway_service" "test" {
+  execution_role_arn      = aws_iam_role.execution.arn
+  infrastructure_role_arn = aws_iam_role.infrastructure.arn
+  service_name            = %[1]q
+  
+  primary_container {
+    image = "public.ecr.aws/nginx/nginx:1.28-alpine3.21-slim"
+  }
+
+  scaling_target {
+    min_task_count = 1
+    max_task_count = 2
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution,
+    aws_iam_role_policy_attachment.infrastructure,
+  ]
+}
+`, rName))
 }

--- a/internal/service/ecs/express_gateway_service_test.go
+++ b/internal/service/ecs/express_gateway_service_test.go
@@ -1123,7 +1123,7 @@ resource "aws_ecs_express_gateway_service" "test" {
   execution_role_arn      = aws_iam_role.execution.arn
   infrastructure_role_arn = aws_iam_role.infrastructure.arn
   service_name            = %[1]q
-  
+
   primary_container {
     image = "public.ecr.aws/nginx/nginx:1.28-alpine3.21-slim"
   }


### PR DESCRIPTION
## Rollback Plan

Revert this pull request. The resource will return to its previous behavior.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR resolves an issue where `aws_ecs_express_gateway_service` produces a "Provider produced inconsistent result after apply" error when `auto_scaling_metric` and `auto_scaling_target_value` are omitted from the `scaling_target` block. This occurs because the AWS API injects default values (`AVERAGE_CPU` and `60`) behind the scenes.

The fix introduces an interceptor function (`restorePlanScalingTarget`) during the `Create`, `Read`, and `Update` operations to restore the user's plan values before flattening the API response, bypassing internal schema validation issues with the Plugin Framework wrappers. A dedicated regression test has also been added.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.
--->
Closes #49511

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% TF_ACC=1 go test ./internal/service/ecs -v -run=TestAccECSExpressGatewayService_scalingTargetDefaults
2026/09/03 21:49:26 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/03 21:49:26 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSExpressGatewayService_scalingTargetDefaults
=== PAUSE TestAccECSExpressGatewayService_scalingTargetDefaults
=== CONT  TestAccECSExpressGatewayService_scalingTargetDefaults
--- PASS: TestAccECSExpressGatewayService_scalingTargetDefaults (155.03s)
PASS
ok      [github.com/hashicorp/terraform-provider-aws/internal/service/ecs](https://github.com/hashicorp/terraform-provider-aws/internal/service/ecs)        162.265s