### PR TITLE
docs/cloudwatch_event_target: reference the rule name, not its id

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -245,7 +245,7 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
 ```terraform
 resource "aws_cloudwatch_event_target" "example" {
   arn  = "${aws_api_gateway_stage.example.execution_arn}/GET"
-  rule = aws_cloudwatch_event_rule.example.id
+  rule = aws_cloudwatch_event_rule.example.name
 
   http_target {
     query_string_parameters = {
@@ -331,7 +331,7 @@ resource "aws_cloudwatch_event_target" "stop_instances" {
 ```terraform
 resource "aws_cloudwatch_event_target" "example" {
   arn  = aws_lambda_function.example.arn
-  rule = aws_cloudwatch_event_rule.example.id
+  rule = aws_cloudwatch_event_rule.example.name
 
   input_transformer {
     input_paths = {
@@ -357,7 +357,7 @@ resource "aws_cloudwatch_event_rule" "example" {
 ```terraform
 resource "aws_cloudwatch_event_target" "example" {
   arn  = aws_lambda_function.example.arn
-  rule = aws_cloudwatch_event_rule.example.id
+  rule = aws_cloudwatch_event_rule.example.name
 
   input_transformer {
     input_paths = {
@@ -465,7 +465,7 @@ resource "aws_cloudwatch_event_rule" "invoke_appsync_mutation" {
 
 resource "aws_cloudwatch_event_target" "invoke_appsync_mutation" {
   arn      = replace(aws_appsync_graphql_api.graphql-api.arn, "apis", "endpoints/graphql-api")
-  rule     = aws_cloudwatch_event_rule.invoke_appsync_mutation.id
+  rule     = aws_cloudwatch_event_rule.invoke_appsync_mutation.name
   role_arn = aws_iam_role.appsync_mutation_role.arn
 
   input_transformer {


### PR DESCRIPTION
### Description

Four examples on the `aws_cloudwatch_event_target` page set `rule` from `aws_cloudwatch_event_rule.<name>.id`. The argument reference on the same page says `rule` is *"The name of the rule you want to add targets to"*, and the remaining examples on the page already use `.name`.

`.id` happens to equal the name only on the **default** event bus. From `internal/service/events/rule.go`:

```go
func ruleCreateResourceID(eventBusName, ruleName string) string {
	if eventBusName == "" || eventBusName == defaultEventBusName {
		return ruleName
	}
	parts := []string{eventBusName, ruleName}
	return strings.Join(parts, ruleResourceIDSeparator)   // "<event_bus_name>/<rule_name>"
}
```

So a reader who copies one of these examples and points it at a custom event bus gets `my-bus/my-rule` where a bare rule name is required. This makes the four examples consistent with the page's own argument reference and with its other examples.

### Relations

Closes #49798

### Changes

Only `website/docs/r/cloudwatch_event_target.html.markdown`, four lines, `.id` → `.name`:

| line | example |
| --- | --- |
| 248 | API Gateway target |
| 334 | Input Transformer Usage - JSON Object |
| 360 | Input Transformer Usage - Simple String |
| 468 | AppSync Usage |

No configuration or generated code is touched, so there is no `.changelog` entry.

### Output from Acceptance Testing

Website-only change; no acceptance tests apply.