### PR TITLE
CI: Installs `terraform` binary before executing tests

### DIFF
--- a/.teamcity/components/service_build_config.kt
+++ b/.teamcity/components/service_build_config.kt
@@ -71,6 +71,7 @@ class Service(name: String, spec: ServiceSpec) {
             val serviceDir = "./internal/service/$packageName"
             steps {
                 ConfigureGoEnv()
+                InstallTerraform()
                 script {
                     name = "Compile Test Binary"
                     workingDir = serviceDir

--- a/.teamcity/scripts/pullrequest_tests/install_terraform_core.sh
+++ b/.teamcity/scripts/pullrequest_tests/install_terraform_core.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# Copyright IBM Corp. 2014, 2026
-# SPDX-License-Identifier: MPL-2.0
-
-mkdir -p tools && wget -O tf.zip https://releases.hashicorp.com/terraform/%TERRAFORM_CORE_VERSION%/terraform_%TERRAFORM_CORE_VERSION%_linux_amd64.zip && unzip tf.zip && mv terraform tools

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -347,6 +347,7 @@ object SetUp : BuildType({
 
     steps {
         ConfigureGoEnv()
+        InstallTerraform()
         script {
             name = "Run provider tests"
             scriptContent = File("./scripts/provider_tests/tests.sh").readText()

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -154,10 +154,7 @@ class PullRequest(terraformVersion: String) : BuildType({
     val accTestRoleARN = DslContext.getParameter("aws_account.role_arn", "")
     steps {
         ConfigureGoEnv()
-        script {
-            name = "Install Terraform Core"
-            scriptContent = File("./scripts/pullrequest_tests/install_terraform_core.sh").readText()
-        }
+        InstallTerraform()
         script {
             name = "Install Github CLI"
             scriptContent = File("./scripts/pullrequest_tests/install_gh_cli.sh").readText()

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -123,6 +123,12 @@ project {
             text("POST_GITHUB_COMMENT", "false")
             password("env.GH_TOKEN", DslContext.getParameter("github_token", ""), display = ParameterDisplay.HIDDEN)
         }
+
+        // Parameters used by `install_terraform.sh`
+        text("env.TERRAFORM_CORE_VERSION", "")
+        text("TOOLS_DIR", "%system.teamcity.build.checkoutDir%/tools", display = ParameterDisplay.HIDDEN, readOnly = true)
+        text("env.TF_ACC_TERRAFORM_PATH", "%TOOLS_DIR%/terraform", display = ParameterDisplay.HIDDEN, readOnly = true)
+
     }
 
     subProject(Services)
@@ -132,7 +138,6 @@ class PullRequest(terraformVersion: String) : BuildType({
     name = "Pull Request"
 
     params {
-        text("env.TF_ACC_TERRAFORM_PATH", "%system.teamcity.build.checkoutDir%/tools/terraform")
         text("TERRAFORM_CORE_VERSION", terraformVersion)
 
         text("env.GOFLAGS", "-modcacherw")
@@ -544,10 +549,6 @@ object SmokeTestsCoreServices : BuildType({
     params {
         text("env.GOFLAGS", "-json", display = ParameterDisplay.HIDDEN, readOnly = true)
 
-        text("TOOLS_DIR", "%system.teamcity.build.checkoutDir%/tools", display = ParameterDisplay.HIDDEN, readOnly = true)
-        text("env.TERRAFORM_CORE_VERSION", "")
-        text("env.TF_ACC_TERRAFORM_PATH", "%TOOLS_DIR%/terraform", display = ParameterDisplay.HIDDEN, readOnly = true)
-
         text("env.TF_LOG", "")
     }
 
@@ -680,10 +681,6 @@ object SmokeTestsResourceIdentity : BuildType({
 
     params {
         text("env.GOFLAGS", "-json", display = ParameterDisplay.HIDDEN, readOnly = true)
-
-        text("TOOLS_DIR", "%system.teamcity.build.checkoutDir%/tools", display = ParameterDisplay.HIDDEN, readOnly = true)
-        text("env.TERRAFORM_CORE_VERSION", "")
-        text("env.TF_ACC_TERRAFORM_PATH", "%TOOLS_DIR%/terraform", display = ParameterDisplay.HIDDEN, readOnly = true)
 
         text("env.TF_LOG", "")
     }


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Installs the `terraform` binary using standard script before running acceptance tests

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>