### PR TITLE
r/aws_cloudwatch_metric_alarm: Add warm_up_configuration block

### DIFF
--- a/.changelog/49873.txt
+++ b/.changelog/49873.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudwatch_metric_alarm: Add `warm_up_configuration` configuration block
+```

--- a/internal/service/cloudwatch/metric_alarm.go
+++ b/internal/service/cloudwatch/metric_alarm.go
@@ -343,6 +343,25 @@ func resourceMetricAlarm() *schema.Resource {
 					Optional:         true,
 					ValidateDiagFunc: enum.Validate[awstypes.StandardUnit](),
 				},
+				"warm_up_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"only_start_evaluating_after_warm_up_period_ends": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+							"warm_up_period_duration_in_minutes": {
+								Type:         schema.TypeInt,
+								Required:     true,
+								ValidateFunc: validation.IntBetween(1, 2880),
+							},
+						},
+					},
+				},
 			}
 		},
 
@@ -560,6 +579,10 @@ func expandPutMetricAlarmInput(ctx context.Context, d *schema.ResourceData) *clo
 		apiObject.OKActions = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
+	if v, ok := d.GetOk("warm_up_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.WarmUpConfiguration = expandWarmUpConfiguration(v.([]any)[0].(map[string]any))
+	}
+
 	// Handle evaluation_criteria (PromQL alarms).
 	if v, ok := d.GetOk("evaluation_criteria"); ok && len(v.([]any)) > 0 {
 		apiObject.EvaluationCriteria = expandEvaluationCriteria(v.([]any)[0].(map[string]any))
@@ -657,6 +680,19 @@ func flattenEvaluationCriteria(apiObject awstypes.EvaluationCriteria) []any {
 		}
 
 		tfMap["promql_criteria"] = []any{promqlMap}
+	}
+
+	return []any{tfMap}
+}
+
+func flattenWarmUpConfiguration(apiObject *awstypes.WarmUpConfiguration) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"only_start_evaluating_after_warm_up_period_ends": aws.ToBool(apiObject.OnlyStartEvaluatingAfterWarmUpPeriodEnds),
+		"warm_up_period_duration_in_minutes":              aws.ToInt32(apiObject.WarmUpPeriodDurationInMinutes),
 	}
 
 	return []any{tfMap}
@@ -833,6 +869,22 @@ func expandEvaluationCriteria(tfMap map[string]any) awstypes.EvaluationCriteria 
 	return nil
 }
 
+func expandWarmUpConfiguration(tfMap map[string]any) *awstypes.WarmUpConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &awstypes.WarmUpConfiguration{
+		WarmUpPeriodDurationInMinutes: aws.Int32(int32(tfMap["warm_up_period_duration_in_minutes"].(int))),
+	}
+
+	if v, ok := tfMap["only_start_evaluating_after_warm_up_period_ends"]; ok {
+		apiObject.OnlyStartEvaluatingAfterWarmUpPeriodEnds = aws.Bool(v.(bool))
+	}
+
+	return apiObject
+}
+
 func expandMetricAlarmDimensions(tfMap map[string]any) []awstypes.Dimension {
 	if len(tfMap) == 0 {
 		return nil
@@ -915,37 +967,42 @@ func resourceMetricAlarmFlatten(_ context.Context, d *schema.ResourceData, alarm
 		d.Set("treat_missing_data", missingDataMissing)
 	}
 
+	if err := d.Set("warm_up_configuration", flattenWarmUpConfiguration(alarm.WarmUpConfiguration)); err != nil {
+		return smarterr.NewError(fmt.Errorf("setting warm_up_configuration: %w", err))
+	}
+
 	return nil
 }
 
 type metricAlarmResourceModel struct {
 	framework.WithRegionModel
-	ActionsEnabled                    types.Bool                                               `tfsdk:"actions_enabled"`
-	AlarmActions                      fwtypes.SetOfString                                      `tfsdk:"alarm_actions"`
-	AlarmDescription                  types.String                                             `tfsdk:"alarm_description"`
-	AlarmName                         types.String                                             `tfsdk:"alarm_name"`
-	ARN                               types.String                                             `tfsdk:"arn"`
-	ComparisonOperator                fwtypes.StringEnum[awstypes.ComparisonOperator]          `tfsdk:"comparison_operator"`
-	DatapointsToAlarm                 types.Int64                                              `tfsdk:"datapoints_to_alarm"`
-	Dimensions                        fwtypes.MapOfString                                      `tfsdk:"dimensions"`
-	EvaluateLowSampleCountPercentiles types.String                                             `tfsdk:"evaluate_low_sample_count_percentiles"`
-	EvaluationCriteria                fwtypes.ListNestedObjectValueOf[evaluationCriteriaModel] `tfsdk:"evaluation_criteria"`
-	EvaluationInterval                types.Int64                                              `tfsdk:"evaluation_interval"`
-	EvaluationPeriods                 types.Int64                                              `tfsdk:"evaluation_periods"`
-	ExtendedStatistic                 types.String                                             `tfsdk:"extended_statistic"`
-	InsufficientDataActions           fwtypes.SetOfString                                      `tfsdk:"insufficient_data_actions"`
-	MetricName                        types.String                                             `tfsdk:"metric_name"`
-	MetricQuery                       fwtypes.SetNestedObjectValueOf[metricDataQueryModel]     `tfsdk:"metric_query"`
-	Namespace                         types.String                                             `tfsdk:"namespace"`
-	OKActions                         fwtypes.SetOfString                                      `tfsdk:"ok_actions"`
-	Period                            types.Int64                                              `tfsdk:"period"`
-	Statistic                         fwtypes.StringEnum[awstypes.Statistic]                   `tfsdk:"statistic"`
-	Tags                              tftags.Map                                               `tfsdk:"tags"`
-	TagsAll                           tftags.Map                                               `tfsdk:"tags_all"`
-	Threshold                         types.Float64                                            `tfsdk:"threshold"`
-	ThresholdMetricID                 types.String                                             `tfsdk:"threshold_metric_id"`
-	TreatMissingData                  types.String                                             `tfsdk:"treat_missing_data"`
-	Unit                              fwtypes.StringEnum[awstypes.StandardUnit]                `tfsdk:"unit"`
+	ActionsEnabled                    types.Bool                                                `tfsdk:"actions_enabled"`
+	AlarmActions                      fwtypes.SetOfString                                       `tfsdk:"alarm_actions"`
+	AlarmDescription                  types.String                                              `tfsdk:"alarm_description"`
+	AlarmName                         types.String                                              `tfsdk:"alarm_name"`
+	ARN                               types.String                                              `tfsdk:"arn"`
+	ComparisonOperator                fwtypes.StringEnum[awstypes.ComparisonOperator]           `tfsdk:"comparison_operator"`
+	DatapointsToAlarm                 types.Int64                                               `tfsdk:"datapoints_to_alarm"`
+	Dimensions                        fwtypes.MapOfString                                       `tfsdk:"dimensions"`
+	EvaluateLowSampleCountPercentiles types.String                                              `tfsdk:"evaluate_low_sample_count_percentiles"`
+	EvaluationCriteria                fwtypes.ListNestedObjectValueOf[evaluationCriteriaModel]  `tfsdk:"evaluation_criteria"`
+	EvaluationInterval                types.Int64                                               `tfsdk:"evaluation_interval"`
+	EvaluationPeriods                 types.Int64                                               `tfsdk:"evaluation_periods"`
+	ExtendedStatistic                 types.String                                              `tfsdk:"extended_statistic"`
+	InsufficientDataActions           fwtypes.SetOfString                                       `tfsdk:"insufficient_data_actions"`
+	MetricName                        types.String                                              `tfsdk:"metric_name"`
+	MetricQuery                       fwtypes.SetNestedObjectValueOf[metricDataQueryModel]      `tfsdk:"metric_query"`
+	Namespace                         types.String                                              `tfsdk:"namespace"`
+	OKActions                         fwtypes.SetOfString                                       `tfsdk:"ok_actions"`
+	Period                            types.Int64                                               `tfsdk:"period"`
+	Statistic                         fwtypes.StringEnum[awstypes.Statistic]                    `tfsdk:"statistic"`
+	Tags                              tftags.Map                                                `tfsdk:"tags"`
+	TagsAll                           tftags.Map                                                `tfsdk:"tags_all"`
+	Threshold                         types.Float64                                             `tfsdk:"threshold"`
+	ThresholdMetricID                 types.String                                              `tfsdk:"threshold_metric_id"`
+	TreatMissingData                  types.String                                              `tfsdk:"treat_missing_data"`
+	Unit                              fwtypes.StringEnum[awstypes.StandardUnit]                 `tfsdk:"unit"`
+	WarmUpConfiguration               fwtypes.ListNestedObjectValueOf[warmUpConfigurationModel] `tfsdk:"warm_up_configuration"`
 }
 
 type evaluationCriteriaModel struct {
@@ -975,4 +1032,9 @@ type metricStatModel struct {
 	Period     types.Int64                               `tfsdk:"period"`
 	Stat       types.String                              `tfsdk:"stat"`
 	Unit       fwtypes.StringEnum[awstypes.StandardUnit] `tfsdk:"unit"`
+}
+
+type warmUpConfigurationModel struct {
+	OnlyStartEvaluatingAfterWarmUpPeriodEnds types.Bool  `tfsdk:"only_start_evaluating_after_warm_up_period_ends"`
+	WarmUpPeriodDurationInMinutes            types.Int64 `tfsdk:"warm_up_period_duration_in_minutes"`
 }

--- a/internal/service/cloudwatch/metric_alarm_test.go
+++ b/internal/service/cloudwatch/metric_alarm_test.go
@@ -649,6 +649,52 @@ func TestAccCloudWatchMetricAlarm_promql(t *testing.T) {
 	})
 }
 
+func TestAccCloudWatchMetricAlarm_warmUpConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	var alarm types.MetricAlarm
+	resourceName := "aws_cloudwatch_metric_alarm.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMetricAlarmDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetricAlarmConfig_warmUpConfiguration(rName, 60),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMetricAlarmExists(ctx, t, resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "warm_up_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "warm_up_configuration.0.warm_up_period_duration_in_minutes", "60"),
+					resource.TestCheckResourceAttr(resourceName, "warm_up_configuration.0.only_start_evaluating_after_warm_up_period_ends", acctest.CtFalse),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccMetricAlarmConfig_warmUpConfigurationOnlyStartEvaluatingAfterWarmUpPeriodEnds(rName, 120, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMetricAlarmExists(ctx, t, resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "warm_up_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "warm_up_configuration.0.warm_up_period_duration_in_minutes", "120"),
+					resource.TestCheckResourceAttr(resourceName, "warm_up_configuration.0.only_start_evaluating_after_warm_up_period_ends", acctest.CtTrue),
+				),
+			},
+			{
+				Config: testAccMetricAlarmConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMetricAlarmExists(ctx, t, resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "warm_up_configuration.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 // https://github.com/hashicorp/terraform-provider-aws/issues/47624.
 func TestAccCloudWatchMetricAlarm_metricNameUnknown(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -1249,6 +1295,57 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   evaluation_interval = 600
 }
 `, rName)
+}
+
+func testAccMetricAlarmConfig_warmUpConfiguration(rName string, durationInMinutes int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "test" {
+  alarm_name                = %[1]q
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = 2
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/EC2"
+  period                    = 120
+  statistic                 = "Average"
+  threshold                 = 80
+  alarm_description         = "This metric monitors ec2 cpu utilization"
+  insufficient_data_actions = []
+
+  dimensions = {
+    InstanceId = "i-abcd1234"
+  }
+
+  warm_up_configuration {
+    warm_up_period_duration_in_minutes = %[2]d
+  }
+}
+`, rName, durationInMinutes)
+}
+
+func testAccMetricAlarmConfig_warmUpConfigurationOnlyStartEvaluatingAfterWarmUpPeriodEnds(rName string, durationInMinutes int, onlyStartEvaluatingAfterWarmUpPeriodEnds bool) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "test" {
+  alarm_name                = %[1]q
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = 2
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/EC2"
+  period                    = 120
+  statistic                 = "Average"
+  threshold                 = 80
+  alarm_description         = "This metric monitors ec2 cpu utilization"
+  insufficient_data_actions = []
+
+  dimensions = {
+    InstanceId = "i-abcd1234"
+  }
+
+  warm_up_configuration {
+    warm_up_period_duration_in_minutes              = %[2]d
+    only_start_evaluating_after_warm_up_period_ends = %[3]t
+  }
+}
+`, rName, durationInMinutes, onlyStartEvaluatingAfterWarmUpPeriodEnds)
 }
 
 func testAccMetricAlarmConfig_metricNameUnknown(rName string) string {

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -218,6 +218,27 @@ resource "aws_cloudwatch_metric_alarm" "nlb_healthyhosts" {
 }
 ```
 
+### With a Warm-Up Period
+
+```terraform
+resource "aws_cloudwatch_metric_alarm" "example" {
+  alarm_name          = "example-service-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "Errors"
+  namespace           = "ExampleApp"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 0
+  treat_missing_data  = "breaching"
+  alarm_actions       = [aws_sns_topic.example.arn]
+
+  warm_up_configuration {
+    warm_up_period_duration_in_minutes = 30
+  }
+}
+```
+
 ~> **NOTE:**  You cannot create a metric alarm consisting of both `statistic` and `extended_statistic` parameters.
 You must choose one or the other.
 
@@ -256,6 +277,7 @@ This resource supports the following arguments:
   If you specify `evaluate` or omit this parameter, the alarm will always be evaluated and possibly change state no matter how many data points are available.
 The following values are supported: `ignore`, and `evaluate`.
 * `metric_query` (Optional) Enables you to create an alarm based on a metric math expression. You may specify at most 20.
+* `warm_up_configuration` - (Optional) Warm-up period that delays alarm evaluation after the alarm is created. During the warm-up period the alarm stays in `INSUFFICIENT_DATA` and does not perform alarm actions. See [`warm_up_configuration`](#warm_up_configuration) below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 See [related part of AWS Docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html)
@@ -302,6 +324,13 @@ for details about valid values.
 * `stat` - (Required) The statistic to apply to this metric.
    See docs for [supported statistics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html).
 * `unit` - (Optional) The unit for this metric.
+
+#### `warm_up_configuration`
+
+* `warm_up_period_duration_in_minutes` - (Required) Length of the warm-up period, in minutes. Valid values are `1` to `2880`.
+* `only_start_evaluating_after_warm_up_period_ends` - (Optional) Whether to wait for the full warm-up period before evaluation begins, even if metric data arrives earlier. When `false`, the warm-up period ends early as soon as the alarm has enough data to fill its evaluation window. Defaults to `false`.
+
+~> **Note:** The warm-up period applies once, when the alarm is created. Changing the warm-up configuration after the warm-up period ends does not start a new warm-up period. See [Alarm warm-up periods](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/alarm-warm-up.html) in the Amazon CloudWatch User Guide.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

Adds an optional `warm_up_configuration` block to `aws_cloudwatch_metric_alarm`, exposing the CloudWatch alarm warm-up period that AWS released on 1 September 2026 (`PutMetricAlarm` `WarmUpConfiguration`).

- `warm_up_period_duration_in_minutes` (Required, 1 to 2880)
- `only_start_evaluating_after_warm_up_period_ends` (Optional, default `false`)

The attribute names match `awscc_cloudwatch_alarm`. The block is expanded in the common section of `expandPutMetricAlarmInput`, so both traditional and PromQL alarms send it, and flattened in `resourceMetricAlarmFlatten`, which the list resource shares. Removing the block drops the configuration from the alarm, which the last acceptance test step asserts.

Two points from the issue are intentionally not implemented. A computed `warm_up_period_ends` attribute is not possible because `DescribeAlarms` has no such member in the service model. The docs also do not say that updates restart the warm-up clock, because the CloudWatch user guide states that warm-up applies only once at alarm creation and does not restart.

No SDK bump is needed: `service/cloudwatch` v1.67.0 introduced the type and the provider is already on v1.69.1.

### Relations

Closes #49773

### References

- https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/alarm-warm-up.html
- https://aws.amazon.com/about-aws/whats-new/2026/08/amazon-cloudwatch-alarms-warmup-period/
- https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-cloudwatch-alarm-warmupconfiguration.html
- #47449 (PromQL `evaluation_criteria`, used as the pattern for this change)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccCloudWatchMetricAlarm_warmUpConfiguration PKG=cloudwatch
TF_ACC=1 go1.26.6 test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchMetricAlarm_warmUpConfiguration'  -timeout 360m -vet=off -buildvcs=false
2026/09/07 11:38:39 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/07 11:38:39 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCloudWatchMetricAlarm_warmUpConfiguration
=== PAUSE TestAccCloudWatchMetricAlarm_warmUpConfiguration
=== CONT  TestAccCloudWatchMetricAlarm_warmUpConfiguration
--- PASS: TestAccCloudWatchMetricAlarm_warmUpConfiguration (70.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	70.486s
```
