### PR TITLE
r/aws_s3_bucket_lifecycle_configuration: preserve transition_default_minimum_object_size when backend omits it

### DIFF
--- a/.changelog/49902.txt
+++ b/.changelog/49902.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Prevent "inconsistent result after apply" errors and non-terminating stabilization with S3-compatible backends (e.g. Ceph RADOS Gateway) that omit the `x-amz-transition-default-minimum-object-size` field
+```

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -433,7 +433,7 @@ func (r *bucketLifecycleConfigurationResource) Create(ctx context.Context, reque
 		return
 	}
 
-	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	flattenBucketLifecycleConfigurationResource(ctx, output, &data, &response.Diagnostics)
 
 	data.ID = types.StringValue(createResourceID(bucket, expectedBucketOwner))
 	data.ExpectedBucketOwner = types.StringValue(expectedBucketOwner)
@@ -546,7 +546,7 @@ func (r *bucketLifecycleConfigurationResource) Update(ctx context.Context, reque
 		return
 	}
 
-	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &new)...)
+	flattenBucketLifecycleConfigurationResource(ctx, output, &new, &response.Diagnostics)
 
 	new.ID = types.StringValue(createResourceID(bucket, expectedBucketOwner))
 	new.ExpectedBucketOwner = types.StringValue(expectedBucketOwner)
@@ -614,7 +614,23 @@ func (r *bucketLifecycleConfigurationResource) ImportState(ctx context.Context, 
 }
 
 func flattenBucketLifecycleConfigurationResource(ctx context.Context, bucket *s3.GetBucketLifecycleConfigurationOutput, data *bucketLifecycleConfigurationResourceModel, diags *diag.Diagnostics) {
+	// Preserve the planned/prior transition_default_minimum_object_size when the
+	// backend omits it. AWS S3 always returns the
+	// x-amz-transition-default-minimum-object-size field, but it is optional and
+	// some S3-compatible backends (e.g. Ceph RADOS Gateway) omit it. Overwriting
+	// the incoming value with an empty string would trip Terraform's
+	// "inconsistent result after apply" check or produce a perpetual diff.
+	// data holds the planned value in Create/Update and the prior state value in
+	// Read; capture it before flattening so it can be restored if the backend
+	// returns nothing. On AWS the flattened value is never empty, so this is a
+	// no-op there.
+	transitionMinSize := data.TransitionDefaultMinimumObjectSize
+
 	diags.Append(fwflex.Flatten(ctx, bucket, data)...)
+
+	if data.TransitionDefaultMinimumObjectSize.ValueString() == "" {
+		data.TransitionDefaultMinimumObjectSize = transitionMinSize
+	}
 }
 
 func (r *bucketLifecycleConfigurationResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
@@ -655,8 +671,16 @@ func findBucketLifecycleConfiguration(ctx context.Context, conn *s3.Client, buck
 	return output, nil
 }
 
+// lifecycleConfigEqual reports whether two lifecycle configurations match.
+//
+// transitionMinSize1 is expected to be the observed (backend GET) value, which
+// may be empty on S3-compatible backends that don't implement the
+// x-amz-transition-default-minimum-object-size field (e.g. Ceph RADOS Gateway).
+// When it is empty we don't hold the requested transitionMinSize2 against it,
+// otherwise the convergence wait in waitLifecycleConfigEquals would never reach
+// its target on those backends. Callers must pass the observed value first.
 func lifecycleConfigEqual(transitionMinSize1 awstypes.TransitionDefaultMinimumObjectSize, rules1 []awstypes.LifecycleRule, transitionMinSize2 awstypes.TransitionDefaultMinimumObjectSize, rules2 []awstypes.LifecycleRule) bool {
-	if transitionMinSize1 != transitionMinSize2 {
+	if transitionMinSize1 != "" && transitionMinSize1 != transitionMinSize2 {
 		return false
 	}
 

--- a/internal/service/s3/bucket_lifecycle_configuration_unit_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_unit_test.go
@@ -1,0 +1,121 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package s3_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+)
+
+// TestLifecycleConfigEqual exercises the transition_default_minimum_object_size
+// comparison, which must tolerate an empty *observed* value so that S3-compatible
+// backends that omit the x-amz-transition-default-minimum-object-size field (e.g.
+// Ceph RADOS Gateway) can still reach convergence in waitLifecycleConfigEquals.
+//
+// The first argument is the observed (backend GET) value; the second is the
+// requested value. The empty-tolerance is asymmetric by design: an empty
+// observed value matches any requested value, but a non-empty observed value
+// must match exactly. Callers must pass the observed value first.
+func TestLifecycleConfigEqual(t *testing.T) {
+	t.Parallel()
+
+	rules := []awstypes.LifecycleRule{
+		{
+			ID:     aws.String("rule-1"),
+			Status: awstypes.ExpirationStatusEnabled,
+			Filter: &awstypes.LifecycleRuleFilter{Prefix: aws.String("/")},
+			NoncurrentVersionExpiration: &awstypes.NoncurrentVersionExpiration{
+				NoncurrentDays: aws.Int32(1),
+			},
+		},
+	}
+	differentRules := []awstypes.LifecycleRule{
+		{
+			ID:     aws.String("rule-1"),
+			Status: awstypes.ExpirationStatusEnabled,
+			Filter: &awstypes.LifecycleRuleFilter{Prefix: aws.String("/")},
+			NoncurrentVersionExpiration: &awstypes.NoncurrentVersionExpiration{
+				NoncurrentDays: aws.Int32(5),
+			},
+		},
+	}
+
+	const (
+		size128k awstypes.TransitionDefaultMinimumObjectSize = awstypes.TransitionDefaultMinimumObjectSizeAllStorageClasses128k
+		sizeVary awstypes.TransitionDefaultMinimumObjectSize = awstypes.TransitionDefaultMinimumObjectSizeVariesByStorageClass
+		empty    awstypes.TransitionDefaultMinimumObjectSize = ""
+	)
+
+	testCases := map[string]struct {
+		observedSize awstypes.TransitionDefaultMinimumObjectSize
+		observedRule []awstypes.LifecycleRule
+		requestSize  awstypes.TransitionDefaultMinimumObjectSize
+		requestRule  []awstypes.LifecycleRule
+		want         bool
+	}{
+		// The Ceph case: the backend omits the field, so the observed value is
+		// empty. It must be treated as equal to any requested value, otherwise the
+		// convergence wait loops forever. This is the whole point of the guard.
+		"observed empty, requested non-empty, rules equal": {
+			observedSize: empty,
+			observedRule: rules,
+			requestSize:  size128k,
+			requestRule:  rules,
+			want:         true,
+		},
+		"observed empty, requested empty, rules equal": {
+			observedSize: empty,
+			observedRule: rules,
+			requestSize:  empty,
+			requestRule:  rules,
+			want:         true,
+		},
+		// The AWS regression guard: a non-empty observed value that differs from
+		// the requested value must NOT be treated as equal, so genuine mismatches
+		// on real AWS are still detected.
+		"observed non-empty differs from requested": {
+			observedSize: size128k,
+			observedRule: rules,
+			requestSize:  sizeVary,
+			requestRule:  rules,
+			want:         false,
+		},
+		"observed non-empty equals requested": {
+			observedSize: size128k,
+			observedRule: rules,
+			requestSize:  size128k,
+			requestRule:  rules,
+			want:         true,
+		},
+		// Rule differences are still detected regardless of the size handling.
+		"observed empty, rules differ": {
+			observedSize: empty,
+			observedRule: rules,
+			requestSize:  size128k,
+			requestRule:  differentRules,
+			want:         false,
+		},
+		"sizes equal, rules differ": {
+			observedSize: size128k,
+			observedRule: rules,
+			requestSize:  size128k,
+			requestRule:  differentRules,
+			want:         false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tfs3.LifecycleConfigEqual(tc.observedSize, tc.observedRule, tc.requestSize, tc.requestRule)
+			if got != tc.want {
+				t.Errorf("LifecycleConfigEqual(%q, _, %q, _) = %t, want %t", tc.observedSize, tc.requestSize, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No. This change does not alter any access controls, encryption, or logging behavior.

### Description

`aws_s3_bucket_lifecycle_configuration` never stabilized on S3-compatible
backends (e.g. Ceph RADOS Gateway), timing out during create/update.

The resource waits for the applied configuration to be readable back before
returning. That comparison includes `transition_default_minimum_object_size`,
which the provider defaults to `128k` for general purpose buckets. AWS S3
always returns the corresponding `x-amz-transition-default-minimum-object-size`
field on `GetBucketLifecycleConfiguration`, but the field is optional and
S3-compatible backends omit it. The observed value therefore came back empty
and never matched the requested `128k`, so the stabilization wait
(`waitLifecycleConfigEquals`) could never reach its target and timed out.
The empty value flattened into state also produced "inconsistent result after
apply" errors and perpetual diffs.

This change:

- Tolerates an empty *observed* value in `lifecycleConfigEqual`, so the
  stabilization wait converges when the backend omits the field. The check is
  asymmetric by design — an empty observed value matches any requested value,
  but a non-empty observed value must still match exactly.
- Preserves the planned (Create/Update) or prior (Read) value for
  `transition_default_minimum_object_size` when the flattened value is empty,
  avoiding the inconsistent-result error and perpetual diff.

On real AWS S3 both behaviors are strict no-ops, because AWS always populates
the field: the observed value is never empty, so the equality guard reduces to
the original comparison and the value is never preserved from an empty result.

Note: the ~3 minute timeout reported in the issue is the create/update
stabilization timeout. With this fix the configuration converges as soon as the
backend reports matching rules, so the operation completes within the default
window rather than timing out.

### Relations

Closes #25939

### References

- S3 `GetBucketLifecycleConfiguration` `x-amz-transition-default-minimum-object-size` is an optional response field: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html

### Output from Acceptance Testing

Unit coverage for the equality guard, which encodes the asymmetric
empty-tolerance behavior:

```console
% go test ./internal/service/s3/ -run '^TestLifecycleConfigEqual$' -v
=== RUN   TestLifecycleConfigEqual
=== RUN   TestLifecycleConfigEqual/observed_empty,_requested_non-empty,_rules_equal
=== RUN   TestLifecycleConfigEqual/observed_empty,_requested_empty,_rules_equal
=== RUN   TestLifecycleConfigEqual/observed_non-empty_differs_from_requested
=== RUN   TestLifecycleConfigEqual/observed_non-empty_equals_requested
=== RUN   TestLifecycleConfigEqual/observed_empty,_rules_differ
=== RUN   TestLifecycleConfigEqual/sizes_equal,_rules_differ
--- PASS: TestLifecycleConfigEqual (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3
```

<!--
Acceptance tests (make testacc) run against real AWS, where this change is a
no-op. The reproduction requires an S3-compatible backend (Ceph RADOS Gateway)
that omits the x-amz-transition-default-minimum-object-size field. Manually
verified create and update against Ceph RGW: both converge within the default
timeout and produce no perpetual diff.
-->
