### PR TITLE
List: network_acl_rule

### DIFF
--- a/.changelog/49916.txt
+++ b/.changelog/49916.txt
@@ -1,0 +1,3 @@
+```release-note:new-list-resource
+aws_network_acl_rule
+```

--- a/internal/acctest/statecheck/identity.go
+++ b/internal/acctest/statecheck/identity.go
@@ -77,6 +77,8 @@ func (v *identity) Checks() func() map[string]knownvalue.Check {
 					} else {
 						checks[k] = knownvalue.StringExact(v.String())
 					}
+				case bool:
+					checks[k] = knownvalue.Bool(v)
 				default:
 					checks[k] = knownvalue.StringExact(fmt.Sprintf("%v", val))
 				}

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -2224,6 +2224,18 @@ func (p *servicePackage) SDKListResources(ctx context.Context) iter.Seq[*inttype
 			Identity: inttypes.RegionalSingleParameterIdentity(inttypes.StringIdentityAttribute(names.AttrID, true)),
 		},
 		{
+			Factory:  newNetworkACLRuleResourceAsListResource,
+			TypeName: "aws_network_acl_rule",
+			Name:     "Network ACL Rule",
+			Region:   inttypes.ResourceRegionDefault(),
+			Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
+				inttypes.StringIdentityAttribute("network_acl_id", true),
+				inttypes.BoolIdentityAttribute("egress", true),
+				inttypes.IntIdentityAttribute("rule_number", true),
+				inttypes.StringIdentityAttribute(names.AttrProtocol, true),
+			}),
+		},
+		{
 			Factory:  newNetworkInterfaceResourceAsListResource,
 			TypeName: "aws_network_interface",
 			Name:     "Network Interface",

--- a/internal/service/ec2/testdata/NetworkACLRule/list_basic/main.tf
+++ b/internal/service/ec2/testdata/NetworkACLRule/list_basic/main.tf
@@ -1,0 +1,43 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_network_acl_rule" "test" {
+  count = var.resource_count
+
+  network_acl_id = aws_network_acl.test.id
+  rule_number    = 1233 + count.index
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 22
+  to_port        = 22
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = var.rName
+  }
+}
+
+resource "aws_network_acl" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = var.rName
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/ec2/testdata/NetworkACLRule/list_basic/main.tf
+++ b/internal/service/ec2/testdata/NetworkACLRule/list_basic/main.tf
@@ -5,9 +5,9 @@ resource "aws_network_acl_rule" "test" {
   count = var.resource_count
 
   network_acl_id = aws_network_acl.test.id
-  rule_number    = 1233 + count.index
+  rule_number    = 200 + count.index
   egress         = false
-  protocol       = "tcp"
+  protocol       = "6"
   rule_action    = "allow"
   cidr_block     = "0.0.0.0/0"
   from_port      = 22

--- a/internal/service/ec2/testdata/NetworkACLRule/list_basic/query.tfquery.hcl
+++ b/internal/service/ec2/testdata/NetworkACLRule/list_basic/query.tfquery.hcl
@@ -1,0 +1,6 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_network_acl_rule" "test" {
+  provider = aws
+}

--- a/internal/service/ec2/testdata/NetworkACLRule/list_include_resource/main.tf
+++ b/internal/service/ec2/testdata/NetworkACLRule/list_include_resource/main.tf
@@ -1,0 +1,43 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_network_acl_rule" "test" {
+  count = var.resource_count
+
+  network_acl_id = aws_network_acl.test.id
+  rule_number    = 200 + count.index
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 22
+  to_port        = 22
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = var.rName
+  }
+}
+
+resource "aws_network_acl" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = var.rName
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}

--- a/internal/service/ec2/testdata/NetworkACLRule/list_include_resource/main.tf
+++ b/internal/service/ec2/testdata/NetworkACLRule/list_include_resource/main.tf
@@ -7,7 +7,7 @@ resource "aws_network_acl_rule" "test" {
   network_acl_id = aws_network_acl.test.id
   rule_number    = 200 + count.index
   egress         = false
-  protocol       = "tcp"
+  protocol       = "6"
   rule_action    = "allow"
   cidr_block     = "0.0.0.0/0"
   from_port      = 22

--- a/internal/service/ec2/testdata/NetworkACLRule/list_include_resource/query.tfquery.hcl
+++ b/internal/service/ec2/testdata/NetworkACLRule/list_include_resource/query.tfquery.hcl
@@ -1,0 +1,8 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_network_acl_rule" "test" {
+  provider = aws
+
+  include_resource = true
+}

--- a/internal/service/ec2/testdata/NetworkACLRule/list_region_override/main.tf
+++ b/internal/service/ec2/testdata/NetworkACLRule/list_region_override/main.tf
@@ -8,7 +8,7 @@ resource "aws_network_acl_rule" "test" {
   network_acl_id = aws_network_acl.test.id
   rule_number    = 200 + count.index
   egress         = false
-  protocol       = "tcp"
+  protocol       = "6"
   rule_action    = "allow"
   cidr_block     = "0.0.0.0/0"
   from_port      = 22

--- a/internal/service/ec2/testdata/NetworkACLRule/list_region_override/main.tf
+++ b/internal/service/ec2/testdata/NetworkACLRule/list_region_override/main.tf
@@ -1,0 +1,54 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_network_acl_rule" "test" {
+  count  = var.resource_count
+  region = var.region
+
+  network_acl_id = aws_network_acl.test.id
+  rule_number    = 200 + count.index
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 22
+  to_port        = 22
+}
+
+resource "aws_vpc" "test" {
+  region = var.region
+
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = var.rName
+  }
+}
+
+resource "aws_network_acl" "test" {
+  region = var.region
+
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = var.rName
+  }
+}
+
+variable "rName" {
+  description = "Name for resource"
+  type        = string
+  nullable    = false
+}
+
+variable "resource_count" {
+  description = "Number of resources to create"
+  type        = number
+  nullable    = false
+}
+
+variable "region" {
+  description = "Region to deploy resource in"
+  type        = string
+  nullable    = false
+}

--- a/internal/service/ec2/testdata/NetworkACLRule/list_region_override/query.tfquery.hcl
+++ b/internal/service/ec2/testdata/NetworkACLRule/list_region_override/query.tfquery.hcl
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+list "aws_network_acl_rule" "test" {
+  provider = aws
+
+  config {
+    region = var.region
+  }
+}

--- a/internal/service/ec2/vpc_network_acl_rule.go
+++ b/internal/service/ec2/vpc_network_acl_rule.go
@@ -249,7 +249,7 @@ func resourceNetworkACLRuleFlatten(d *schema.ResourceData, naclEntry *awstypes.N
 		protocolNumber, err := networkACLProtocolNumber(v)
 
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "reading EC2 Network ACL Rule: %s", err)
+			return sdkdiag.AppendErrorf(diags, "reading EC2 Network ACL Rule (%s): %s", d.Id(), err)
 		}
 
 		d.Set(names.AttrProtocol, strconv.Itoa(protocolNumber))

--- a/internal/service/ec2/vpc_network_acl_rule.go
+++ b/internal/service/ec2/vpc_network_acl_rule.go
@@ -223,6 +223,12 @@ func resourceNetworkACLRuleRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "reading EC2 Network ACL Rule (%s): %s", d.Id(), err)
 	}
 
+	return resourceNetworkACLRuleFlatten(d, naclEntry)
+}
+
+func resourceNetworkACLRuleFlatten(d *schema.ResourceData, naclEntry *awstypes.NetworkAclEntry) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	d.Set(names.AttrCIDRBlock, naclEntry.CidrBlock)
 	d.Set("egress", naclEntry.Egress)
 	d.Set("ipv6_cidr_block", naclEntry.Ipv6CidrBlock)
@@ -243,7 +249,7 @@ func resourceNetworkACLRuleRead(ctx context.Context, d *schema.ResourceData, met
 		protocolNumber, err := networkACLProtocolNumber(v)
 
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "reading EC2 Network ACL Rule (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading EC2 Network ACL Rule: %s", err)
 		}
 
 		d.Set(names.AttrProtocol, strconv.Itoa(protocolNumber))

--- a/internal/service/ec2/vpc_network_acl_rule_list.go
+++ b/internal/service/ec2/vpc_network_acl_rule_list.go
@@ -51,9 +51,11 @@ func (l *networkACLRuleListResource) List(ctx context.Context, request list.List
 			naclID := aws.ToString(nacl.NetworkAclId)
 
 			for _, entry := range nacl.Entries {
-				egress := aws.ToBool(entry.Egress)
 				ruleNumber := int(aws.ToInt32(entry.RuleNumber))
-
+				if ruleNumber == defaultACLRuleNumberIPv4 || ruleNumber == defaultACLRuleNumberIPv6 {
+					continue
+				}
+				egress := aws.ToBool(entry.Egress)
 				ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("network_acl_id"), naclID)
 				ctx = tflog.SetField(ctx, logging.ResourceAttributeKey("rule_number"), ruleNumber)
 				ctx = tflog.SetField(ctx, logging.ResourceAttributeKey("egress"), egress)

--- a/internal/service/ec2/vpc_network_acl_rule_list.go
+++ b/internal/service/ec2/vpc_network_acl_rule_list.go
@@ -1,0 +1,104 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/logging"
+	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKListResource("aws_network_acl_rule")
+func newNetworkACLRuleResourceAsListResource() inttypes.ListResourceForSDK {
+	l := networkACLRuleListResource{}
+	l.SetResourceSchema(resourceNetworkACLRule())
+
+	return &l
+}
+
+var _ list.ListResource = &networkACLRuleListResource{}
+
+type networkACLRuleListResource struct {
+	framework.ListResourceWithSDKv2Resource
+}
+
+func (l *networkACLRuleListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	conn := l.Meta().EC2Client(ctx)
+
+	tflog.Info(ctx, "Listing resources")
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		nacls, err := findNetworkACLs(ctx, conn, &ec2.DescribeNetworkAclsInput{})
+		if err != nil {
+			result := fwdiag.NewListResultErrorDiagnostic(fmt.Errorf("listing EC2 Network ACL Rules: %w", err))
+			yield(result)
+			return
+		}
+
+		for _, nacl := range nacls {
+			naclID := aws.ToString(nacl.NetworkAclId)
+
+			for _, entry := range nacl.Entries {
+				egress := aws.ToBool(entry.Egress)
+				ruleNumber := int(aws.ToInt32(entry.RuleNumber))
+
+				ctx := tflog.SetField(ctx, logging.ResourceAttributeKey("network_acl_id"), naclID)
+				ctx = tflog.SetField(ctx, logging.ResourceAttributeKey("rule_number"), ruleNumber)
+				ctx = tflog.SetField(ctx, logging.ResourceAttributeKey("egress"), egress)
+
+				protocolNumber, err := networkACLProtocolNumber(aws.ToString(entry.Protocol))
+				if err != nil {
+					tflog.Error(ctx, "Reading EC2 Network ACL Rule", map[string]any{
+						"error": err.Error(),
+					})
+					continue
+				}
+				protocol := strconv.Itoa(protocolNumber)
+
+				result := request.NewListResult(ctx)
+
+				rd := l.ResourceData()
+				rd.Set("network_acl_id", naclID)
+				rd.Set("egress", egress)
+				rd.Set("rule_number", ruleNumber)
+				rd.Set(names.AttrProtocol, protocol)
+
+				id := networkACLRuleCreateResourceID(naclID, ruleNumber, egress, protocol)
+				rd.SetId(id)
+
+				if request.IncludeResource {
+					if diags := resourceNetworkACLRuleFlatten(rd, &entry); diags.HasError() {
+						tflog.Error(ctx, "Reading EC2 Network ACL Rule", map[string]any{
+							"diags": sdkdiag.DiagnosticsString(diags),
+						})
+						continue
+					}
+				}
+
+				result.DisplayName = id
+
+				l.SetResult(ctx, l.Meta(), request.IncludeResource, rd, &result)
+				if result.Diagnostics.HasError() {
+					yield(result)
+					return
+				}
+
+				if !yield(result) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/service/ec2/vpc_network_acl_rule_list_test.go
+++ b/internal/service/ec2/vpc_network_acl_rule_list_test.go
@@ -1,0 +1,230 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfquerycheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/querycheck"
+	tfqueryfilter "github.com/hashicorp/terraform-provider-aws/internal/acctest/queryfilter"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccVPCNetworkACLRule_List_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_network_acl_rule.test[0]"
+	resourceName2 := "aws_network_acl_rule.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	id1 := tfstatecheck.StateValue()
+	id2 := tfstatecheck.StateValue()
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		CheckDestroy:             testAccCheckNetworkACLRuleDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/NetworkACLRule/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					id1.GetStateValue(resourceName1, tfjsonpath.New(names.AttrID)),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("network_acl_id")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("egress")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("rule_number")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New(names.AttrProtocol)),
+
+					identity2.GetIdentity(resourceName2),
+					id2.GetStateValue(resourceName2, tfjsonpath.New(names.AttrID)),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New("network_acl_id")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New("egress")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New("rule_number")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New(names.AttrProtocol)),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/NetworkACLRule/list_basic/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_network_acl_rule.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_network_acl_rule.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), id1.ValueCheck()),
+					tfquerycheck.ExpectNoResourceObject("aws_network_acl_rule.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks())),
+
+					tfquerycheck.ExpectIdentityFunc("aws_network_acl_rule.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_network_acl_rule.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), id2.ValueCheck()),
+					tfquerycheck.ExpectNoResourceObject("aws_network_acl_rule.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks())),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPCNetworkACLRule_List_includeResource(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_network_acl_rule.test[0]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	id1 := tfstatecheck.StateValue()
+	naclID := tfstatecheck.StateValue()
+	identity1 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		CheckDestroy:             testAccCheckNetworkACLRuleDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/NetworkACLRule/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					id1.GetStateValue(resourceName1, tfjsonpath.New(names.AttrID)),
+					naclID.GetStateValue("aws_network_acl.test", tfjsonpath.New(names.AttrID)),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("network_acl_id")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("egress")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("rule_number")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New(names.AttrProtocol)),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/NetworkACLRule/list_include_resource/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(1),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					// IncludeResource is true, so all resource attributes should be populated.
+					tfquerycheck.ExpectIdentityFunc("aws_network_acl_rule.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_network_acl_rule.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), id1.ValueCheck()),
+					querycheck.ExpectResourceKnownValues("aws_network_acl_rule.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), []querycheck.KnownValueCheck{
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrID), id1.ValueCheck()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("network_acl_id"), naclID.ValueCheck()),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("egress"), knownvalue.Bool(false)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("rule_number"), knownvalue.Int64Exact(200)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrProtocol), knownvalue.StringExact("6")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("rule_action"), knownvalue.StringExact("allow")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New(names.AttrCIDRBlock), knownvalue.StringExact("0.0.0.0/0")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("ipv6_cidr_block"), knownvalue.StringExact("")),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("from_port"), knownvalue.Int64Exact(22)),
+						tfquerycheck.KnownValueCheck(tfjsonpath.New("to_port"), knownvalue.Int64Exact(22)),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPCNetworkACLRule_List_regionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName1 := "aws_network_acl_rule.test[0]"
+	resourceName2 := "aws_network_acl_rule.test[1]"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	id1 := tfstatecheck.StateValue()
+	id2 := tfstatecheck.StateValue()
+
+	identity1 := tfstatecheck.Identity()
+	identity2 := tfstatecheck.Identity()
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		CheckDestroy:             testAccCheckNetworkACLRuleDestroy(ctx, t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Setup
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/NetworkACLRule/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					identity1.GetIdentity(resourceName1),
+					id1.GetStateValue(resourceName1, tfjsonpath.New(names.AttrID)),
+					statecheck.ExpectKnownValue(resourceName1, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("network_acl_id")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("egress")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New("rule_number")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName1, tfjsonpath.New(names.AttrProtocol)),
+
+					identity2.GetIdentity(resourceName2),
+					id2.GetStateValue(resourceName2, tfjsonpath.New(names.AttrID)),
+					statecheck.ExpectKnownValue(resourceName2, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New("network_acl_id")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New("egress")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New("rule_number")),
+					statecheck.ExpectIdentityValueMatchesState(resourceName2, tfjsonpath.New(names.AttrProtocol)),
+				},
+			},
+
+			// Step 2: Query
+			{
+				Query:           true,
+				ConfigDirectory: config.StaticDirectory("testdata/NetworkACLRule/list_region_override/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:  config.StringVariable(rName),
+					"resource_count": config.IntegerVariable(2),
+					"region":         config.StringVariable(acctest.AlternateRegion()),
+				},
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					tfquerycheck.ExpectIdentityFunc("aws_network_acl_rule.test", identity1.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_network_acl_rule.test", tfqueryfilter.ByResourceIdentityFunc(identity1.Checks()), id1.ValueCheck()),
+
+					tfquerycheck.ExpectIdentityFunc("aws_network_acl_rule.test", identity2.Checks()),
+					querycheck.ExpectResourceDisplayName("aws_network_acl_rule.test", tfqueryfilter.ByResourceIdentityFunc(identity2.Checks()), id2.ValueCheck()),
+				},
+			},
+		},
+	})
+}

--- a/website/docs/list-resources/network_acl_rule.html.markdown
+++ b/website/docs/list-resources/network_acl_rule.html.markdown
@@ -8,12 +8,12 @@ description: |-
 
 # List Resource: aws_ec2_network_acl_rule
 
-Lists EC2 (Elastic Compute Cloud) Network ACL Rule resources.
+Lists EC2 Network ACL Rule resources.
 
 ## Example Usage
 
 ```terraform
-list "aws_ec2_network_acl_rule" "example" {
+list "aws_network_acl_rule" "example" {
   provider = aws
 }
 ```

--- a/website/docs/list-resources/network_acl_rule.html.markdown
+++ b/website/docs/list-resources/network_acl_rule.html.markdown
@@ -1,0 +1,25 @@
+---
+subcategory: "EC2 (Elastic Compute Cloud)"
+layout: "aws"
+page_title: "AWS: aws_ec2_network_acl_rule"
+description: |-
+  Lists EC2 (Elastic Compute Cloud) Network ACL Rule resources.
+---
+
+# List Resource: aws_ec2_network_acl_rule
+
+Lists EC2 (Elastic Compute Cloud) Network ACL Rule resources.
+
+## Example Usage
+
+```terraform
+list "aws_ec2_network_acl_rule" "example" {
+  provider = aws
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `region` - (Optional) Region to query. Defaults to provider region.

--- a/website/docs/list-resources/network_acl_rule.html.markdown
+++ b/website/docs/list-resources/network_acl_rule.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "EC2 (Elastic Compute Cloud)"
 layout: "aws"
-page_title: "AWS: aws_ec2_network_acl_rule"
+page_title: "AWS: aws_network_acl_rule"
 description: |-
   Lists EC2 (Elastic Compute Cloud) Network ACL Rule resources.
 ---
 
-# List Resource: aws_ec2_network_acl_rule
+# List Resource: aws_network_acl_rule
 
 Lists EC2 Network ACL Rule resources.
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds bool case to Identity Checks().
Adds List support for `network_acl_rule`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #48579

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccVPCNetworkACLRule_ K=ec2     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 list-network-acl-rule 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkACLRule_'  -timeout 360m -vet=off -buildvcs=false
2026/09/09 21:40:17 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/09 21:40:17 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCNetworkACLRule_Identity_basic
=== PAUSE TestAccVPCNetworkACLRule_Identity_basic
=== RUN   TestAccVPCNetworkACLRule_Identity_regionOverride
=== PAUSE TestAccVPCNetworkACLRule_Identity_regionOverride
=== RUN   TestAccVPCNetworkACLRule_Identity_ExistingResource_basic
=== PAUSE TestAccVPCNetworkACLRule_Identity_ExistingResource_basic
=== RUN   TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange
=== RUN   TestAccVPCNetworkACLRule_List_basic
=== PAUSE TestAccVPCNetworkACLRule_List_basic
=== RUN   TestAccVPCNetworkACLRule_List_includeResource
=== PAUSE TestAccVPCNetworkACLRule_List_includeResource
=== RUN   TestAccVPCNetworkACLRule_List_regionOverride
=== PAUSE TestAccVPCNetworkACLRule_List_regionOverride
=== RUN   TestAccVPCNetworkACLRule_basic
=== PAUSE TestAccVPCNetworkACLRule_basic
=== RUN   TestAccVPCNetworkACLRule_disappears
=== PAUSE TestAccVPCNetworkACLRule_disappears
=== RUN   TestAccVPCNetworkACLRule_Disappears_networkACL
=== PAUSE TestAccVPCNetworkACLRule_Disappears_networkACL
=== RUN   TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber
=== PAUSE TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber
=== RUN   TestAccVPCNetworkACLRule_ipv6
=== PAUSE TestAccVPCNetworkACLRule_ipv6
=== RUN   TestAccVPCNetworkACLRule_ipv6ICMP
=== PAUSE TestAccVPCNetworkACLRule_ipv6ICMP
=== RUN   TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate
=== PAUSE TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate
=== RUN   TestAccVPCNetworkACLRule_allProtocol
=== PAUSE TestAccVPCNetworkACLRule_allProtocol
=== RUN   TestAccVPCNetworkACLRule_tcpProtocol
=== PAUSE TestAccVPCNetworkACLRule_tcpProtocol
=== RUN   TestAccVPCNetworkACLRule_duplicate
=== PAUSE TestAccVPCNetworkACLRule_duplicate
=== CONT  TestAccVPCNetworkACLRule_Identity_basic
=== CONT  TestAccVPCNetworkACLRule_List_includeResource
=== CONT  TestAccVPCNetworkACLRule_Disappears_networkACL
=== CONT  TestAccVPCNetworkACLRule_Identity_regionOverride
=== CONT  TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate
=== CONT  TestAccVPCNetworkACLRule_basic
=== CONT  TestAccVPCNetworkACLRule_duplicate
=== CONT  TestAccVPCNetworkACLRule_allProtocol
=== CONT  TestAccVPCNetworkACLRule_tcpProtocol
=== CONT  TestAccVPCNetworkACLRule_ipv6ICMP
=== CONT  TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccVPCNetworkACLRule_List_basic
=== CONT  TestAccVPCNetworkACLRule_Identity_ExistingResource_basic
=== CONT  TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber
=== CONT  TestAccVPCNetworkACLRule_disappears
=== CONT  TestAccVPCNetworkACLRule_List_regionOverride
=== CONT  TestAccVPCNetworkACLRule_ipv6
--- PASS: TestAccVPCNetworkACLRule_duplicate (26.85s)
=== NAME  TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange
    vpc_network_acl_rule_identity_gen_test.go:291: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_network_acl_rule.test - Identity found in state, and was not expected.
=== NAME  TestAccVPCNetworkACLRule_Identity_ExistingResource_basic
    vpc_network_acl_rule_identity_gen_test.go:228: Step 1/2 error: Post-apply refresh state check(s) failed:
        aws_network_acl_rule.test - Identity found in state, and was not expected.
--- PASS: TestAccVPCNetworkACLRule_ipv6ICMP (42.95s)
--- PASS: TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber (44.84s)
--- PASS: TestAccVPCNetworkACLRule_ipv6 (44.86s)
--- PASS: TestAccVPCNetworkACLRule_disappears (45.18s)
--- PASS: TestAccVPCNetworkACLRule_List_includeResource (45.19s)
--- FAIL: TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange (46.99s)
--- FAIL: TestAccVPCNetworkACLRule_Identity_ExistingResource_basic (47.40s)
--- PASS: TestAccVPCNetworkACLRule_Disappears_networkACL (47.42s)
--- PASS: TestAccVPCNetworkACLRule_List_basic (47.79s)
--- PASS: TestAccVPCNetworkACLRule_List_regionOverride (48.09s)
--- PASS: TestAccVPCNetworkACLRule_allProtocol (56.47s)
--- PASS: TestAccVPCNetworkACLRule_tcpProtocol (58.72s)
--- PASS: TestAccVPCNetworkACLRule_basic (59.28s)
--- PASS: TestAccVPCNetworkACLRule_Identity_regionOverride (62.12s)
--- PASS: TestAccVPCNetworkACLRule_Identity_basic (65.30s)
--- PASS: TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate (75.33s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ec2        80.620s


% make t T=TestAccVPCNetworkACLRule_Identity K=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 list-network-acl-rule 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkACLRule_Identity'  -timeout 360m -vet=off -buildvcs=false
2026/09/09 21:43:10 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/09 21:43:10 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCNetworkACLRule_Identity_basic
=== PAUSE TestAccVPCNetworkACLRule_Identity_basic
=== RUN   TestAccVPCNetworkACLRule_Identity_regionOverride
=== PAUSE TestAccVPCNetworkACLRule_Identity_regionOverride
=== RUN   TestAccVPCNetworkACLRule_Identity_ExistingResource_basic
=== PAUSE TestAccVPCNetworkACLRule_Identity_ExistingResource_basic
=== RUN   TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange
=== PAUSE TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange
=== CONT  TestAccVPCNetworkACLRule_Identity_basic
=== CONT  TestAccVPCNetworkACLRule_Identity_ExistingResource_basic
=== CONT  TestAccVPCNetworkACLRule_Identity_regionOverride
=== CONT  TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange
--- PASS: TestAccVPCNetworkACLRule_Identity_basic (52.40s)
--- PASS: TestAccVPCNetworkACLRule_Identity_regionOverride (52.59s)
--- PASS: TestAccVPCNetworkACLRule_Identity_ExistingResource_noRefreshNoChange (64.89s)
--- PASS: TestAccVPCNetworkACLRule_Identity_ExistingResource_basic (78.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        83.807s
...
```
