### PR TITLE
resource/aws_iam_role (list): Add path_prefix argument

### DIFF
--- a/.changelog/49541.txt
+++ b/.changelog/49541.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iam_role (list): Add `path_prefix` configuration argument
+```

--- a/internal/service/iam/role_list.go
+++ b/internal/service/iam/role_list.go
@@ -11,6 +11,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -32,7 +35,23 @@ type roleListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type roleListResourceModel struct{}
+type roleListResourceModel struct {
+	PathPrefix types.String `tfsdk:"path_prefix"`
+}
+
+func (l *roleListResource) ListResourceConfigSchema(ctx context.Context, request list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			"path_prefix": listschema.StringAttribute{
+				Optional:    true,
+				Description: "Path prefix on which to filter role names.",
+				Validators: []validator.String{
+					validPolicyPathFramework,
+				},
+			},
+		},
+	}
+}
 
 func (l *roleListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()

--- a/internal/service/iam/role_list_test.go
+++ b/internal/service/iam/role_list_test.go
@@ -155,8 +155,8 @@ func TestAccIAMRole_List_pathPrefix(t *testing.T) {
 					acctest.CtRName: config.StringVariable(rName),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.GlobalARNExact("iam", "role"+pathPrefix+rName+"-0")),
-					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.GlobalARNExact("iam", "role"+pathPrefix+rName+"-1")),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.GlobalARNExact("iam", names.AttrRole+pathPrefix+rName+"-0")),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.GlobalARNExact("iam", names.AttrRole+pathPrefix+rName+"-1")),
 				},
 			},
 

--- a/internal/service/iam/role_list_test.go
+++ b/internal/service/iam/role_list_test.go
@@ -130,3 +130,54 @@ func TestAccIAMRole_List_includeResource(t *testing.T) {
 		},
 	})
 }
+
+func TestAccIAMRole_List_pathPrefix(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_iam_role.test_match[0]"
+	resourceName2 := "aws_iam_role.test_match[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	pathPrefix := "/test-path/"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy:             testAccCheckRoleDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup resources (2 matching, 1 non-matching)
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Role/list_path_prefix/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrARN), tfknownvalue.GlobalARNExact("iam", "role"+pathPrefix+rName+"-0")),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrARN), tfknownvalue.GlobalARNExact("iam", "role"+pathPrefix+rName+"-1")),
+				},
+			},
+
+			// Step 2: Run the list query and verify it filtered correctly
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/Role/list_path_prefix/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName: config.StringVariable(rName),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("aws_iam_role.test", map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrName:      knownvalue.StringExact(rName + "-0"),
+					}),
+					querycheck.ExpectIdentity("aws_iam_role.test", map[string]knownvalue.Check{
+						names.AttrAccountID: tfknownvalue.AccountID(),
+						names.AttrName:      knownvalue.StringExact(rName + "-1"),
+					}),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/iam/testdata/Role/list_path_prefix/main.tfquery.hcl
+++ b/internal/service/iam/testdata/Role/list_path_prefix/main.tfquery.hcl
@@ -1,0 +1,9 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_iam_role" "test" {
+  provider = aws
+  config {
+    path_prefix = "/test-path/"
+  }
+}

--- a/internal/service/iam/testdata/Role/list_path_prefix/main_gen.tf
+++ b/internal/service/iam/testdata/Role/list_path_prefix/main_gen.tf
@@ -1,0 +1,29 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+variable "rName" {
+  type = string
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "test_match" {
+  count              = 2
+  name               = "${var.rName}-${count.index}"
+  path               = "/test-path/"
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}
+
+resource "aws_iam_role" "test_nomatch" {
+  name               = "${var.rName}-nomatch"
+  path               = "/wrong-path/"
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR introduces the `path_prefix` configuration argument to the `aws_iam_role` list resource. 

The underlying `ListRoles` API supports this parameter natively. Adding it allows practitioners to perform query-driven imports of existing roles by filtering them server-side (e.g., retrieving only roles under `/bootstrap/dev/`) instead of pulling the entire account inventory. 

The implementation utilizes the existing Plugin Framework `fwflex.Expand` mapping and includes full acceptance testing using the `tfquery` framework to verify the API filtering behavior.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.
--->
Closes #49541

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
* [ListRoles API Documentation](https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListRoles.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% TF_ACC=1 go test ./internal/service/iam -v -run=TestAccIAMRole_List_pathPrefix
2026/09/04 21:02:44 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/04 21:02:44 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMRole_List_pathPrefix
=== PAUSE TestAccIAMRole_List_pathPrefix
=== CONT  TestAccIAMRole_List_pathPrefix
--- PASS: TestAccIAMRole_List_pathPrefix (28.78s)
PASS
ok      [github.com/hashicorp/terraform-provider-aws/internal/service/iam](https://github.com/hashicorp/terraform-provider-aws/internal/service/iam)        36.283s