### PR TITLE
docs(ec2): document supported key types for aws_key_pair public_key

### DIFF
--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -18,6 +18,8 @@ When importing an existing key pair the public key material may be in any format
 * Base64 encoded DER format
 * SSH public key file format as specified in RFC4716
 
+Amazon EC2 supports RSA keys (Linux and Windows instances) and ED25519 keys (Linux instances only); DSA keys are not accepted. See the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws) for details.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None. This is a documentation-only change.

### Description

`aws_key_pair`'s `public_key` argument documented the accepted encoding **formats** (OpenSSH, Base64 DER, RFC4716) but said nothing about accepted key **algorithms**, so it wasn't discoverable that:

- DSA keys are rejected by the AWS API.
- ED25519 keys only work for Linux instances, not Windows.

Per [AWS's own EC2 key pair documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws) (fetched and confirmed before writing this): supported types are RSA (Linux and Windows) and ED25519 (Linux only); DSA keys are explicitly not accepted. Added one line citing that page.

No code changes — `website/docs/r/key_pair.html.markdown` only.

### Relations

Closes #49767

### References

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws

### Output from Acceptance Testing

Not applicable — documentation-only change, no provider code touched. Verified with the website-specific checks:

```console
$ terrafmt diff ./website/docs/r/key_pair.html.markdown --check
(no output — clean)

$ misspell -error -source text website/docs/r/key_pair.html.markdown
(no output — clean)
```

No `.changelog/` entry per `docs/changelog-process.md` ("Resource and provider documentation updates" are excluded).