### PR TITLE
d/`aws_workspaces_directory`: Add `workspace_access_properties.access_endpoint_config` attribute  + Fix `setting workspace_access_properties: Invalid address to set` errors

### DIFF
--- a/.changelog/49849.txt
+++ b/.changelog/49849.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+data-source/aws_workspaces_directory: Fix `setting workspace_access_properties: Invalid address to set` errors
+```
+
+```release-note:enhancement
+data-source/aws_workspaces_directory: Add `workspace_access_properties.access_endpoint_config` attribute
+```

--- a/internal/service/workspaces/directory_data_source.go
+++ b/internal/service/workspaces/directory_data_source.go
@@ -161,6 +161,35 @@ func dataSourceDirectory() *schema.Resource {
 					Computed: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
+							"access_endpoint_config": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"access_endpoints": {
+											Type:     schema.TypeSet,
+											Computed: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"access_endpoint_type": {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
+													names.AttrVPCEndpointID: {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
+												},
+											},
+										},
+										"internet_fallback_protocols": {
+											Type:     schema.TypeList,
+											Computed: true,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+									},
+								},
+							},
 							"device_type_android": {
 								Type:     schema.TypeString,
 								Computed: true,

--- a/internal/service/workspaces/directory_data_source_test.go
+++ b/internal/service/workspaces/directory_data_source_test.go
@@ -86,6 +86,43 @@ func testAccDirectoryDataSource_basic(t *testing.T) {
 	})
 }
 
+func testAccDirectoryDataSource_accessEndpointConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandString(t, 8)
+	domain := acctest.RandomDomainName(t)
+
+	resourceName := "aws_workspaces_directory.main"
+	dataSourceName := "data.aws_workspaces_directory.test"
+
+	acctest.Test(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckDirectory(ctx, t)
+			acctest.PreCheckDirectoryServiceSimpleDirectory(ctx, t)
+			acctest.PreCheckHasIAMRole(ctx, t, "workspaces_DefaultRole")
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(workspaces.ServiceID)),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDirectoryDataSourceConfig_accessEndpointConfig(rName, domain),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "workspace_access_properties.#", resourceName, "workspace_access_properties.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "workspace_access_properties.0.access_endpoint_config.#", resourceName, "workspace_access_properties.0.access_endpoint_config.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "workspace_access_properties.0.access_endpoint_config.0.access_endpoints.#", resourceName, "workspace_access_properties.0.access_endpoint_config.0.access_endpoints.#"),
+					resource.TestCheckResourceAttr(dataSourceName, "workspace_access_properties.0.access_endpoint_config.0.access_endpoints.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "workspace_access_properties.0.access_endpoint_config.0.access_endpoints.*", map[string]string{
+						"access_endpoint_type": "STREAMING_WSP",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "workspace_access_properties.0.access_endpoint_config.0.access_endpoints.*.vpc_endpoint_id", "aws_vpc_endpoint.streaming", names.AttrID),
+					resource.TestCheckResourceAttr(dataSourceName, "workspace_access_properties.0.access_endpoint_config.0.internet_fallback_protocols.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "workspace_access_properties.0.access_endpoint_config.0.internet_fallback_protocols.0", "PCOIP"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDirectoryDataSourceConfig_basic(rName, domain string) string {
 	return acctest.ConfigCompose(
 		testAccDirectoryConfig_base(rName, domain),
@@ -153,4 +190,14 @@ data "aws_iam_role" "workspaces-default" {
   name = "workspaces_DefaultRole"
 }
 `, rName, domain))
+}
+
+func testAccDirectoryDataSourceConfig_accessEndpointConfig(rName, domain string) string {
+	return acctest.ConfigCompose(
+		testAccDirectoryConfig_accessEndpointConfig(rName, domain),
+		`
+data "aws_workspaces_directory" "test" {
+  directory_id = aws_workspaces_directory.main.id
+}
+`)
 }

--- a/internal/service/workspaces/directory_data_source_test.go
+++ b/internal/service/workspaces/directory_data_source_test.go
@@ -103,6 +103,7 @@ func testAccDirectoryDataSource_accessEndpointConfig(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(workspaces.ServiceID)),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDirectoryDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDirectoryDataSourceConfig_accessEndpointConfig(rName, domain),

--- a/internal/service/workspaces/workspaces_data_source_test.go
+++ b/internal/service/workspaces/workspaces_data_source_test.go
@@ -21,7 +21,8 @@ func TestAccWorkSpacesDataSource_serial(t *testing.T) {
 			"privateOwner":            testAccWorkspaceBundleDataSource_privateOwner,
 		},
 		"Directory": {
-			acctest.CtBasic: testAccDirectoryDataSource_basic,
+			acctest.CtBasic:        testAccDirectoryDataSource_basic,
+			"accessEndpointConfig": testAccDirectoryDataSource_accessEndpointConfig,
 		},
 		"Image": {
 			acctest.CtBasic: testAccImageDataSource_basic,

--- a/website/docs/d/workspaces_directory.html.markdown
+++ b/website/docs/d/workspaces_directory.html.markdown
@@ -51,6 +51,11 @@ This data source exports the following attributes in addition to the arguments a
 * `tags` - A map of tags assigned to the WorkSpaces directory.
 * `user_identity_type` - The user identity type for the WorkSpaces directory.
 * `workspace_access_properties` - Specifies which devices and operating systems users can use to access their WorkSpaces.
+    * `access_endpoint_config` - Configuration for accessing WorkSpaces through VPC endpoints instead of the public internet.
+        * `access_endpoints` - Set of access endpoints used to control the network paths that users use to access their WorkSpaces.
+            * `access_endpoint_type` - Type of access endpoint.
+            * `vpc_endpoint_id` - Identifier of the VPC endpoint that the access endpoint uses.
+        * `internet_fallback_protocols` - List of protocols that fall back to the public internet when streaming over a VPC endpoint is unavailable.
     * `device_type_android` - (Optional) Indicates whether users can use Android devices to access their WorkSpaces.
     * `device_type_chromeos` - (Optional) Indicates whether users can use Chromebooks to access their WorkSpaces.
     * `device_type_ios` - (Optional) Indicates whether users can use iOS devices to access their WorkSpaces.


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

d/aws_workspaces_directory: Add workspace_access_properties.access_endpoint_config attribute + Fix setting workspace_access_properties: Invalid address to set errors - See https://github.com/hashicorp/terraform-provider-aws/issues/49727

Reproduced the bug : 

```console
make t K=workspaces T='TestAccWorkSpacesDataSource_serial/Directory/basic'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 b-ds-aws_workspaces_directory_access_endpoint_config 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/workspaces/... -v -count 1 -parallel 20 -run='TestAccWorkSpacesDataSource_serial/Directory/basic'  -timeout 360m -vet=off -buildvcs=false
2026/09/04 04:18:33 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/04 04:18:33 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWorkSpacesDataSource_serial
=== PAUSE TestAccWorkSpacesDataSource_serial
=== CONT  TestAccWorkSpacesDataSource_serial
=== RUN   TestAccWorkSpacesDataSource_serial/Directory
=== RUN   TestAccWorkSpacesDataSource_serial/Directory/basic
panic: Invalid address to set: []string{"workspace_access_properties", "0", "access_endpoint_config"}
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/49727

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
--- PASS: TestAccWorkSpacesDataSource_serial (1304.76s)
    --- PASS: TestAccWorkSpacesDataSource_serial/Directory (1304.76s)
        --- PASS: TestAccWorkSpacesDataSource_serial/Directory/basic (659.89s)
        --- PASS: TestAccWorkSpacesDataSource_serial/Directory/accessEndpointConfig (644.87s)
```
