### PR TITLE
docs(sns): document PEM credentials for APNS platform applications

### DIFF
--- a/website/docs/r/sns_platform_application.html.markdown
+++ b/website/docs/r/sns_platform_application.html.markdown
@@ -14,12 +14,14 @@ Provides an SNS platform application resource
 
 ### Apple Push Notification Service (APNS) using certificate-based authentication
 
+~> **NOTE:** For certificate-based APNS, both `platform_credential` (private key) and `platform_principal` (certificate) must be PEM-encoded strings. Terraform string values must be valid UTF-8, so do not pass a binary Apple `.p12` via `base64decode()` — that fails with `the result of decoding the provided string is not valid UTF-8`. Convert the `.p12` to PEM (for example with `openssl`) and load the PEM files instead.
+
 ```terraform
 resource "aws_sns_platform_application" "apns_application" {
   name                = "apns_application"
   platform            = "APNS"
-  platform_credential = "<APNS PRIVATE KEY>"
-  platform_principal  = "<APNS CERTIFICATE>"
+  platform_credential = file("apns-private-key.pem")
+  platform_principal  = file("apns-certificate.pem")
 }
 ```
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.

### Description

Documents that certificate-based APNS for `aws_sns_platform_application` requires PEM-encoded strings for both `platform_credential` (private key) and `platform_principal` (certificate). Adds a note about the Terraform UTF-8 / `base64decode` pitfall with binary Apple `.p12` files, and updates the example to load PEM files via `file()`.

Prior unmerged attempt: #48252.

### Relations

Closes #40803

### References

* Issue discussion confirming PEM works when both credential and principal are PEM
* Terraform `base64decode` UTF-8 requirement: https://developer.hashicorp.com/terraform/language/functions/base64decode

### Output from Acceptance Testing

N/A — documentation-only change.