### PR TITLE
r/aws_db_proxy_default_target_group: clear init_query and session_pinning_filters when removed

### DIFF
--- a/.changelog/49876.txt
+++ b/.changelog/49876.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_proxy_default_target_group: Fix `init_query` and `session_pinning_filters` not being cleared on the target group when removed from configuration
+```

--- a/internal/service/rds/proxy_default_target_group.go
+++ b/internal/service/rds/proxy_default_target_group.go
@@ -263,11 +263,11 @@ func expandConnectionPoolConfiguration(tfMap map[string]any) *types.ConnectionPo
 		MaxIdleConnectionsPercent: aws.Int32(int32(tfMap["max_idle_connections_percent"].(int))),
 	}
 
-	if v, ok := tfMap["init_query"].(string); ok && v != "" {
+	if v, ok := tfMap["init_query"].(string); ok {
 		apiObject.InitQuery = aws.String(v)
 	}
 
-	if v, ok := tfMap["session_pinning_filters"].(*schema.Set); ok && v.Len() > 0 {
+	if v, ok := tfMap["session_pinning_filters"].(*schema.Set); ok {
 		apiObject.SessionPinningFilters = flex.ExpandStringValueSet(v)
 	}
 

--- a/internal/service/rds/proxy_default_target_group_test.go
+++ b/internal/service/rds/proxy_default_target_group_test.go
@@ -173,6 +173,13 @@ func TestAccRDSProxyDefaultTargetGroup_initQuery(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.init_query", "SET a=2, b=1"),
 				),
 			},
+			{
+				Config: testAccProxyDefaultTargetGroupConfig_emptyConnectionPoolConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProxyTargetGroupExists(ctx, t, resourceName, &dbProxyTargetGroup),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_config.0.init_query", ""),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

### Description

`expandConnectionPoolConfiguration` only set `InitQuery` when `init_query` was non-empty, and `SessionPinningFilters` when `session_pinning_filters` had at least one element. `ModifyDBProxyTargetGroup` is a partial update, so an omitted field keeps its current value. As a result, removing `init_query` (or `session_pinning_filters`) from the configuration was never applied, and every subsequent `terraform plan` showed the same in-place update.

This change always sends both fields, so an empty value clears them on the target group. This matches how other RDS resources handle optional string attributes (e.g. `monitoring_role_arn` and `option_group_name` in `aws_db_instance` are sent unconditionally on change). Sending `InitQuery=""` was verified with the AWS CLI to clear the initialization query.

The `initQuery` acceptance test gains a step that removes `init_query` and asserts it is empty afterwards.

### Relations

Closes #49875

### References

- [ConnectionPoolConfiguration - Amazon RDS API Reference](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ConnectionPoolConfiguration.html)

### Output from Acceptance Testing

```console
make testacc TESTS='TestAccRDSProxyDefaultTargetGroup_(initQuery|emptyConnectionPool|sessionPinningFilters)' PKG=rds

--- snip ---

ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	0.205s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	0.181s
make: Running acceptance tests on branch: 🌿 HEAD 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSProxyDefaultTargetGroup_(initQuery|emptyConnectionPool|sessionPinningFilters)'  -timeout 360m -vet=off -buildvcs=false
2026/09/08 10:29:09 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/08 10:29:09 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSProxyDefaultTargetGroup_emptyConnectionPool
=== PAUSE TestAccRDSProxyDefaultTargetGroup_emptyConnectionPool
=== RUN   TestAccRDSProxyDefaultTargetGroup_initQuery
=== PAUSE TestAccRDSProxyDefaultTargetGroup_initQuery
=== RUN   TestAccRDSProxyDefaultTargetGroup_sessionPinningFilters
=== PAUSE TestAccRDSProxyDefaultTargetGroup_sessionPinningFilters
=== CONT  TestAccRDSProxyDefaultTargetGroup_emptyConnectionPool
=== CONT  TestAccRDSProxyDefaultTargetGroup_sessionPinningFilters
=== CONT  TestAccRDSProxyDefaultTargetGroup_initQuery
--- PASS: TestAccRDSProxyDefaultTargetGroup_emptyConnectionPool (488.77s)
--- PASS: TestAccRDSProxyDefaultTargetGroup_sessionPinningFilters (524.61s)
--- PASS: TestAccRDSProxyDefaultTargetGroup_initQuery (561.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	561.944s
```
