### PR TITLE
r/aws_kms_replica_key: Add configurable create timeout

### DIFF
--- a/.changelog/49917.txt
+++ b/.changelog/49917.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_kms_replica_key: Add configurable `timeouts` block with `create` timeout
+```

--- a/internal/service/kms/replica_key.go
+++ b/internal/service/kms/replica_key.go
@@ -43,6 +43,10 @@ func resourceReplicaKey() *schema.Resource {
 		UpdateWithoutTimeout: resourceReplicaKeyUpdate,
 		DeleteWithoutTimeout: resourceReplicaKeyDelete,
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(replicaKeyCreatedTimeout),
+		},
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -147,7 +151,7 @@ func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	ctx = tflog.SetField(ctx, logging.KeyResourceId, d.Id())
 
-	if _, err := waitReplicaKeyCreated(ctx, conn, d.Id()); err != nil {
+	if _, err := waitReplicaKeyCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for KMS Replica Key (%s) create: %s", d.Id(), err)
 	}
 
@@ -294,10 +298,7 @@ func resourceReplicaKeyDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func waitReplicaKeyCreated(ctx context.Context, conn *kms.Client, id string) (*awstypes.KeyMetadata, error) {
-	const (
-		timeout = 2 * time.Minute
-	)
+func waitReplicaKeyCreated(ctx context.Context, conn *kms.Client, id string, timeout time.Duration) (*awstypes.KeyMetadata, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.KeyStateCreating),
 		Target:  enum.Slice(awstypes.KeyStateEnabled),

--- a/internal/service/kms/wait.go
+++ b/internal/service/kms/wait.go
@@ -14,6 +14,11 @@ import (
 const (
 	keyRotationUpdatedTimeout = 10 * time.Minute
 
+	// Timeout for a replica key to finish being created after ReplicateKey.
+	// Multi-Region key replication can take longer than the KMS default
+	// eventual-consistency window, so allow a generous default.
+	replicaKeyCreatedTimeout = 20 * time.Minute
+
 	// General timeout for KMS resource changes to propagate.
 	// See https://docs.aws.amazon.com/kms/latest/developerguide/programming-eventual-consistency.html
 	propagationTimeout = 3 * time.Minute // nosemgrep:ci.kms-in-const-name, ci.kms-in-var-name

--- a/website/docs/r/kms_replica_key.html.markdown
+++ b/website/docs/r/kms_replica_key.html.markdown
@@ -90,6 +90,14 @@ This resource exports the following attributes in addition to the arguments abov
 * `key_usage` - The [cryptographic operations](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations) for which you can use the KMS key. This is a shared property of multi-Region keys.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
+## Timeouts
+
+~> **Note:** There are a variety of default timeouts set internally. If you set a shorter custom timeout than one of the defaults, the custom timeout will not be respected as the longer of the custom or internal default will be used.
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `20m`)
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import KMS multi-Region replica keys using the `id`. For example:


### PR DESCRIPTION
### Description

Closes #49915.

The `aws_kms_replica_key` create path waits for the replica key to leave `Creating` and reach `Enabled` using a hardcoded 2 minute timeout (`waitReplicaKeyCreated`). Multi-Region key replication routinely takes longer than that, roughly 10 minutes for `us-east-1` to `eu-central-1` in the reported case, so the create reliably fails even though AWS goes on to finish creating the replica successfully.

This change adds a `timeouts` block with a configurable `create` timeout, defaulting to 20 minutes, and wires it into `waitReplicaKeyCreated`. Users replicating across slower regions can now raise the timeout instead of the create failing every time.

### Relations

This addresses the hardcoded 2 minute wait described in #49915. The other two symptoms reported there, the tainted-resource `ReplicateKey` `AlreadyExistsException` path and `updateKeyEnabled` not retrying `KMSInvalidStateException`, are left for separate follow-ups so this change stays focused.

### References

- Issue: #49915
