### PR TITLE
resource/aws_s3_bucket: fix CreateBucket LocationConstraint for S3-compatible endpoints

### DIFF
--- a/.changelog/49890.txt
+++ b/.changelog/49890.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket: Send the configured `region` as the S3 `CreateBucket` `LocationConstraint` when using a custom S3 endpoint with a non-standard region string (e.g. Ceph, MinIO), fixing bucket creation failures against S3-compatible storage
+```

--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -286,6 +286,14 @@ func (c *AWSClient) S3UsePathStyle(context.Context) bool {
 	return c.s3UsePathStyle
 }
 
+// S3OriginalRegion returns the original, non-standard Region string configured for
+// S3-compatible storage (Ceph, MinIO, etc.). It is empty when the configured Region
+// is a standard AWS Region. See config.go where the Region is substituted with a
+// compliant dummy value for AWS SDK initialization.
+func (c *AWSClient) S3OriginalRegion(context.Context) string {
+	return c.s3OriginalRegion
+}
+
 // SetHTTPClient sets the http.Client used for AWS API calls.
 func (c *AWSClient) SetHTTPClient(_ context.Context, httpClient *http.Client) {
 	c.httpClient = httpClient

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -787,9 +787,9 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html#AmazonS3-CreateBucket-request-LocationConstraint.
-	if region != endpoints.UsEast1RegionID {
+	if locationConstraint := BucketLocationConstraint(region, c.S3OriginalRegion(ctx)); locationConstraint != "" {
 		input.CreateBucketConfiguration = &types.CreateBucketConfiguration{
-			LocationConstraint: types.BucketLocationConstraint(region),
+			LocationConstraint: locationConstraint,
 		}
 	}
 
@@ -860,6 +860,31 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	return append(diags, resourceBucketUpdate(ctx, d, meta)...)
+}
+
+// BucketLocationConstraint returns the LocationConstraint value to send in a
+// CreateBucket request, or an empty value when none should be sent.
+//
+// region is the effective SDK region. originalRegion is the non-standard region
+// preserved for S3-compatible storage (Ceph, MinIO, etc.) and is empty for
+// native AWS. For S3-compatible storage the configured region is substituted
+// with a compliant dummy value (us-east-1) during SDK initialization, so the
+// original region is preferred here to avoid sending an empty
+// CreateBucketConfiguration. Any non-standard string (e.g. ":region-ha-premium"
+// or "ceph-objectstore-region1:region-ha-premium") is passed through verbatim.
+//
+// As on native AWS, us-east-1 must not send a LocationConstraint, so an empty
+// value is returned in that case.
+// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html#AmazonS3-CreateBucket-request-LocationConstraint.
+func BucketLocationConstraint(region, originalRegion string) types.BucketLocationConstraint {
+	locationConstraint := region
+	if originalRegion != "" {
+		locationConstraint = originalRegion
+	}
+	if locationConstraint == endpoints.UsEast1RegionID {
+		return ""
+	}
+	return types.BucketLocationConstraint(locationConstraint)
 }
 
 func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -3216,6 +3216,58 @@ func TestBucketRegionalDomainName(t *testing.T) {
 	}
 }
 
+func TestBucketLocationConstraint(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		region         string
+		originalRegion string
+		want           types.BucketLocationConstraint
+	}{
+		"native aws global region sends no constraint": {
+			region:         endpoints.UsEast1RegionID,
+			originalRegion: "",
+			want:           "",
+		},
+		"native aws regional region uses region": {
+			region:         endpoints.EuWest1RegionID,
+			originalRegion: "",
+			want:           types.BucketLocationConstraint(endpoints.EuWest1RegionID),
+		},
+		// Regression: S3-compatible storage substitutes the configured region with
+		// the SDK default region during init. Without preferring the original
+		// region, this produced an empty CreateBucketConfiguration and Ceph returned
+		// 400 InvalidArgument.
+		"s3-compatible substituted region uses original bare constraint": {
+			region:         endpoints.UsEast1RegionID,
+			originalRegion: ":region-ha-premium",
+			want:           types.BucketLocationConstraint(":region-ha-premium"),
+		},
+		// Ceph treats the prefixed and bare forms equally server-side; the provider
+		// passes whichever the user configured through verbatim.
+		"s3-compatible substituted region uses original prefixed constraint": {
+			region:         endpoints.UsEast1RegionID,
+			originalRegion: "ceph-objectstore-region1:region-ha-premium",
+			want:           types.BucketLocationConstraint("ceph-objectstore-region1:region-ha-premium"),
+		},
+		"s3-compatible original global region sends no constraint": {
+			region:         endpoints.UsEast1RegionID,
+			originalRegion: endpoints.UsEast1RegionID,
+			want:           "",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tfs3.BucketLocationConstraint(tc.region, tc.originalRegion); got != tc.want {
+				t.Errorf("BucketLocationConstraint(%q, %q) = %q, want %q", tc.region, tc.originalRegion, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWebsiteEndpoint(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

This change only affects the `LocationConstraint` value sent in the S3 `CreateBucket` request body when a custom S3 endpoint is configured with a non-standard region string. It does not alter access controls, encryption, or logging. Request signing behavior is unchanged.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When a custom S3 endpoint is configured (`endpoints { s3 = ... }`) together with a non-standard region string — for example the region names used by Ceph RGW or MinIO such as `:region-ha-premium` or `ceph-objectstore-region1:region-ha-premium` — the provider substitutes the configured region with a compliant dummy value (`us-east-1`) so the AWS SDK for Go v2's strict region validation passes, while preserving the original region for request signing.

The problem: `resourceBucketCreate` derived the `CreateBucket` `LocationConstraint` from the (now substituted) effective region. Since that value is `us-east-1` — where AWS requires that no `LocationConstraint` be sent — the constraint was omitted and an empty `<CreateBucketConfiguration></CreateBucketConfiguration>` was sent. S3-compatible backends reject this with `400 InvalidArgument`, so bucket creation fails. Provider v5.x sent the configured region verbatim and worked.

This PR prefers the preserved original region for the `LocationConstraint` so the create request again matches the configured region:

- `internal/conns/awsclient.go`: adds an exported `S3OriginalRegion(ctx)` accessor for the region preserved during the S3-compatible substitution.
- `internal/service/s3/bucket.go`: extracts the `LocationConstraint` derivation into a pure, exported helper `BucketLocationConstraint(region, originalRegion)` and uses it in `resourceBucketCreate`. It prefers the original region when set, and continues to send no constraint for `us-east-1`.

Native AWS is unaffected: `S3OriginalRegion` is only populated for a non-AWS region behind a custom S3 endpoint, so on AWS the effective region is used and `us-east-1` continues to send no `LocationConstraint`. Any non-standard region string is passed through verbatim; the equivalence of the prefixed and bare Ceph forms is enforced server-side by Ceph, not by the provider.

Verified against a Ceph RGW gateway: `terraform apply` now sends `<LocationConstraint>:region-ha-premium</LocationConstraint>` and the bucket is created (HTTP 200), matching provider v5.x behavior.

#### `CreateBucket` request body

Config used (Ceph RGW endpoint, non-standard region `:region-ha-premium`):

```hcl
provider "aws" {
  region            = ":region-ha-premium"
  s3_use_path_style = true
  endpoints {
    s3 = "https://ceph.endpoint"
  }
  # ... skip_* flags + static credentials
}

resource "aws_s3_bucket" "example" {
  bucket = "test-aws-bucket"
}
```

Before (v6.63.0, broken) — the substituted `us-east-1` region caused the `LocationConstraint` to be dropped, sending an empty configuration that Ceph rejects with `400 InvalidArgument`:

```http
PUT /test-aws-bucket HTTP/1.1

<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></CreateBucketConfiguration>
```
```
HTTP/1.1 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?><Error><Code>InvalidArgument</Code>...</Error>
```

After (this PR / matches v5.100.0) — the preserved original region is sent as the `LocationConstraint` and Ceph accepts it:

```http
PUT /test-aws-bucket HTTP/1.1

<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LocationConstraint>:region-ha-premium</LocationConstraint></CreateBucketConfiguration>
```
```
HTTP/1.1 200 OK
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

Closes #46517

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- AWS S3 `CreateBucket` `LocationConstraint` reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html#AmazonS3-CreateBucket-request-LocationConstraint
- Related S3-compatible `CreateBucketConfiguration` handling: https://github.com/hashicorp/terraform-provider-aws/issues/47061

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test ./internal/service/s3/ -run 'TestBucketLocationConstraint' -v

=== RUN   TestBucketLocationConstraint
=== PAUSE TestBucketLocationConstraint
=== CONT  TestBucketLocationConstraint
=== RUN   TestBucketLocationConstraint/native_aws_us-east-1_sends_no_constraint
=== RUN   TestBucketLocationConstraint/native_aws_non_us-east-1_uses_region
=== RUN   TestBucketLocationConstraint/s3-compatible_substituted_region_uses_original_bare_constraint
=== RUN   TestBucketLocationConstraint/s3-compatible_substituted_region_uses_original_prefixed_constraint
=== RUN   TestBucketLocationConstraint/s3-compatible_original_us-east-1_sends_no_constraint
--- PASS: TestBucketLocationConstraint (0.00s)
    --- PASS: TestBucketLocationConstraint/native_aws_us-east-1_sends_no_constraint (0.00s)
    --- PASS: TestBucketLocationConstraint/native_aws_non_us-east-1_uses_region (0.00s)
    --- PASS: TestBucketLocationConstraint/s3-compatible_substituted_region_uses_original_bare_constraint (0.00s)
    --- PASS: TestBucketLocationConstraint/s3-compatible_substituted_region_uses_original_prefixed_constraint (0.00s)
    --- PASS: TestBucketLocationConstraint/s3-compatible_original_us-east-1_sends_no_constraint (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 0.208s
```

```console
% make testacc TESTS=TestAccS3Bucket_basic PKG=s3

# Requires an S3-compatible endpoint (e.g. Ceph RGW) with a non-standard region
# string configured to exercise the S3-compatible LocationConstraint path.
...
```
