### PR TITLE
r/aws_codebuild_fleet: Allow base_capacity of 0 🤖🤖🤖

### DIFF
--- a/.changelog/49912.txt
+++ b/.changelog/49912.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codebuild_fleet: Allow `base_capacity` of `0`
+```

--- a/internal/service/codebuild/fleet.go
+++ b/internal/service/codebuild/fleet.go
@@ -48,7 +48,7 @@ func resourceFleet() *schema.Resource {
 				"base_capacity": {
 					Type:         schema.TypeInt,
 					Required:     true,
-					ValidateFunc: validation.IntAtLeast(1),
+					ValidateFunc: validation.IntAtLeast(0),
 				},
 				"compute_configuration": {
 					Type:     schema.TypeList,

--- a/internal/service/codebuild/fleet_test.go
+++ b/internal/service/codebuild/fleet_test.go
@@ -133,17 +133,17 @@ func TestAccCodeBuildFleet_baseCapacity(t *testing.T) {
 		CheckDestroy:             testAccCheckFleetDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
+				Config: testAccFleetConfig_baseCapacity(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "base_capacity", "0"),
+				),
+			},
+			{
 				Config: testAccFleetConfig_baseCapacity(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFleetExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "base_capacity", "1"),
-				),
-			},
-			{
-				Config: testAccFleetConfig_baseCapacity(rName, 2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFleetExists(ctx, t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "base_capacity", "2"),
 				),
 			},
 		},

--- a/website/docs/r/codebuild_fleet.html.markdown
+++ b/website/docs/r/codebuild_fleet.html.markdown
@@ -45,7 +45,7 @@ resource "aws_codebuild_fleet" "example" {
 The following arguments are required:
 
 * `name` - (Required) Fleet name.
-* `base_capacity` - (Required) Number of machines allocated to the ﬂeet.
+* `base_capacity` - (Required) Number of machines allocated to the fleet. Minimum value of `0`.
 * `compute_type` - (Required) Compute resources the compute fleet uses. See [compute types](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html#environment.types) for more information and valid values.
 * `environment_type` - (Required) Environment type of the compute fleet. See [environment types](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html#environment.types) for more information and valid values.
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.

### Description

`aws_codebuild_fleet` rejected `base_capacity = 0` in schema validation (`validation.IntAtLeast(1)`) even though AWS CloudFormation documents `BaseCapacity` with a minimum of `0`. That blocked Terraform-managing a reserved fleet with no warm hosts.

This PR changes the validator to `IntAtLeast(0)`, documents the minimum, and extends `TestAccCodeBuildFleet_baseCapacity` to create with `0` then update to `1`.

**AI usage:** An LLM agent drafted the issue, schema/test/docs change, and this PR. I reviewed the diff and own the submission.

### Relations

Closes #49911

### References

* [AWS::CodeBuild::Fleet `BaseCapacity`](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-codebuild-fleet.html) — Minimum: `0`
* Registry docs previously omitted the floor

### Output from Acceptance Testing

Acceptance tests were not run locally (no Go toolchain on this machine; also creates a real CodeBuild reserved fleet). Please run:

```console
% make testacc TESTS=TestAccCodeBuildFleet_baseCapacity PKG=codebuild
```