### PR TITLE
docs: fix aws_cloudwatch_event_target examples to reference rule by name

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -245,7 +245,7 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
 ```terraform
 resource "aws_cloudwatch_event_target" "example" {
   arn  = "${aws_api_gateway_stage.example.execution_arn}/GET"
-  rule = aws_cloudwatch_event_rule.example.id
+  rule = aws_cloudwatch_event_rule.example.name
 
   http_target {
     query_string_parameters = {
@@ -331,7 +331,7 @@ resource "aws_cloudwatch_event_target" "stop_instances" {
 ```terraform
 resource "aws_cloudwatch_event_target" "example" {
   arn  = aws_lambda_function.example.arn
-  rule = aws_cloudwatch_event_rule.example.id
+  rule = aws_cloudwatch_event_rule.example.name
 
   input_transformer {
     input_paths = {
@@ -357,7 +357,7 @@ resource "aws_cloudwatch_event_rule" "example" {
 ```terraform
 resource "aws_cloudwatch_event_target" "example" {
   arn  = aws_lambda_function.example.arn
-  rule = aws_cloudwatch_event_rule.example.id
+  rule = aws_cloudwatch_event_rule.example.name
 
   input_transformer {
     input_paths = {
@@ -465,7 +465,7 @@ resource "aws_cloudwatch_event_rule" "invoke_appsync_mutation" {
 
 resource "aws_cloudwatch_event_target" "invoke_appsync_mutation" {
   arn      = replace(aws_appsync_graphql_api.graphql-api.arn, "apis", "endpoints/graphql-api")
-  rule     = aws_cloudwatch_event_rule.invoke_appsync_mutation.id
+  rule     = aws_cloudwatch_event_rule.invoke_appsync_mutation.name
   role_arn = aws_iam_role.appsync_mutation_role.arn
 
   input_transformer {


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None. This is a documentation-only change.

### Description

The `aws_cloudwatch_event_target` documentation's **API Gateway target**, both **Input Transformer** examples, and the **AppSync Usage** example set:

```terraform
rule = aws_cloudwatch_event_rule.example.id
```

while every other example on the same page (Kinesis, SSM Document, RunCommand, ECS Run Task, Cross-Account Event Bus, Cloudwatch Log Group Usage) correctly uses `.name`.

The Argument Reference is explicit that `rule` is "the name of the rule you want to add targets to," and `aws_cloudwatch_event_rule`'s own Attribute Reference documents its `id` as "the name of the rule" — so `.id` happens to resolve to the same string here, which is why this was easy to miss and easy to copy into new examples. The fix makes the four inconsistent examples reference `.name`, matching the argument's actual documented contract instead of a value that only works because it happens to resolve to the same thing for this one resource.

No code changes — `website/docs/r/cloudwatch_event_target.html.markdown` only.

### Relations

Closes #49798

### References

None.

### Output from Acceptance Testing

Not applicable — documentation-only change, no provider code touched. Verified instead with the website-specific checks:

```console
$ terrafmt diff ./website --check --pattern '*.markdown'
(no output — clean)

$ misspell -error -source text website/docs/r/cloudwatch_event_target.html.markdown
(no output — clean)
```

Per `docs/changelog-process.md`, "Resource and provider documentation updates" don't require a `.changelog/` entry, so none is included.