### PR TITLE
resource/aws_db_instance: Fixes error when restoring multi-az SQL Server from snapshot

### DIFF
--- a/.changelog/49846.txt
+++ b/.changelog/49846.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Fix error when restoring multi-az SQL Server from snapshot.
+```

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -1380,6 +1380,14 @@ resource "aws_rds_global_cluster" "test" {
 
 func testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName string, upgrade bool) string {
 	return fmt.Sprintf(`
+resource "aws_rds_global_cluster" "test" {
+  force_destroy                = true
+  global_cluster_identifier    = %[1]q
+  engine                       = aws_rds_cluster.test.engine
+  engine_version               = local.engine_version
+  source_db_cluster_identifier = aws_rds_cluster.test.arn
+}
+
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
   engine              = local.engine
@@ -1400,14 +1408,6 @@ resource "aws_rds_cluster_instance" "test" {
   engine             = aws_rds_cluster.test.engine
   engine_version     = aws_rds_cluster.test.engine_version
   instance_class     = "db.r5.large"
-}
-
-resource "aws_rds_global_cluster" "test" {
-  force_destroy                = true
-  global_cluster_identifier    = %[1]q
-  engine                       = aws_rds_cluster.test.engine
-  engine_version               = local.engine_version
-  source_db_cluster_identifier = aws_rds_cluster.test.arn
 }
 
 data "aws_rds_engine_version" "original" {

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -711,8 +711,6 @@ func TestAccRDSGlobalCluster_SourceDBClusterIdentifier_EngineVersion_updateMajor
 	var v types.GlobalCluster
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_rds_global_cluster.test"
-	engineVersion := "15.10"
-	engineVersionUpdated := "16.6"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
@@ -721,10 +719,10 @@ func TestAccRDSGlobalCluster_SourceDBClusterIdentifier_EngineVersion_updateMajor
 		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName, engineVersion),
+				Config: testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, engineVersion),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.original", "version_actual"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -733,10 +731,10 @@ func TestAccRDSGlobalCluster_SourceDBClusterIdentifier_EngineVersion_updateMajor
 				},
 			},
 			{
-				Config: testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName, engineVersionUpdated),
+				Config: testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, t, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, engineVersionUpdated),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngineVersion, "data.aws_rds_engine_version.upgrade", "version_actual"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1380,12 +1378,12 @@ resource "aws_rds_global_cluster" "test" {
 `, rName)
 }
 
-func testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName, engineVersion string) string {
+func testAccGlobalClusterConfig_sourceClusterIDEngineVersion(rName string, upgrade bool) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
-  engine              = "aurora-postgresql"
-  engine_version      = %[2]q
+  engine              = local.engine
+  engine_version      = local.engine_version
   master_password     = "mustbeeightcharacters"
   master_username     = "test"
   skip_final_snapshot = true
@@ -1408,10 +1406,27 @@ resource "aws_rds_global_cluster" "test" {
   force_destroy                = true
   global_cluster_identifier    = %[1]q
   engine                       = aws_rds_cluster.test.engine
-  engine_version               = %[2]q
+  engine_version               = local.engine_version
   source_db_cluster_identifier = aws_rds_cluster.test.arn
 }
-`, rName, engineVersion)
+
+data "aws_rds_engine_version" "original" {
+  engine           = "aurora-postgresql"
+  has_major_target = true
+  latest           = true
+}
+
+data "aws_rds_engine_version" "upgrade" {
+  engine             = local.engine
+  latest             = true
+  preferred_versions = data.aws_rds_engine_version.original.valid_major_targets
+}
+
+locals {
+  engine         = data.aws_rds_engine_version.original.engine
+  engine_version = %[2]t ? data.aws_rds_engine_version.upgrade.version_actual : data.aws_rds_engine_version.original.version_actual
+}
+`, rName, upgrade)
 }
 
 func testAccGlobalClusterConfig_storageEncrypted(rName string, storageEncrypted bool) string {

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1449,11 +1449,11 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta an
 		// possible to immediately enable mirroring since
 		// BackupRetentionPeriod is not available as a parameter to
 		// RestoreDBInstanceFromDBSnapshot and you receive an error. e.g.
-		// InvalidParameterValue: Mirroring cannot be applied to instances with backup retention set to zero.
+		// InvalidParameterValue: Mirroring or AlwaysOn cannot be applied to instances with backup retention set to zero.
 		// Since engine is not a required argument when using snapshot_identifier
 		// and the RDS API determines this condition, we catch the error
 		// and remove the invalid configuration for it to be fixed afterwards.
-		if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "Mirroring cannot be applied to instances with backup retention set to zero") {
+		if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "cannot be applied to instances with backup retention set to zero") {
 			input.MultiAZ = aws.Bool(false)
 			modifyDbInstanceInput.MultiAZ = aws.Bool(true)
 			requiresModifyDbInstance = true


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The service error returned when restoring multi-az SQL Server from snapshot has changed. Updates the matching string.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc make testacc PKG=rds TESTS=TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer

--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer (4534.58s)
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>