### PR TITLE
docs: note supported SSH key types for aws_key_pair (#49767)

### DIFF
--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -18,6 +18,8 @@ When importing an existing key pair the public key material may be in any format
 * Base64 encoded DER format
 * SSH public key file format as specified in RFC4716
 
+~> **NOTE:** AWS only accepts `RSA` and `ED25519` key types. Other key types, such as `ECDSA` or `DSA`, are not supported and will be rejected by the AWS API.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
The `aws_key_pair` resource docs list the *encoding* formats AWS accepts for imported public key material (OpenSSH, Base64 DER, RFC4716), but never state which *key algorithms* are supported. That information also isn't surfaced in the linked EC2 "Key pairs" console guide — it exists only in a different subsection ("Create a key pair") that isn't linked from here, making it easy to miss until you hit an API error.

This adds a note clarifying that AWS only accepts RSA and ED25519 key types.

No changelog entry included — per the [Changelog Process guide](https://hashicorp.github.io/terraform-provider-aws/changelog-process/), resource/provider documentation updates should not have a CHANGELOG entry.


### Relations
Closes #49767

### References
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws


### Output from Acceptance Testing
N/A — documentation-only change, no code or test-affecting logic modified.

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
