### PR TITLE
internal/acctest: handle go-vcr in `WithProvider` test checks

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -202,6 +202,8 @@ func protoV5ProviderFactoriesNamedInit(ctx context.Context, t *testing.T, provid
 			t.Fatal(err)
 		}
 
+		composeVCRWrapper(t, p)
+
 		factories[name] = func() (tfprotov5.ProviderServer, error) { //nolint:unparam
 			return providerServerFactory(), nil
 		}
@@ -223,6 +225,8 @@ func protoV5ProviderFactoriesPlusProvidersInit(ctx context.Context, t *testing.T
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		composeVCRWrapper(t, p)
 
 		factories[name] = func() (tfprotov5.ProviderServer, error) { //nolint:unparam
 			return providerServerFactory(), nil
@@ -348,17 +352,9 @@ func PreCheck(ctx context.Context, t *testing.T) {
 
 // ProviderAccountID returns the account ID of an AWS provider
 func ProviderAccountID(ctx context.Context, provider *schema.Provider) string {
-	if provider == nil {
-		log.Print("[DEBUG] Unable to read account ID from test provider: empty provider")
-		return ""
-	}
-	if provider.Meta() == nil {
-		log.Print("[DEBUG] Unable to read account ID from test provider: unconfigured provider")
-		return ""
-	}
-	client, ok := provider.Meta().(*conns.AWSClient)
+	client, ok := providerClient(provider)
 	if !ok {
-		log.Print("[DEBUG] Unable to read account ID from test provider: non-AWS or unconfigured AWS provider")
+		log.Print("[DEBUG] Unable to read account ID from test provider: non-AWS or unconfigured provider")
 		return ""
 	}
 	return client.AccountID(ctx)
@@ -1559,16 +1555,9 @@ func RegionProviderFunc(ctx context.Context, region string, providers *[]*schema
 
 		log.Printf("[DEBUG] Checking providers for AWS region: %s", region)
 		for _, provo := range *providers {
-			// Ignore if Meta is empty, this can happen for validation providers
-			if provo == nil || provo.Meta() == nil {
-				log.Printf("[DEBUG] Skipping empty provider")
-				continue
-			}
-
-			// Ignore if Meta is not conns.AWSClient, this will happen for other providers
-			client, ok := provo.Meta().(*conns.AWSClient)
+			client, ok := providerClient(provo)
 			if !ok {
-				log.Printf("[DEBUG] Skipping non-AWS provider")
+				log.Printf("[DEBUG] Skipping non-AWS or unconfigured provider")
 				continue
 			}
 
@@ -1678,8 +1667,8 @@ func CheckWithProviders(f TestCheckWithProviderFunc, providers *[]*schema.Provid
 	return func(s *terraform.State) error {
 		numberOfProviders := len(*providers)
 		for i, provo := range *providers {
-			if provo.Meta() == nil {
-				log.Printf("[DEBUG] Skipping empty provider %d (total: %d)", i, numberOfProviders)
+			if _, ok := providerClient(provo); !ok {
+				log.Printf("[DEBUG] Skipping unconfigured provider %d (total: %d)", i, numberOfProviders)
 				continue
 			}
 			log.Printf("[DEBUG] Calling check with provider %d (total: %d)", i, numberOfProviders)
@@ -1695,8 +1684,8 @@ func CheckWithNamedProviders(f TestCheckWithProviderFunc, providers map[string]*
 	return func(s *terraform.State) error {
 		numberOfProviders := len(providers)
 		for k, provo := range providers {
-			if provo.Meta() == nil {
-				log.Printf("[DEBUG] Skipping empty provider %q (total: %d)", k, numberOfProviders)
+			if _, ok := providerClient(provo); !ok {
+				log.Printf("[DEBUG] Skipping unconfigured provider %q (total: %d)", k, numberOfProviders)
 				continue
 			}
 			log.Printf("[DEBUG] Calling check with provider %q (total: %d)", k, numberOfProviders)
@@ -1706,6 +1695,24 @@ func CheckWithNamedProviders(f TestCheckWithProviderFunc, providers map[string]*
 		}
 		return nil
 	}
+}
+
+// providerClient returns provo's configured AWS client.
+//
+// It reports false for a nil provider, a non-AWS provider, and an AWS provider
+// whose ConfigureContextFunc has not run.
+func providerClient(provo *schema.Provider) (*conns.AWSClient, bool) {
+	if provo == nil {
+		return nil, false
+	}
+
+	client, ok := provo.Meta().(*conns.AWSClient)
+
+	if !ok || !client.Configured() {
+		return nil, false
+	}
+
+	return client, true
 }
 
 type TestCheckWithRegionFunc func(*terraform.State, string) error

--- a/internal/acctest/configure_wrapper.go
+++ b/internal/acctest/configure_wrapper.go
@@ -91,3 +91,23 @@ func ProtoV5ProviderFactoriesWithWrappers(
 		},
 	}
 }
+
+// composeVCRWrapper composes VCR record/replay onto p's ConfigureContextFunc
+// when VCR is enabled, and marks t so the auto-wrap path in [vcrTestCase] does
+// not build a second set of providers.
+//
+// Factory builders that hand the caller the *schema.Provider itself must call
+// this. Those providers are what [RegionProviderFunc], [CheckWithProviders],
+// and [ProviderAccountID] read their Meta from, and the auto-wrap path
+// substitutes providers of its own, leaving the caller's instances
+// unconfigured.
+func composeVCRWrapper(t *testing.T, p *schema.Provider) {
+	t.Helper()
+
+	if !vcr.IsEnabled() {
+		return
+	}
+
+	disableVCRAutoWrap(t)
+	p.ConfigureContextFunc = chainConfigureWrappers(p.ConfigureContextFunc, vcrConfigureWrapper(p, t))
+}

--- a/internal/acctest/configure_wrapper_test.go
+++ b/internal/acctest/configure_wrapper_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
 // TestChainConfigureWrappers verifies that wrappers compose so that the
@@ -179,5 +181,73 @@ func TestVCRTestCase_ShortCircuitsWhenAutoWrapDisabled(t *testing.T) {
 	if reflect.ValueOf(tc.ProtoV5ProviderFactories).Pointer() !=
 		reflect.ValueOf(original).Pointer() {
 		t.Error("vcrTestCase replaced ProtoV5ProviderFactories despite the auto-wrap-disabled marker")
+	}
+}
+
+// TestProtoV5FactoriesPlusProvidersAlternate_VCREnabled verifies that the
+// providers handed back to a multi-region test survive VCR setup.
+func TestProtoV5FactoriesPlusProvidersAlternate_VCREnabled(t *testing.T) {
+	t.Setenv("VCR_MODE", "RECORD_ONLY")
+	t.Setenv("VCR_PATH", t.TempDir())
+
+	var providers []*schema.Provider
+	factories := ProtoV5FactoriesPlusProvidersAlternate(context.Background(), t, &providers)
+
+	if len(providers) != 2 {
+		t.Fatalf("recorded %d providers, want 2", len(providers))
+	}
+
+	tc := resource.TestCase{ProtoV5ProviderFactories: factories}
+	if !vcrTestCase(context.Background(), t, &tc) {
+		t.Fatal("vcrTestCase returned false; want true so the test still runs")
+	}
+
+	if reflect.ValueOf(tc.ProtoV5ProviderFactories).Pointer() !=
+		reflect.ValueOf(factories).Pointer() {
+		t.Error("vcrTestCase replaced the factories serving the recorded providers")
+	}
+}
+
+// TestRegionProviderFunc_UnconfiguredProvider verifies that an unconfigured
+// provider is skipped rather than dereferenced. Provider construction installs
+// a placeholder AWSClient as Meta, so a non-nil Meta is not enough to call
+// Region on.
+//
+// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/49795
+func TestRegionProviderFunc_UnconfiguredProvider(t *testing.T) {
+	t.Parallel()
+
+	unconfigured := &schema.Provider{}
+	unconfigured.SetMeta(new(conns.AWSClient))
+	providers := []*schema.Provider{nil, unconfigured}
+
+	if p := RegionProviderFunc(context.Background(), "us-west-2", &providers)(); p != nil {
+		t.Errorf("returned provider %v, want nil", p)
+	}
+}
+
+// TestCheckWithProviders_UnconfiguredProvider verifies that CheckWithProviders
+// skips a provider whose Meta is an unconfigured AWSClient, so CheckDestroy
+// does not request a service client from it.
+//
+// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/49795
+func TestCheckWithProviders_UnconfiguredProvider(t *testing.T) {
+	t.Parallel()
+
+	unconfigured := &schema.Provider{}
+	unconfigured.SetMeta(new(conns.AWSClient))
+	providers := []*schema.Provider{unconfigured}
+
+	called := false
+	check := CheckWithProviders(func(*terraform.State, *schema.Provider) error {
+		called = true
+		return nil
+	}, &providers)
+
+	if err := check(nil); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if called {
+		t.Error("check was invoked with an unconfigured provider")
 	}
 }

--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -75,6 +75,10 @@ func (c *AWSClient) TerraformVersion(_ context.Context) string {
 	return c.terraformVersion
 }
 
+func (c *AWSClient) Configured() bool {
+	return c != nil && c.awsConfig != nil
+}
+
 // CredentialsProvider returns the AWS SDK for Go v2 credentials provider.
 func (c *AWSClient) CredentialsProvider(context.Context) aws.CredentialsProvider {
 	if c.awsConfig == nil {


### PR DESCRIPTION

<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds additional handling to ensure that the provider wrapping done when go-vcr is enabled is compatible with test checks that explicitly pass providers as function arguments.

In `RECORD_ONLY` mode:

```console
% make t K=s3 T=TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
make: Running acceptance tests on branch: 🌿 td-go-vcr-alternate-fix 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation'  -timeout 360m -vet=off -buildvcs=false
2026/09/09 15:36:42 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/09 15:36:42 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (63.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 72.384s
```

**AI Disclosure**: An agent (Claude Opus 5) was used to diagnose and fix this issue. I have reviewed and approved all proposed changes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49795



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=s3 T=TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
make: Running acceptance tests on branch: 🌿 td-go-vcr-alternate-fix 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation'  -timeout 360m -vet=off -buildvcs=false
2026/09/09 15:36:42 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/09 15:36:42 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (63.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 72.384s
```
