### PR TITLE
Update backup_selection.html.markdown

### DIFF
--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -94,6 +94,27 @@ resource "aws_backup_selection" "example" {
 }
 ```
 
+### Selecting Backups By Resource Type And Tag
+
+~> **Note:** To select resources that match both an ARN pattern (for example a service-scoped wildcard) **and** a tag, use `condition` with `resources`. Do **not** combine `resources` wildcards with `selection_tag` — that combination uses OR semantics and can select far more resources than expected. See [Argument Reference](#argument-reference) below.
+
+```terraform
+resource "aws_backup_selection" "example" {
+  iam_role_arn = aws_iam_role.example.arn
+  name         = "tf_example_backup_selection"
+  plan_id      = aws_backup_plan.example.id
+
+  resources = ["arn:aws:s3:::*"]
+
+  condition {
+    string_equals {
+      key   = "aws:ResourceTag/enable_backup"
+      value = "true"
+    }
+  }
+}
+```
+
 ### Selecting Backups By Resource
 
 ```terraform
@@ -130,13 +151,15 @@ resource "aws_backup_selection" "example" {
 
 This resource supports the following arguments:
 
+~> **Note:** `resources` and `selection_tag` are evaluated independently and combined with **OR** semantics (AWS Backup `Resources` + `ListOfTags`). A resource is selected if it matches **any** ARN/pattern in `resources` **or** **any** `selection_tag`. Tag conditions in `selection_tag` do **not** further filter the ARNs in `resources`. In particular, `resources = ["*"]` or a service-scoped wildcard such as `["arn:aws:s3:::*"]` together with `selection_tag` selects all resources matching the ARN pattern **plus** all resources matching the tag(s), which can result in an unintended account-wide selection. To require **both** an ARN match and a tag match, set `resources` to the desired pattern and use `condition` (AWS Backup `Conditions`) instead of `selection_tag`. Multiple `condition` rules use **AND** semantics. See [CreateBackupSelection](https://docs.aws.amazon.com/cli/latest/reference/backup/create-backup-selection.html).
+
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `name` - (Required) The display name of a resource selection document.
 * `plan_id` - (Required) The backup plan ID to be associated with the selection of resources.
 * `iam_role_arn` - (Required) The ARN of the IAM role that AWS Backup uses to authenticate when restoring and backing up the target resource. See the [AWS Backup Developer Guide](https://docs.aws.amazon.com/aws-backup/latest/devguide/access-control.html#managed-policies) for additional information about using AWS managed policies or creating custom policies attached to the IAM role.
-* `selection_tag` - (Optional) Tag-based conditions used to specify a set of resources to assign to a backup plan. See [below](#selection_tag) for details.
-* `condition` - (Optional) Condition-based filters used to specify sets of resources for a backup plan. See [below](#condition) for details.
-* `resources` - (Optional) Array of strings that either contain ARNs or match patterns of resources to assign to a backup plan.
+* `selection_tag` - (Optional) Tag-based conditions used to specify a set of resources to assign to a backup plan (`ListOfTags` in the AWS API). Multiple tags use OR logic among themselves. When set together with `resources`, selection is the union of both (OR), not an intersection. See [below](#selection_tag) for details.
+* `condition` - (Optional) Condition-based filters applied to resources selected for a backup plan (`Conditions` in the AWS API). Multiple conditions use AND logic. Use this with `resources` when you need tag filters to narrow an ARN pattern. See [below](#condition) for details.
+* `resources` - (Optional) Array of strings that either contain ARNs or match patterns of resources to assign to a backup plan. Multiple ARNs use OR logic. Combined with `selection_tag` using OR semantics (see note above).
 * `not_resources` - (Optional) Array of strings that either contain ARNs or match patterns of resources to exclude from a backup plan.
 
 ### selection_tag


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. Documentation-only change.

### Description

Clarify how `resources` and `selection_tag` interact on `aws_backup_selection`.

AWS Backup evaluates `Resources` and `ListOfTags` (`selection_tag`) independently with **OR** semantics. Combining a wildcard such as `resources = ["*"]` or `["arn:aws:s3:::*"]` with `selection_tag` does **not** filter the ARN set by tag; it selects all matching ARNs **plus** all resources matching the tag(s), which can create an unintended broad selection.

This PR:
- Adds an Argument Reference note describing OR vs AND behavior
- Clarifies the `resources`, `selection_tag`, and `condition` argument descriptions
- Adds a practical example that uses `resources` + `condition` for ARN-pattern + tag filtering

No Go code or behavior changes.

### Relations

Closes #49829  
Relates #41274

### References

- https://docs.aws.amazon.com/cli/latest/reference/backup/create-backup-selection.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_selection

### Output from Acceptance Testing

N/A — documentation-only change; no acceptance tests required.

```console
% # no acceptance tests run