### PR TITLE
🤖🤖🤖 resource/aws_lb: Fix permanent subnet_mapping diff on dual-stack NLBs pinning allocation_id and ipv6_address

### DIFF
--- a/.changelog/49861.txt
+++ b/.changelog/49861.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb: Fix permanent `subnet_mapping` diff on dual-stack Network Load Balancers that pin both `allocation_id` and `ipv6_address`
+```

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -1356,10 +1356,17 @@ func flattenSubnetMappingsFromAvailabilityZones(apiObjects []awstypes.Availabili
 			names.AttrSubnetID: aws.ToString(apiObject.SubnetId),
 		}
 		if apiObjects := apiObject.LoadBalancerAddresses; len(apiObjects) > 0 {
-			apiObject := apiObjects[0]
-			tfMap["allocation_id"] = aws.ToString(apiObject.AllocationId)
-			tfMap["ipv6_address"] = aws.ToString(apiObject.IPv6Address)
-			tfMap["private_ipv4_address"] = aws.ToString(apiObject.PrivateIPv4Address)
+			for _, apiObject := range apiObjects {
+				if v := aws.ToString(apiObject.AllocationId); v != "" {
+					tfMap["allocation_id"] = v
+				}
+				if v := aws.ToString(apiObject.IPv6Address); v != "" {
+					tfMap["ipv6_address"] = v
+				}
+				if v := aws.ToString(apiObject.PrivateIPv4Address); v != "" {
+					tfMap["private_ipv4_address"] = v
+				}
+			}
 		}
 
 		return tfMap

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -507,6 +507,51 @@ func TestAccELBV2LoadBalancer_NLB_allocationID(t *testing.T) {
 	})
 }
 
+func TestAccELBV2LoadBalancer_NLB_allocationIDAndIPv6(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.LoadBalancer
+	resourceName := "aws_lb.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoadBalancerDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoadBalancerConfig_nlbAllocationIDAndIPv6(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLoadBalancerExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "subnet_mapping.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_mapping.0.allocation_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_mapping.0.ipv6_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_mapping.1.allocation_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_mapping.1.ipv6_address"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				Config: testAccLoadBalancerConfig_nlbAllocationIDAndIPv6(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccELBV2LoadBalancer_NLB_privateIPv4Address(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.LoadBalancer
@@ -3864,6 +3909,38 @@ resource "aws_eip" "test" {
   tags = {
     Name = %[1]q
   }
+}
+`, rName))
+}
+
+func testAccLoadBalancerConfig_nlbAllocationIDAndIPv6(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnetsIPv6(rName, 2), fmt.Sprintf(`
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_eip" "test" {
+  count = 2
+}
+
+resource "aws_lb" "test" {
+  name               = %[1]q
+  load_balancer_type = "network"
+  ip_address_type    = "dualstack"
+
+  subnet_mapping {
+    subnet_id     = aws_subnet.test[0].id
+    allocation_id = aws_eip.test[0].id
+    ipv6_address  = cidrhost(cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 0), 5)
+  }
+
+  subnet_mapping {
+    subnet_id     = aws_subnet.test[1].id
+    allocation_id = aws_eip.test[1].id
+    ipv6_address  = cidrhost(cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1), 5)
+  }
+
+  depends_on = [aws_internet_gateway.test]
 }
 `, rName))
 }


### PR DESCRIPTION
### Description

A dual-stack `aws_lb` Network Load Balancer whose `subnet_mapping` blocks pin
both an `allocation_id` (EIP) and an `ipv6_address` never reads the IPv6
address back into state. This produces a permanent `subnet_mapping` diff that
never converges, and can escalate an AZ addition into a full NLB replacement —
releasing BYOIP/static addresses for affected users.

Closes #49531.

### Root cause

For this configuration, `DescribeLoadBalancers` returns two
`LoadBalancerAddresses` per Availability Zone: the IPv4/EIP pair first and the
IPv6 address second. `flattenSubnetMappingsFromAvailabilityZones` only read
element `[0]`, whose `IPv6Address` is empty, so `ipv6_address` was always
written to state as `""`. Since `subnet_mapping` is a `TypeSet` and
`ipv6_address` participates in the element hash, config and state hash
differently, yielding a perpetual remove-and-re-add of the block. The same
empty read drove `customizeDiffLoadBalancerNLB` to plan AZ additions as full
replacements.

### Change

`flattenSubnetMappingsFromAvailabilityZones` now iterates over all
`LoadBalancerAddresses` for the AZ and merges the non-empty `allocation_id`,
`ipv6_address`, and `private_ipv4_address` values. Behavior for
single-address (IPv4-only) load balancers is unchanged.

### Testing

Added `TestAccELBV2LoadBalancer_NLB_allocationIDAndIPv6` (config
`testAccLoadBalancerConfig_nlbAllocationIDAndIPv6`). It provisions a dual-stack
NLB whose two `subnet_mapping` blocks each pin an `allocation_id` and an
`ipv6_address`, asserts both attributes are set, re-applies the identical
config asserting an empty plan (the step that fails without the fix), and
performs an ImportState/ImportStateVerify round-trip.

- `go test ./internal/service/elbv2`: 94 passed (unit-level; acceptance tests
  not run against AWS).
- `gofmt` clean.

### Files changed

- `internal/service/elbv2/load_balancer.go`
- `internal/service/elbv2/load_balancer_test.go`

### AI usage disclosure

This PR was AI-assisted, per the repository's [AI usage policy](docs/ai-usage.md):
the `🤖🤖🤖` marker is in the title and the AI contributed to the code, tests,
and this description. A human author is fully responsible for the change.