### PR TITLE
r/aws_bedrockagentcore_oauth2_credential_provider: support EXTERNAL client secret source 🤖🤖🤖

### DIFF
--- a/.changelog/49880.txt
+++ b/.changelog/49880.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagentcore_oauth2_credential_provider: Add `client_secret_config` and `client_secret_source` arguments
+```

--- a/internal/service/bedrockagentcore/oauth2_credential_provider.go
+++ b/internal/service/bedrockagentcore/oauth2_credential_provider.go
@@ -76,9 +76,16 @@ func oauth2ClientCredentialsAttributes(context.Context) map[string]schema.Attrib
 				stringvalidator.ConflictsWith(path.Expressions{
 					path.MatchRelative().AtParent().AtName("client_id_wo"),
 				}...),
-				stringvalidator.AlsoRequires(path.Expressions{
-					path.MatchRelative().AtParent().AtName(names.AttrClientSecret),
-				}...),
+				// The client secret is either supplied inline or read by the service
+				// from a Secrets Manager secret referenced by client_secret_config.
+				stringvalidator.Any(
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRelative().AtParent().AtName(names.AttrClientSecret),
+					}...),
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRelative().AtParent().AtName("client_secret_config"),
+					}...),
+				),
 				//stringvalidator.PreferWriteOnlyAttribute(path.MatchRelative().AtParent().AtName("client_id_wo")),
 			},
 		},
@@ -111,6 +118,10 @@ func oauth2ClientCredentialsAttributes(context.Context) map[string]schema.Attrib
 				//stringvalidator.PreferWriteOnlyAttribute(path.MatchRelative().AtParent().AtName("client_secret_wo")),
 			},
 		},
+		"client_secret_source": schema.StringAttribute{
+			CustomType: fwtypes.StringEnumType[awstypes.SecretSourceType](),
+			Optional:   true,
+		},
 		"client_secret_wo": schema.StringAttribute{
 			Optional:  true,
 			WriteOnly: true,
@@ -129,6 +140,38 @@ func oauth2ClientCredentialsAttributes(context.Context) map[string]schema.Attrib
 	}
 }
 
+// oauth2ClientSecretConfigBlock describes a Secrets Manager secret that the service
+// reads the client secret from, used when the client secret source is EXTERNAL.
+func oauth2ClientSecretConfigBlock(ctx context.Context) schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[oauth2SecretReferenceModel](ctx),
+		Validators: []validator.List{
+			listvalidator.SizeAtMost(1),
+			listvalidator.ConflictsWith(path.Expressions{
+				path.MatchRelative().AtParent().AtName(names.AttrClientSecret),
+				path.MatchRelative().AtParent().AtName("client_secret_wo"),
+				path.MatchRelative().AtParent().AtName("client_credentials_wo_version"),
+			}...),
+		},
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"json_key": schema.StringAttribute{
+					Required: true,
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 128),
+					},
+				},
+				"secret_id": schema.StringAttribute{
+					Required: true,
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 2048),
+					},
+				},
+			},
+		},
+	}
+}
+
 func basicOAuth2ProviderConfigBlock[T any](ctx context.Context) schema.ListNestedBlock {
 	attrs := oauth2ClientCredentialsAttributes(ctx)
 	attrs["oauth_discovery"] = framework.ResourceComputedListOfObjectsAttribute[oauth2DiscoveryModel](ctx)
@@ -140,6 +183,9 @@ func basicOAuth2ProviderConfigBlock[T any](ctx context.Context) schema.ListNeste
 		},
 		NestedObject: schema.NestedBlockObject{
 			Attributes: attrs,
+			Blocks: map[string]schema.Block{
+				"client_secret_config": oauth2ClientSecretConfigBlock(ctx),
+			},
 		},
 	}
 }
@@ -186,6 +232,7 @@ func (r *oauth2CredentialProviderResource) Schema(ctx context.Context, request r
 							NestedObject: schema.NestedBlockObject{
 								Attributes: oauth2ClientCredentialsAttributes(ctx),
 								Blocks: map[string]schema.Block{
+									"client_secret_config": oauth2ClientSecretConfigBlock(ctx),
 									"oauth_discovery": schema.ListNestedBlock{
 										CustomType: fwtypes.NewListNestedObjectTypeOf[oauth2DiscoveryModel](ctx),
 										Validators: []validator.List{
@@ -590,6 +637,26 @@ func (m oauth2ProviderConfigModel) Expand(ctx context.Context) (any, diag.Diagno
 		clientCredentials.ClientSecret = clientCredentials.ClientSecretWO
 	}
 
+	// The API only reads client_secret_config when the source is EXTERNAL, so infer
+	// the source rather than making practitioners repeat it.
+	externalSecret := !clientCredentials.ClientSecretConfig.IsNull()
+	switch source := clientCredentials.ClientSecretSource.ValueEnum(); {
+	case externalSecret && source != "" && source != awstypes.SecretSourceTypeExternal:
+		diags.AddError(
+			"Invalid OAuth2 Client Secret Configuration",
+			fmt.Sprintf("client_secret_source must be %q when client_secret_config is configured, got %q", awstypes.SecretSourceTypeExternal, source),
+		)
+		return nil, diags
+	case !externalSecret && source == awstypes.SecretSourceTypeExternal:
+		diags.AddError(
+			"Invalid OAuth2 Client Secret Configuration",
+			fmt.Sprintf("client_secret_config must be configured when client_secret_source is %q", awstypes.SecretSourceTypeExternal),
+		)
+		return nil, diags
+	case externalSecret:
+		clientCredentials.ClientSecretSource = fwtypes.StringEnumValue(awstypes.SecretSourceTypeExternal)
+	}
+
 	switch {
 	case !m.CustomOAuth2ProviderConfig.IsNull():
 		data, d := m.CustomOAuth2ProviderConfig.ToPtr(ctx)
@@ -734,11 +801,18 @@ func (m *oauth2ProviderConfigModel) clientCredentials(ctx context.Context) (oaut
 }
 
 type oauth2ClientCredentialsModel struct {
-	ClientCredentialsWOVersion types.Int64  `tfsdk:"client_credentials_wo_version"`
-	ClientID                   types.String `tfsdk:"client_id"`
-	ClientIDWO                 types.String `tfsdk:"client_id_wo"`
-	ClientSecret               types.String `tfsdk:"client_secret"`
-	ClientSecretWO             types.String `tfsdk:"client_secret_wo"`
+	ClientCredentialsWOVersion types.Int64                                                 `tfsdk:"client_credentials_wo_version"`
+	ClientID                   types.String                                                `tfsdk:"client_id"`
+	ClientIDWO                 types.String                                                `tfsdk:"client_id_wo"`
+	ClientSecret               types.String                                                `tfsdk:"client_secret"`
+	ClientSecretConfig         fwtypes.ListNestedObjectValueOf[oauth2SecretReferenceModel] `tfsdk:"client_secret_config"`
+	ClientSecretSource         fwtypes.StringEnum[awstypes.SecretSourceType]               `tfsdk:"client_secret_source"`
+	ClientSecretWO             types.String                                                `tfsdk:"client_secret_wo"`
+}
+
+type oauth2SecretReferenceModel struct {
+	JSONKey  types.String `tfsdk:"json_key"`
+	SecretID types.String `tfsdk:"secret_id"`
 }
 
 type oauth2DiscoveryModel struct {

--- a/internal/service/bedrockagentcore/oauth2_credential_provider_test.go
+++ b/internal/service/bedrockagentcore/oauth2_credential_provider_test.go
@@ -243,6 +243,140 @@ func TestAccBedrockAgentCoreOAuth2CredentialProvider_full(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentCoreOAuth2CredentialProvider_externalClientSecret(t *testing.T) {
+	ctx := acctest.Context(t)
+	var oauth2credentialprovider bedrockagentcorecontrol.GetOauth2CredentialProviderOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_oauth2_credential_provider.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOAuth2CredentialProviders(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOAuth2CredentialProviderDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOAuth2CredentialProviderConfig_externalClientSecret(rName, "test-client-id", "oauth_client_secret"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOAuth2CredentialProviderExists(ctx, t, resourceName, &oauth2credentialprovider),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("oauth2_provider_config").AtSliceIndex(0).AtMapKey("github_oauth2_provider_config").AtSliceIndex(0).AtMapKey("client_secret_source"), knownvalue.StringExact("EXTERNAL")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("oauth2_provider_config").AtSliceIndex(0).AtMapKey("github_oauth2_provider_config").AtSliceIndex(0).AtMapKey("client_secret_config"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"json_key":  knownvalue.StringExact("oauth_client_secret"),
+							"secret_id": tfknownvalue.RegionalARNRegexp("secretsmanager", regexache.MustCompile(`secret:.+`)),
+						}),
+					})),
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrName,
+				// The API does not return the client ID or any of the client secret
+				// configuration, so these cannot be populated on import.
+				ImportStateVerifyIgnore: []string{
+					"oauth2_provider_config.0.github_oauth2_provider_config.0.client_id",
+					"oauth2_provider_config.0.github_oauth2_provider_config.0.client_secret_config",
+					"oauth2_provider_config.0.github_oauth2_provider_config.0.client_secret_source",
+				},
+			},
+			{
+				Config: testAccOAuth2CredentialProviderConfig_externalClientSecret(rName, "updated-client-id", "oauth_client_secret"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOAuth2CredentialProviderExists(ctx, t, resourceName, &oauth2credentialprovider),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreOAuth2CredentialProvider_customExternalClientSecret(t *testing.T) {
+	ctx := acctest.Context(t)
+	var oauth2credentialprovider bedrockagentcorecontrol.GetOauth2CredentialProviderOutput
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagentcore_oauth2_credential_provider.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOAuth2CredentialProviders(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOAuth2CredentialProviderDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOAuth2CredentialProviderConfig_customExternalClientSecret(rName, "https://dev-example.auth0.com/.well-known/openid-configuration"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOAuth2CredentialProviderExists(ctx, t, resourceName, &oauth2credentialprovider),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrName,
+				ImportStateVerifyIgnore: []string{
+					"oauth2_provider_config.0.custom_oauth2_provider_config.0.client_id",
+					"oauth2_provider_config.0.custom_oauth2_provider_config.0.client_secret_config",
+					"oauth2_provider_config.0.custom_oauth2_provider_config.0.client_secret_source",
+				},
+			},
+		},
+	})
+}
+
+func TestAccBedrockAgentCoreOAuth2CredentialProvider_externalClientSecretConflicts(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID)
+			testAccPreCheckOAuth2CredentialProviders(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentCoreServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOAuth2CredentialProviderDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccOAuth2CredentialProviderConfig_externalClientSecretWithInlineSecret(rName),
+				ExpectError: regexache.MustCompile(`Invalid Attribute Combination`),
+			},
+			{
+				Config:      testAccOAuth2CredentialProviderConfig_externalSourceWithoutConfig(rName),
+				ExpectError: regexache.MustCompile(`Invalid OAuth2 Client Secret Configuration`),
+			},
+		},
+	})
+}
+
 func testAccCheckOAuth2CredentialProviderDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.ProviderMeta(ctx, t).BedrockAgentCoreClient(ctx)
@@ -364,6 +498,132 @@ resource "aws_bedrockagentcore_oauth2_credential_provider" "test" {
   }
 }
 `, rName, clientId, clientSecret, version, issuer, authEndpoint, tokenEndpoint, responseType1, responseType2)
+}
+
+func testAccOAuth2CredentialProviderConfig_externalSecretBase(rName, jsonKey string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test" {
+  name                    = %[1]q
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id     = aws_secretsmanager_secret.test.id
+  secret_string = jsonencode({ %[2]q = "test-client-secret" })
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["bedrock-agentcore.amazonaws.com"]
+    }
+
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_secretsmanager_secret_policy" "test" {
+  secret_arn = aws_secretsmanager_secret.test.arn
+  policy     = data.aws_iam_policy_document.test.json
+}
+`, rName, jsonKey)
+}
+
+func testAccOAuth2CredentialProviderConfig_externalClientSecret(rName, clientID, jsonKey string) string {
+	return acctest.ConfigCompose(testAccOAuth2CredentialProviderConfig_externalSecretBase(rName, jsonKey), fmt.Sprintf(`
+resource "aws_bedrockagentcore_oauth2_credential_provider" "test" {
+  name = %[1]q
+
+  credential_provider_vendor = "GithubOauth2"
+  oauth2_provider_config {
+    github_oauth2_provider_config {
+      client_id            = %[2]q
+      client_secret_source = "EXTERNAL"
+
+      client_secret_config {
+        secret_id = aws_secretsmanager_secret.test.arn
+        json_key  = %[3]q
+      }
+    }
+  }
+
+  depends_on = [
+    aws_secretsmanager_secret_policy.test,
+    aws_secretsmanager_secret_version.test,
+  ]
+}
+`, rName, clientID, jsonKey))
+}
+
+func testAccOAuth2CredentialProviderConfig_customExternalClientSecret(rName, discoveryURL string) string {
+	return acctest.ConfigCompose(testAccOAuth2CredentialProviderConfig_externalSecretBase(rName, "oauth_client_secret"), fmt.Sprintf(`
+resource "aws_bedrockagentcore_oauth2_credential_provider" "test" {
+  name = %[1]q
+
+  credential_provider_vendor = "CustomOauth2"
+  oauth2_provider_config {
+    custom_oauth2_provider_config {
+      client_id = "custom-client-id"
+
+      client_secret_config {
+        secret_id = aws_secretsmanager_secret.test.arn
+        json_key  = "oauth_client_secret"
+      }
+
+      oauth_discovery {
+        discovery_url = %[2]q
+      }
+    }
+  }
+
+  depends_on = [
+    aws_secretsmanager_secret_policy.test,
+    aws_secretsmanager_secret_version.test,
+  ]
+}
+`, rName, discoveryURL))
+}
+
+func testAccOAuth2CredentialProviderConfig_externalClientSecretWithInlineSecret(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_bedrockagentcore_oauth2_credential_provider" "test" {
+  name = %[1]q
+
+  credential_provider_vendor = "GithubOauth2"
+  oauth2_provider_config {
+    github_oauth2_provider_config {
+      client_id     = "test-client-id"
+      client_secret = "test-client-secret"
+
+      client_secret_config {
+        secret_id = "example-secret"
+        json_key  = "oauth_client_secret"
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccOAuth2CredentialProviderConfig_externalSourceWithoutConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_bedrockagentcore_oauth2_credential_provider" "test" {
+  name = %[1]q
+
+  credential_provider_vendor = "GithubOauth2"
+  oauth2_provider_config {
+    github_oauth2_provider_config {
+      client_id            = "test-client-id"
+      client_secret        = "test-client-secret"
+      client_secret_source = "EXTERNAL"
+    }
+  }
+}
+`, rName)
 }
 
 func testAccOAuth2CredentialProviderConfig_full(rName string) string {

--- a/website/docs/r/bedrockagentcore_oauth2_credential_provider.html.markdown
+++ b/website/docs/r/bedrockagentcore_oauth2_credential_provider.html.markdown
@@ -12,6 +12,8 @@ Manages an AWS Bedrock AgentCore OAuth2 Credential Provider. OAuth2 credential p
 
 -> **Note:** Write-Only arguments `client_id_wo` and `client_secret_wo` are available to use in place of `client_id` and `client_secret`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments).
 
+-> **Note:** Alternatively, `client_secret_config` points AgentCore at a client secret you already hold in AWS Secrets Manager, so the secret value never passes through Terraform. AgentCore reads the value at token exchange time, which means the secret can be populated or rotated out-of-band without re-running Terraform. Without `client_secret_config`, AgentCore creates and manages the secret itself and its name, tags, KMS key, resource policy, and rotation schedule are not configurable.
+
 ## Example Usage
 
 ### GitHub OAuth Provider
@@ -45,6 +47,52 @@ resource "aws_bedrockagentcore_oauth2_credential_provider" "auth0" {
 
       oauth_discovery {
         discovery_url = "https://dev-company.auth0.com/.well-known/openid-configuration"
+      }
+    }
+  }
+}
+```
+
+### Referencing an Existing Secrets Manager Secret
+
+Manage the client secret yourself in AWS Secrets Manager and let AgentCore read it. The secret is never read by Terraform, so it can be populated out-of-band. The secret needs a resource policy allowing AgentCore to call `secretsmanager:GetSecretValue`, plus `kms:Decrypt` on the key when encrypted with a customer managed KMS key.
+
+```terraform
+resource "aws_secretsmanager_secret" "example" {
+  name = "example/github-oauth"
+}
+
+data "aws_iam_policy_document" "example" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["bedrock-agentcore.amazonaws.com"]
+    }
+
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_secretsmanager_secret_policy" "example" {
+  secret_arn = aws_secretsmanager_secret.example.arn
+  policy     = data.aws_iam_policy_document.example.json
+}
+
+resource "aws_bedrockagentcore_oauth2_credential_provider" "example" {
+  name = "github-oauth-provider"
+
+  credential_provider_vendor = "GithubOauth2"
+  oauth2_provider_config {
+    github_oauth2_provider_config {
+      client_id            = "your-github-client-id"
+      client_secret_source = "EXTERNAL"
+
+      client_secret_config {
+        secret_id = aws_secretsmanager_secret.example.arn
+        json_key  = "client_secret"
       }
     }
   }
@@ -116,6 +164,11 @@ The `custom_oauth2_provider_config` block supports the following:
 * `client_secret_wo` - (Optional) Write-only OAuth2 client secret. Cannot be used with `client_secret`. Must be used together with `client_id_wo` and `client_credentials_wo_version`.
 * `client_credentials_wo_version` - (Optional) Used together with write-only credentials to trigger an update. Increment this value when an update to `client_id_wo` or `client_secret_wo` is required.
 
+**Referenced Secret (choose in place of a client secret):**
+
+* `client_secret_config` - (Optional) Reference to an existing AWS Secrets Manager secret that AgentCore reads the client secret from. Cannot be used with `client_secret`, `client_secret_wo`, or `client_credentials_wo_version`. See [`client_secret_config`](#client_secret_config) below.
+* `client_secret_source` - (Optional) Where AgentCore reads the client secret from. Valid values: `MANAGED`, `EXTERNAL`. Inferred as `EXTERNAL` when `client_secret_config` is configured, and defaults to `MANAGED` otherwise.
+
 **OAuth Discovery Configuration:**
 
 * `oauth_discovery` - (Optional) OAuth discovery configuration. See [`oauth_discovery`](#oauth_discovery) below.
@@ -135,7 +188,19 @@ These predefined provider blocks support the following:
 * `client_secret_wo` - (Optional) Write-only OAuth2 client secret. Cannot be used with `client_secret`. Must be used together with `client_id_wo` and `client_credentials_wo_version`.
 * `client_credentials_wo_version` - (Optional) Used together with write-only credentials to trigger an update. Increment this value when an update to `client_id_wo` or `client_secret_wo` is required.
 
+**Referenced Secret (choose in place of a client secret):**
+
+* `client_secret_config` - (Optional) Reference to an existing AWS Secrets Manager secret that AgentCore reads the client secret from. Cannot be used with `client_secret`, `client_secret_wo`, or `client_credentials_wo_version`. See [`client_secret_config`](#client_secret_config) below.
+* `client_secret_source` - (Optional) Where AgentCore reads the client secret from. Valid values: `MANAGED`, `EXTERNAL`. Inferred as `EXTERNAL` when `client_secret_config` is configured, and defaults to `MANAGED` otherwise.
+
 **Note:** These predefined providers automatically configure OAuth discovery settings based on their respective authorization servers.
+
+### `client_secret_config`
+
+The `client_secret_config` block supports the following:
+
+* `json_key` - (Required) Key within the secret's JSON payload that holds the client secret value.
+* `secret_id` - (Required) ARN or name of the AWS Secrets Manager secret that stores the client secret. Secrets in another AWS account in the same Region are supported, in which case an ARN is required.
 
 ### `oauth_discovery`
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Yes, though additive only. This adds a second, opt-in way to supply an OAuth2 client secret: referencing an existing Secrets Manager secret by ID and JSON key rather than passing the secret value through Terraform. The secret value is never read by Terraform and never enters state. Existing inline (`client_secret`) and write-only (`client_secret_wo`) behaviour is unchanged and remains the default (`MANAGED`).

Operators using the new path are responsible for granting AgentCore read access to the secret via a resource policy, which is called out in the documentation.

### Description

AgentCore Identity can now read an OAuth2 client secret from a Secrets Manager secret you already own, instead of creating and managing the secret itself. This exposes that on the resource.

Two new arguments on `custom_oauth2_provider_config` and each of the predefined vendor blocks (`github`, `google`, `microsoft`, `salesforce`, `slack`):

* `client_secret_config` block, with required `secret_id` and `json_key`, matching the API's `SecretReference`.
* `client_secret_source`, `MANAGED` or `EXTERNAL`.

`client_secret_source` is optional and inferred as `EXTERNAL` whenever `client_secret_config` is set, so it doesn't have to be repeated. Setting it to a value that contradicts the presence of `client_secret_config` is rejected with a clear error rather than being silently ignored by the API. `client_secret_config` conflicts with `client_secret`, `client_secret_wo` and `client_credentials_wo_version`.

The `client_id` validator previously required `client_secret` unconditionally, which made `EXTERNAL` unusable. It now requires either `client_secret` or `client_secret_config`.

Notes for reviewers:

* The per-vendor `*Oauth2ProviderConfigOutput` types return only `OauthDiscovery` and `ClientId`. Neither `clientSecretSource` nor `clientSecretConfig` comes back from the API, so both are carried from state through the existing `oauth2ClientCredentialsCtxKey` mechanism, the same way `client_id`/`client_secret` already are. Consequently they cannot be populated on import and are listed in `ImportStateVerifyIgnore`.
* No dependency bump needed; `bedrockagentcorecontrol v1.61.1` already has `types.SecretReference` and `types.SecretSourceType`.
* Cross-account secrets in the same Region are supported by the service, so `secret_id` is deliberately a plain string with no ARN or account validation. It accepts an ARN or a bare name.
* `client_id_wo` still requires `client_secret_wo`, so `EXTERNAL` pairs with plain `client_id`. That matches the AWS CLI example in the launch post. Happy to relax it if you'd prefer `client_id_wo` + `client_secret_config` to be allowed.

The linked issue proposes a different shape (a nested `secret { secret_arn }` block plus a sibling `client_secret_json_key`). I followed the API and the launch post instead, which use a flat `clientSecretConfig` of `secretId` + `jsonKey`.

### Relations

Closes #48535

### References

* Launch post: https://aws.amazon.com/blogs/machine-learning/reference-your-own-aws-secrets-manager-secrets-in-amazon-bedrock-agentcore-identity/
* API `SecretReference`: https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_SecretReference.html
* API `CreateOauth2CredentialProvider`: https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_CreateOauth2CredentialProvider.html

The same launch also adds `apiKeySecretConfig`/`apiKeySecretSource` to `aws_bedrockagentcore_api_key_credential_provider`. That is not in this PR, to keep it to one resource. I'll raise a separate issue and PR for it.

### AI Usage

This change was written with an LLM agent (Kiro), covering the schema changes, the acceptance tests, and the documentation. I directed the work, chose the schema shape against the AWS API reference and launch post rather than the shape suggested in the issue, and reviewed every line before submitting.

### Output from Acceptance Testing

I do not have an AWS account available to run acceptance testing against, so **the acceptance tests in this PR have not been executed and need a maintainer to run them.**

```console
% make testacc TESTS='TestAccBedrockAgentCoreOAuth2CredentialProvider_externalClientSecret|TestAccBedrockAgentCoreOAuth2CredentialProvider_customExternalClientSecret|TestAccBedrockAgentCoreOAuth2CredentialProvider_externalClientSecretConflicts' PKG=bedrockagentcore

# Not run: no AWS credentials available.
```

Please also re-run the existing tests for this resource, since the `client_id` validator changed:

```console
% make testacc TESTS=TestAccBedrockAgentCoreOAuth2CredentialProvider_ PKG=bedrockagentcore
```

One thing worth attention when they run: the test configuration grants `secretsmanager:GetSecretValue` to the `bedrock-agentcore.amazonaws.com` service principal. That is the principal used elsewhere in this repository, but the launch post doesn't name the principal for this feature explicitly, so I could not verify it is the right one for AgentCore Identity secret reads. If the tests fail on access to the secret, that principal is the first thing to check.

What I did verify locally:

* `go build`, `go vet`, `go test ./internal/service/bedrockagentcore/` pass
* `make provider-lint`, `import-lint`, `testacc-lint`, `terraform-fmt`, `website-terrafmt` pass for `PKG=bedrockagentcore`
* semgrep clean against all in-repo rule configs (0 findings)
