### PR TITLE
CI: Standardize `tools` directory

### DIFF
--- a/.teamcity/scripts/install_terraform.sh
+++ b/.teamcity/scripts/install_terraform.sh
@@ -23,7 +23,7 @@ mkdir -p "${tools_dir}"
 zip_file=$(mktemp --suffix=.zip)
 trap 'rm -f "${zip_file}"' EXIT
 
-wget -O "${zip_file}" \
+wget --no-verbose -O "${zip_file}" \
     "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip"
 
 unzip -o -d "${tools_dir}" "${zip_file}" terraform

--- a/.teamcity/scripts/install_terraform.sh
+++ b/.teamcity/scripts/install_terraform.sh
@@ -23,7 +23,7 @@ mkdir -p "${tools_dir}"
 zip_file=$(mktemp --suffix=.zip)
 trap 'rm -f "${zip_file}"' EXIT
 
-curl -fsSL -o "${zip_file}" \
+wget -O "${zip_file}" \
     "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip"
 
 unzip -o -d "${tools_dir}" "${zip_file}" terraform

--- a/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
+++ b/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
@@ -2,6 +2,8 @@
 # Copyright IBM Corp. 2014, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+set -euo pipefail
+
 version=$(curl -fsSL \
   ${GH_TOKEN:+-H "Authorization: Bearer ${GH_TOKEN}"} \
   https://api.github.com/repos/cli/cli/releases/latest \
@@ -17,6 +19,9 @@ echo "Downloading gh ${version}..."
 tools_dir="%TOOLS_DIR%"
 mkdir -p "${tools_dir}"
 
-wget -O gh.tar.gz "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz" \
-  && tar -xzf gh.tar.gz \
-  && mv "gh_${version}_linux_amd64/bin/gh" "${tools_dir}"/gh
+tar_file=$(mktemp --suffix=.tar.gz)
+trap 'rm -f "${tar_file}"' EXIT
+
+wget -O "${tar_file}" "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz"
+tar -xzf "${tar_file}"
+mv "gh_${version}_linux_amd64/bin/gh" "${tools_dir}"/gh

--- a/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
+++ b/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 version=$(curl -fsSL \
   ${GH_TOKEN:+-H "Authorization: Bearer ${GH_TOKEN}"} \
   https://api.github.com/repos/cli/cli/releases/latest \
-  | grep -oP '"tag_name":\s*"v\K[^"]+')
+  | grep -oP '"tag_name":\s*"v\K[^"]+' || true)
 
 if [[ -z "${version}" ]]; then
   version="2.97.0"

--- a/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
+++ b/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
@@ -22,6 +22,6 @@ mkdir -p "${tools_dir}"
 tar_file=$(mktemp --suffix=.tar.gz)
 trap 'rm -f "${tar_file}"' EXIT
 
-wget -O "${tar_file}" "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz"
-tar -xzf "${tar_file}"
-mv "gh_${version}_linux_amd64/bin/gh" "${tools_dir}"/gh
+wget -O "${tar_file}" \
+  "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz"
+tar -xzf "${tar_file}" --strip-components=2 -C "${tools_dir}" "gh_${version}_linux_amd64/bin/gh"

--- a/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
+++ b/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
@@ -12,7 +12,11 @@ if [[ -z "${version}" ]]; then
   echo "WARN: failed to resolve gh CLI version from GitHub API, falling back to ${version}" >&2
 fi
 
-mkdir -p tools \
-  && wget -O gh.tar.gz "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz" \
+echo "Downloading gh ${version}..."
+
+tools_dir="%TOOLS_DIR%"
+mkdir -p "${tools_dir}"
+
+wget -O gh.tar.gz "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz" \
   && tar -xzf gh.tar.gz \
-  && mv "gh_${version}_linux_amd64/bin/gh" tools/gh
+  && mv "gh_${version}_linux_amd64/bin/gh" "${tools_dir}"/gh

--- a/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
+++ b/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
@@ -22,6 +22,6 @@ mkdir -p "${tools_dir}"
 tar_file=$(mktemp --suffix=.tar.gz)
 trap 'rm -f "${tar_file}"' EXIT
 
-wget -O "${tar_file}" \
+wget --no-verbose -O "${tar_file}" \
   "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz"
 tar -xzf "${tar_file}" --strip-components=2 -C "${tools_dir}" "gh_${version}_linux_amd64/bin/gh"


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Uses `TOOLS_DIR` parameter instead of hard-coding directory name.

Downaloads `gh` to temp file and deletes it when installing `gh`

Uses `wget` when downloading `terraform`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>