### PR TITLE
Missing `t.Parallel` in AutoFlex primitive test

### DIFF
--- a/internal/framework/flex/autoflex_primitive_fields_test.go
+++ b/internal/framework/flex/autoflex_primitive_fields_test.go
@@ -94,6 +94,7 @@ func testExpandField[T any](t *testing.T, valueHandler fieldValueHandler[T]) {
 			t.Parallel()
 			for name, tc := range tc {
 				t.Run(name, func(t *testing.T) {
+					t.Parallel()
 					cases := autoFlexTestCases{}
 					for name, tc := range tc {
 						cases[name] = autoFlexTestCase{


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Missing `t.Parallel` in AutoFlex primitive test

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>