### PR TITLE
feat: add version_label to aws_appconfig_hosted_configuration_version

### DIFF
--- a/.changelog/49881.txt
+++ b/.changelog/49881.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appconfig_hosted_configuration_version: Add `version_label` argument
+```

--- a/internal/service/appconfig/hosted_configuration_version.go
+++ b/internal/service/appconfig/hosted_configuration_version.go
@@ -74,6 +74,15 @@ func resourceHostedConfigurationVersion() *schema.Resource {
 					ForceNew:     true,
 					ValidateFunc: validation.StringLenBetween(0, 1024),
 				},
+				"version_label": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 64),
+						validation.StringMatch(regexache.MustCompile(`[^0-9]`), "must contain at least one non-numeric character"),
+					),
+				},
 				"version_number": {
 					Type:     schema.TypeInt,
 					Computed: true,
@@ -98,6 +107,10 @@ func resourceHostedConfigurationVersionCreate(ctx context.Context, d *schema.Res
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
 		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("version_label"); ok {
+		input.VersionLabel = aws.String(v.(string))
 	}
 
 	output, err := conn.CreateHostedConfigurationVersion(ctx, input)
@@ -138,6 +151,7 @@ func resourceHostedConfigurationVersionRead(ctx context.Context, d *schema.Resou
 	d.Set(names.AttrContent, string(output.Content))
 	d.Set(names.AttrContentType, output.ContentType)
 	d.Set(names.AttrDescription, output.Description)
+	d.Set("version_label", output.VersionLabel)
 	d.Set("version_number", output.VersionNumber)
 
 	return diags

--- a/internal/service/appconfig/hosted_configuration_version_test.go
+++ b/internal/service/appconfig/hosted_configuration_version_test.go
@@ -58,6 +58,7 @@ func TestAccAppConfigHostedConfigurationVersion_versionLabel(t *testing.T) {
 	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_appconfig_hosted_configuration_version.test"
 	versionLabel := "v1.2.3"
+	versionLabelUpdated := "v1.2.4"
 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -79,10 +80,10 @@ func TestAccAppConfigHostedConfigurationVersion_versionLabel(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccHostedConfigurationVersionConfig_versionLabel(rName, "v1.2.4"),
+				Config: testAccHostedConfigurationVersionConfig_versionLabel(rName, versionLabelUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHostedConfigurationVersionExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "version_label", "v1.2.4"),
+					resource.TestCheckResourceAttr(resourceName, "version_label", versionLabelUpdated),
 					resource.TestCheckResourceAttr(resourceName, "version_number", "2"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{

--- a/internal/service/appconfig/hosted_configuration_version_test.go
+++ b/internal/service/appconfig/hosted_configuration_version_test.go
@@ -40,6 +40,7 @@ func TestAccAppConfigHostedConfigurationVersion_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrContent, "{\"foo\":\"bar\"}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrContentType, "application/json"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, rName),
+					resource.TestCheckResourceAttr(resourceName, "version_label", ""),
 					resource.TestCheckResourceAttr(resourceName, "version_number", "1"),
 				),
 			},
@@ -47,6 +48,48 @@ func TestAccAppConfigHostedConfigurationVersion_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAppConfigHostedConfigurationVersion_versionLabel(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_appconfig_hosted_configuration_version.test"
+	versionLabel := "v1.2.3"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHostedConfigurationVersionDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostedConfigurationVersionConfig_versionLabel(rName, versionLabel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHostedConfigurationVersionExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "version_label", versionLabel),
+					resource.TestCheckResourceAttr(resourceName, "version_number", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccHostedConfigurationVersionConfig_versionLabel(rName, "v1.2.4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHostedConfigurationVersionExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "version_label", "v1.2.4"),
+					resource.TestCheckResourceAttr(resourceName, "version_number", "2"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
 			},
 		},
 	})
@@ -140,4 +183,23 @@ resource "aws_appconfig_hosted_configuration_version" "test" {
   description = %q
 }
 `, rName))
+}
+
+func testAccHostedConfigurationVersionConfig_versionLabel(rName, versionLabel string) string {
+	return acctest.ConfigCompose(
+		testAccConfigurationProfileConfig_name(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_hosted_configuration_version" "test" {
+  application_id           = aws_appconfig_application.test.id
+  configuration_profile_id = aws_appconfig_configuration_profile.test.configuration_profile_id
+  content_type             = "application/json"
+
+  content = jsonencode({
+    foo = "bar"
+  })
+
+  description   = %[1]q
+  version_label = %[2]q
+}
+`, rName, versionLabel))
 }

--- a/website/docs/r/appconfig_hosted_configuration_version.html.markdown
+++ b/website/docs/r/appconfig_hosted_configuration_version.html.markdown
@@ -124,8 +124,8 @@ This resource supports the following arguments:
 * `content` - (Required, Forces new resource) Content of the configuration or the configuration data.
 * `content_type` - (Required, Forces new resource) Standard MIME type describing the format of the configuration content. For more information, see [Content-Type](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17).
 * `description` - (Optional, Forces new resource) Description of the configuration.
-* `version_label` - (Optional, Forces new resource) User-defined label for the AppConfig hosted configuration version. This value must contain at least one non-numeric character.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `version_label` - (Optional, Forces new resource) User-defined label for the AppConfig hosted configuration version. This value must contain at least one non-numeric character.
 
 ## Attribute Reference
 

--- a/website/docs/r/appconfig_hosted_configuration_version.html.markdown
+++ b/website/docs/r/appconfig_hosted_configuration_version.html.markdown
@@ -124,6 +124,7 @@ This resource supports the following arguments:
 * `content` - (Required, Forces new resource) Content of the configuration or the configuration data.
 * `content_type` - (Required, Forces new resource) Standard MIME type describing the format of the configuration content. For more information, see [Content-Type](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17).
 * `description` - (Optional, Forces new resource) Description of the configuration.
+* `version_label` - (Optional, Forces new resource) User-defined label for the AppConfig hosted configuration version. This value must contain at least one non-numeric character.
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 
 ## Attribute Reference


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.


### Description

Add support for `version_label` to [`aws_appconfig_hosted_configuration_version`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appconfig_hosted_configuration_version)


### Relations

Closes #49867

### References

- [AWS API Docs - CreateHostedConfigurationVersion](https://docs.aws.amazon.com/appconfig/2019-10-09/APIReference/API_CreateHostedConfigurationVersion.html)


### Output from Acceptance Testing

```console
make testacc T=TestAccAppConfigHostedConfigurationVersion_versionLabel K=appconfig
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_appconfig_hosted_configuration_version-add-version-label 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/appconfig/... -v -count 1 -parallel 20 -run='TestAccAppConfigHostedConfigurationVersion_versionLabel'  -timeout 360m -vet=off -buildvcs=false
2026/09/07 20:28:56 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/07 20:28:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAppConfigHostedConfigurationVersion_versionLabel
=== PAUSE TestAccAppConfigHostedConfigurationVersion_versionLabel
=== CONT  TestAccAppConfigHostedConfigurationVersion_versionLabel
--- PASS: TestAccAppConfigHostedConfigurationVersion_versionLabel (56.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appconfig  56.666s

```
