### PR TITLE
r/aws_ec2_transit_gateway_route_table_association: Add configurable timeouts

### DIFF
--- a/.changelog/49924.txt
+++ b/.changelog/49924.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ec2_transit_gateway_route_table_association: Add configurable resource timeouts
+```

--- a/internal/service/ec2/transitgateway_policy_table_association.go
+++ b/internal/service/ec2/transitgateway_policy_table_association.go
@@ -87,7 +87,7 @@ func resourceTransitGatewayPolicyTableAssociationCreate(ctx context.Context, d *
 				return sdkdiag.AppendErrorf(diags, "deleting EC2 Transit Gateway Route Table Association (%s): %s", id, err)
 			}
 
-			if err := waitTransitGatewayRouteTableAssociationDeleted(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID); err != nil {
+			if err := waitTransitGatewayRouteTableAssociationDeleted(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID, transitGatewayRouteTableAssociationDeletedTimeout); err != nil {
 				return sdkdiag.AppendErrorf(diags, "waiting for EC2 Transit Gateway Route Table Association (%s) delete: %s", id, err)
 			}
 		}

--- a/internal/service/ec2/transitgateway_route_table_association.go
+++ b/internal/service/ec2/transitgateway_route_table_association.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -34,6 +35,11 @@ func resourceTransitGatewayRouteTableAssociation() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		SchemaFunc: func() map[string]*schema.Schema {
@@ -91,7 +97,7 @@ func resourceTransitGatewayRouteTableAssociationCreate(ctx context.Context, d *s
 				return sdkdiag.AppendErrorf(diags, "existing EC2 Transit Gateway Route Table (%s) Association (%s) in unexpected state: %s", transitGatewayRouteTableID, transitGatewayAttachmentID, state)
 			}
 
-			if err := disassociateTransitGatewayRouteTable(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID); err != nil {
+			if err := disassociateTransitGatewayRouteTable(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID, d.Timeout(schema.TimeoutCreate)); err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
 			}
 		}
@@ -110,7 +116,7 @@ func resourceTransitGatewayRouteTableAssociationCreate(ctx context.Context, d *s
 
 	d.SetId(id)
 
-	if err := waitTransitGatewayRouteTableAssociationCreated(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID); err != nil {
+	if err := waitTransitGatewayRouteTableAssociationCreated(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for EC2 Transit Gateway Route Table Association (%s) create: %s", d.Id(), err)
 	}
 
@@ -156,7 +162,7 @@ func resourceTransitGatewayRouteTableAssociationDelete(ctx context.Context, d *s
 	}
 
 	log.Printf("[DEBUG] Deleting EC2 Transit Gateway Route Table Association: %s", d.Id())
-	err = disassociateTransitGatewayRouteTable(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID)
+	err = disassociateTransitGatewayRouteTable(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID, d.Timeout(schema.TimeoutDelete))
 
 	if tfawserr.ErrCodeEquals(err, errCodeInvalidAssociationNotFound) {
 		return diags
@@ -193,7 +199,7 @@ func transitGatewayRouteTableAssociationUpdate(ctx context.Context, conn *ec2.Cl
 				return fmt.Errorf("creating EC2 Transit Gateway Route Table Association (%s): %w", id, err)
 			}
 
-			if err := waitTransitGatewayRouteTableAssociationCreated(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID); err != nil {
+			if err := waitTransitGatewayRouteTableAssociationCreated(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID, transitGatewayRouteTableAssociationCreatedTimeout); err != nil {
 				return fmt.Errorf("waiting for EC2 Transit Gateway Route Table Association (%s) create: %w", id, err)
 			}
 		}
@@ -207,11 +213,11 @@ func transitGatewayRouteTableAssociationUpdate(ctx context.Context, conn *ec2.Cl
 
 	if !associate {
 		// Disassociation must be done only on already associated state.
-		if err := waitTransitGatewayRouteTableAssociationCreated(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID); err != nil {
+		if err := waitTransitGatewayRouteTableAssociationCreated(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID, transitGatewayRouteTableAssociationCreatedTimeout); err != nil {
 			return fmt.Errorf("waiting for EC2 Transit Gateway Route Table Association (%s) create: %w", id, err)
 		}
 
-		if err := disassociateTransitGatewayRouteTable(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID); err != nil {
+		if err := disassociateTransitGatewayRouteTable(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID, transitGatewayRouteTableAssociationDeletedTimeout); err != nil {
 			return err
 		}
 	}
@@ -219,7 +225,7 @@ func transitGatewayRouteTableAssociationUpdate(ctx context.Context, conn *ec2.Cl
 	return nil
 }
 
-func disassociateTransitGatewayRouteTable(ctx context.Context, conn *ec2.Client, transitGatewayRouteTableID, transitGatewayAttachmentID string) error {
+func disassociateTransitGatewayRouteTable(ctx context.Context, conn *ec2.Client, transitGatewayRouteTableID, transitGatewayAttachmentID string, timeout time.Duration) error {
 	input := &ec2.DisassociateTransitGatewayRouteTableInput{
 		TransitGatewayAttachmentId: aws.String(transitGatewayAttachmentID),
 		TransitGatewayRouteTableId: aws.String(transitGatewayRouteTableID),
@@ -235,7 +241,7 @@ func disassociateTransitGatewayRouteTable(ctx context.Context, conn *ec2.Client,
 		return fmt.Errorf("deleting EC2 Transit Gateway Route Table (%s) Association (%s): %w", transitGatewayRouteTableID, transitGatewayAttachmentID, err)
 	}
 
-	if err := waitTransitGatewayRouteTableAssociationDeleted(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID); err != nil {
+	if err := waitTransitGatewayRouteTableAssociationDeleted(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID, timeout); err != nil {
 		return fmt.Errorf("waiting for EC2 Transit Gateway Route Table (%s) Association (%s) delete: %w", transitGatewayRouteTableID, transitGatewayAttachmentID, err)
 	}
 

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -2835,11 +2835,11 @@ func waitTransitGatewayPolicyTableAssociationDeleted(ctx context.Context, conn *
 	return nil, err
 }
 
-func waitTransitGatewayRouteTableAssociationCreated(ctx context.Context, conn *ec2.Client, transitGatewayRouteTableID, transitGatewayAttachmentID string) error {
+func waitTransitGatewayRouteTableAssociationCreated(ctx context.Context, conn *ec2.Client, transitGatewayRouteTableID, transitGatewayAttachmentID string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.TransitGatewayAssociationStateAssociating),
 		Target:  enum.Slice(awstypes.TransitGatewayAssociationStateAssociated),
-		Timeout: transitGatewayRouteTableAssociationCreatedTimeout,
+		Timeout: timeout,
 		Refresh: statusTransitGatewayRouteTableAssociation(conn, transitGatewayRouteTableID, transitGatewayAttachmentID),
 	}
 
@@ -2848,11 +2848,11 @@ func waitTransitGatewayRouteTableAssociationCreated(ctx context.Context, conn *e
 	return err
 }
 
-func waitTransitGatewayRouteTableAssociationDeleted(ctx context.Context, conn *ec2.Client, transitGatewayRouteTableID, transitGatewayAttachmentID string) error {
+func waitTransitGatewayRouteTableAssociationDeleted(ctx context.Context, conn *ec2.Client, transitGatewayRouteTableID, transitGatewayAttachmentID string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending:        enum.Slice(awstypes.TransitGatewayAssociationStateAssociated, awstypes.TransitGatewayAssociationStateDisassociating),
 		Target:         []string{},
-		Timeout:        transitGatewayRouteTableAssociationDeletedTimeout,
+		Timeout:        timeout,
 		Refresh:        statusTransitGatewayRouteTableAssociation(conn, transitGatewayRouteTableID, transitGatewayAttachmentID),
 		NotFoundChecks: 1,
 	}

--- a/website/docs/r/ec2_transit_gateway_route_table_association.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route_table_association.html.markdown
@@ -109,6 +109,13 @@ This resource exports the following attributes in addition to the arguments abov
 * `resource_id` - Identifier of the resource
 * `resource_type` - Type of the resource
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `5m`)
+- `delete` - (Default `10m`)
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `aws_ec2_transit_gateway_route_table_association` using the EC2 Transit Gateway Route Table identifier, an underscore, and the EC2 Transit Gateway Attachment identifier. For example:


### PR DESCRIPTION
<!-- Please refer to our contribution guidelines: https://hashicorp.github.io/terraform-provider-aws/#contribute -->

### Description

`aws_ec2_transit_gateway_route_table_association` waited on a hard-coded 5 minute create timeout, with no way for users to extend it. As reported in #42705, associations can legitimately take ~10 minutes, so the apply fails even though the association eventually succeeds:

```
Error: waiting for EC2 Transit Gateway Route Table Association (tgw-rtb-…_tgw-attach-…) create:
timeout while waiting for state to become 'associated' (last state: 'associating', timeout: 5m0s)
```

This adds a `timeouts` block to the resource. The previously hard-coded durations become the defaults, so **behavior is unchanged unless a user opts in**:

```terraform
resource "aws_ec2_transit_gateway_route_table_association" "example" {
  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.example.id
  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.example.id

  timeouts {
    create = "15m"
  }
}
```

Implementation notes:

* `waitTransitGatewayRouteTableAssociationCreated` / `…Deleted` and `disassociateTransitGatewayRouteTable` now take a `timeout time.Duration`, following the existing convention in this package (e.g. `waitTransitGatewayUpdated`).
* Only the resource itself passes `d.Timeout(...)`. The shared helpers used by the attachment resources (`transitgateway_vpc_attachment.go`, `transitgateway_vpc_attachment_accepter.go`, `transitgateway_connect.go`) and `transitgateway_policy_table_association.go` pass the pre-existing `transitGatewayRouteTableAssociation{Created,Deleted}Timeout` constants, so those code paths are untouched.

### Relations

Closes #42705

### References

* [Transit Gateway route table association docs](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-route-tables.html)

### Output from Acceptance Testing

I do not have an AWS account available to run the Transit Gateway acceptance tests, so I have not run them. The change is limited to plumbing a configurable duration into the existing waiters; the defaults are byte-for-byte the previous constants, so `TestAccTransitGatewayRouteTableAssociation_*` should be unaffected. Happy to add a `timeouts`-specific test case if a maintainer would like one.

```console
$ make testacc TESTS=TestAccTransitGatewayRouteTableAssociation PKG=ec2
# not run — no AWS credentials available
```

### GenAI / LLM Assisted Development

This change was written with the assistance of Claude Code. I have reviewed the diff.
