### PR TITLE
r/aws_dynamodb_table: Remove warm_throughput minimum validation

### DIFF
--- a/.changelog/49895.txt
+++ b/.changelog/49895.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_dynamodb_table: Remove overly-strict `warm_throughput` minimum validation
+resource/aws_dynamodb_table: Lower the `warm_throughput` `read_units_per_second` and `write_units_per_second` minimum from `12000` and `4000` to `1`
 ```

--- a/.changelog/49895.txt
+++ b/.changelog/49895.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Remove overly-strict `warm_throughput` minimum validation
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -625,16 +625,14 @@ func warmThroughputSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"read_units_per_second": {
-					Type:         schema.TypeInt,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.IntAtLeast(12000),
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
 				},
 				"write_units_per_second": {
-					Type:         schema.TypeInt,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.IntAtLeast(4000),
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
 				},
 			},
 		},

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -625,14 +625,16 @@ func warmThroughputSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"read_units_per_second": {
-					Type:     schema.TypeInt,
-					Optional: true,
-					Computed: true,
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntAtLeast(1),
 				},
 				"write_units_per_second": {
-					Type:     schema.TypeInt,
-					Optional: true,
-					Computed: true,
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntAtLeast(1),
 				},
 			},
 		},

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -473,8 +473,8 @@ The following arguments are optional:
 
 ~> **Note:** Explicitly configuring both `read_units_per_second` and `write_units_per_second` to the default/minimum values will cause Terraform to report differences.
 
-* `read_units_per_second` - (Optional) Number of read operations a table or index can instantaneously support. For the base table, this value cannot be decreased. For a global secondary index, this value can be increased or decreased. Minimum value of `12000` (default).
-* `write_units_per_second` - (Optional) Number of write operations a table or index can instantaneously support. For the base table, this value cannot be decreased. For a global secondary index, this value can be increased or decreased. Minimum value of `4000` (default).
+* `read_units_per_second` - (Optional) Number of read operations a table or index can instantaneously support. For the base table, this value cannot be decreased. For a global secondary index, this value can be increased or decreased. Minimum value of `1`.
+* `write_units_per_second` - (Optional) Number of write operations a table or index can instantaneously support. For the base table, this value cannot be decreased. For a global secondary index, this value can be increased or decreased. Minimum value of `1`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

The `warm_throughput.read_units_per_second` and `warm_throughput.write_units_per_second`
arguments are validated with static minimums of `12000` and `4000` respectively. These
minimums are incorrect: DynamoDB accepts lower values when the table is in PROVISIONED
billing mode, where the actual minimum depends on the configured `read_capacity` and
`write_capacity`.

This change removes the static validation so that valid configurations are no longer
rejected at plan time. DynamoDB still rejects values it does not accept, so invalid
configurations continue to fail during apply with a descriptive API error.

### Relations

Closes #49894

### References

- https://github.com/hashicorp/terraform-provider-aws/issues/49894

### Output from Acceptance Testing

This change removes schema validation and does not add or modify acceptance tests.

```console
% make test PKG=dynamodb

...
```
