### PR TITLE
.ci/semgrep: add `list-resource-unused-config-model` rule 

### DIFF
--- a/.ci/semgrep/list/unused-config-model.go
+++ b/.ci/semgrep/list/unused-config-model.go
@@ -1,0 +1,123 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+)
+
+type unusedConfigListModel struct {
+	framework.WithRegionModel
+}
+
+type unusedConfigListResource struct{}
+
+func (r *unusedConfigListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	// ruleid: list-resource-unused-config-model
+	var query unusedConfigListModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	stream.Results = func(yield func(list.ListResult) bool) {}
+}
+
+type configuredListModel struct {
+	framework.WithRegionModel
+	Name string
+}
+
+type configuredListResource struct{}
+
+func (r *configuredListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	// ok: list-resource-unused-config-model
+	var query configuredListModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		_ = query.Name
+	}
+}
+
+type expandedListResource struct{}
+
+// The model is expanded into the AWS SDK input struct, so the configuration is used.
+func (r *expandedListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	// ok: list-resource-unused-config-model
+	var query configuredListModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	var input listInput
+	if diags := fwflex.Expand(ctx, query, &input); diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	stream.Results = func(yield func(list.ListResult) bool) {}
+}
+
+type expandedByPointerListResource struct{}
+
+// The model is passed by pointer to something other than `request.Config.Get`,
+// so the configuration is used.
+func (r *expandedByPointerListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	// ok: list-resource-unused-config-model
+	var query configuredListModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	var input listInput
+	if diags := fwflex.Expand(ctx, &query, &input); diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	stream.Results = func(yield func(list.ListResult) bool) {}
+}
+
+type nestedUseListResource struct{}
+
+// The model field is read inside a composite literal nested in a closure.
+func (r *nestedUseListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+	// ok: list-resource-unused-config-model
+	var query configuredListModel
+	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+		if diags := request.Config.Get(ctx, &query); diags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	stream.Results = func(yield func(list.ListResult) bool) {
+		input := listInput{
+			Name: query.Name,
+		}
+		_ = input
+	}
+}
+
+type listInput struct {
+	Name string
+}

--- a/.ci/semgrep/list/unused-config-model.yml
+++ b/.ci/semgrep/list/unused-config-model.yml
@@ -1,0 +1,43 @@
+# Copyright IBM Corp. 2014, 2026
+# "SPDX-License-Identifier: MPL-2.0"
+
+rules:
+  - id: list-resource-unused-config-model
+    languages: [go]
+    message: >-
+      List resource configuration is decoded into `query`, but `query` is never used.
+      Remove the decode block and its region-only model.
+    severity: WARNING
+    paths:
+      include:
+        - "/internal/service/**/*_list.go"
+    patterns:
+      - pattern: |
+          func ($R *$TYPE) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
+            ...
+            var query $MODEL
+            if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
+              if diags := request.Config.Get(ctx, &query); diags.HasError() {
+                stream.Results = list.ListResultsStreamDiagnostics(diags)
+                return
+              }
+            }
+            ...
+          }
+      # Applied to the source text of the range matched above, i.e. the whole
+      # `List` method.
+      #
+      #   \bquery\b          the bare identifier `query`; the word boundaries
+      #                      stop `queryString`, `subquery`, and `queries` from
+      #                      counting as a use
+      #   (?<!var )          not preceded by `var `, which exempts the
+      #                      declaration `var query fooListResourceModel`
+      #   (?<!Get\(ctx, &)   not preceded by `Get(ctx, &`, which exempts
+      #                      `request.Config.Get(ctx, &query)` and nothing else;
+      #                      a `&query` passed anywhere else is a real use
+      #
+      # Both lookbehinds are fixed-width literals. The check is lexical, so a
+      # `query` in a comment or string literal also suppresses the finding. This
+      # is a known, accepted trade off to simplify the rule implementation.
+      - pattern-not-regex: '(?<!var )(?<!Get\(ctx, &)\bquery\b'
+      - focus-metavariable: $MODEL

--- a/internal/service/acm/certificate_list.go
+++ b/internal/service/acm/certificate_list.go
@@ -35,21 +35,9 @@ type certificateListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type certificateListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *certificateListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.ACMClient(ctx)
-
-	var query certificateListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	tflog.Info(ctx, "Listing ACM Certificates")
 

--- a/internal/service/amp/scraper_logging_configuration_list.go
+++ b/internal/service/amp/scraper_logging_configuration_list.go
@@ -33,14 +33,6 @@ type scraperLoggingConfigurationListResource struct {
 func (l *scraperLoggingConfigurationListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().AMPClient(ctx)
 
-	var query listScraperLoggingConfigurationModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Resources")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -89,8 +81,4 @@ func (l *scraperLoggingConfigurationListResource) List(ctx context.Context, requ
 			}
 		}
 	}
-}
-
-type listScraperLoggingConfigurationModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/apigatewayv2/api_list.go
+++ b/internal/service/apigatewayv2/api_list.go
@@ -38,14 +38,6 @@ type apiListResource struct {
 func (l *apiListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().APIGatewayV2Client(ctx)
 
-	var query listAPIModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Resources")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -87,10 +79,6 @@ func (l *apiListResource) List(ctx context.Context, request list.ListRequest, st
 			}
 		}
 	}
-}
-
-type listAPIModel struct {
-	framework.WithRegionModel
 }
 
 func listAPIs(ctx context.Context, conn *apigatewayv2.Client, input *apigatewayv2.GetApisInput) iter.Seq2[awstypes.Api, error] {

--- a/internal/service/appflow/connector_profile_list.go
+++ b/internal/service/appflow/connector_profile_list.go
@@ -38,14 +38,6 @@ func (l *listResourceConnectorProfile) List(ctx context.Context, request list.Li
 	awsClient := l.Meta()
 	conn := awsClient.AppFlowClient(ctx)
 
-	var query listConnectorProfileModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing AppFlow Connector Profile")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input appflow.DescribeConnectorProfilesInput
@@ -80,10 +72,6 @@ func (l *listResourceConnectorProfile) List(ctx context.Context, request list.Li
 			}
 		}
 	}
-}
-
-type listConnectorProfileModel struct {
-	framework.WithRegionModel
 }
 
 func listConnectorProfiles(ctx context.Context, conn *appflow.Client, input *appflow.DescribeConnectorProfilesInput) iter.Seq2[awstypes.ConnectorProfile, error] {

--- a/internal/service/appflow/flow_list.go
+++ b/internal/service/appflow/flow_list.go
@@ -38,14 +38,6 @@ func (l *listResourceFlow) List(ctx context.Context, request list.ListRequest, s
 	awsClient := l.Meta()
 	conn := awsClient.AppFlowClient(ctx)
 
-	var query listFlowModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing AppFlow Flow")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input appflow.ListFlowsInput
@@ -88,10 +80,6 @@ func (l *listResourceFlow) List(ctx context.Context, request list.ListRequest, s
 			}
 		}
 	}
-}
-
-type listFlowModel struct {
-	framework.WithRegionModel
 }
 
 func listFlows(ctx context.Context, conn *appflow.Client, input *appflow.ListFlowsInput) iter.Seq2[awstypes.FlowDefinition, error] {

--- a/internal/service/autoscaling/group_list.go
+++ b/internal/service/autoscaling/group_list.go
@@ -35,21 +35,9 @@ type groupListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type listGroupModel struct {
-	framework.WithRegionModel
-}
-
 func (l *groupListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.AutoScalingClient(ctx)
-
-	var query listGroupModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	tflog.Info(ctx, "Listing Auto Scaling Groups")
 

--- a/internal/service/backup/vault_list.go
+++ b/internal/service/backup/vault_list.go
@@ -32,19 +32,7 @@ type vaultListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type vaultListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *vaultListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query vaultListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	awsClient := l.Meta()
 	conn := awsClient.BackupClient(ctx)
 

--- a/internal/service/batch/job_definition_list.go
+++ b/internal/service/batch/job_definition_list.go
@@ -31,21 +31,9 @@ type jobDefinitionListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type jobDefinitionListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *jobDefinitionListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.BatchClient(ctx)
-
-	var query jobDefinitionListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	var input batch.DescribeJobDefinitionsInput
 

--- a/internal/service/batch/job_queue_list.go
+++ b/internal/service/batch/job_queue_list.go
@@ -29,15 +29,6 @@ type listResourceJobQueue struct {
 }
 
 func (r *listResourceJobQueue) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query jobQueueListModel
-
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	awsClient := r.Meta()
 	conn := awsClient.BatchClient(ctx)
 
@@ -74,10 +65,6 @@ func (r *listResourceJobQueue) List(ctx context.Context, request list.ListReques
 			}
 		}
 	}
-}
-
-type jobQueueListModel struct {
-	framework.WithRegionModel
 }
 
 // DescribeJobQueues is an "All-Or-Some" call.

--- a/internal/service/bedrockagentcore/browser_profile_list.go
+++ b/internal/service/bedrockagentcore/browser_profile_list.go
@@ -36,14 +36,6 @@ type browserProfileListResource struct {
 func (l *browserProfileListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().BedrockAgentCoreClient(ctx)
 
-	var query listBrowserProfileModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input bedrockagentcorecontrol.ListBrowserProfilesInput
 		for item, err := range listBrowserProfiles(ctx, conn, &input) {
@@ -73,10 +65,6 @@ func (l *browserProfileListResource) List(ctx context.Context, request list.List
 			}
 		}
 	}
-}
-
-type listBrowserProfileModel struct {
-	framework.WithRegionModel
 }
 
 func listBrowserProfiles(ctx context.Context, conn *bedrockagentcorecontrol.Client, input *bedrockagentcorecontrol.ListBrowserProfilesInput) iter.Seq2[awstypes.BrowserProfileSummary, error] {

--- a/internal/service/bedrockagentcore/evaluator_list.go
+++ b/internal/service/bedrockagentcore/evaluator_list.go
@@ -39,14 +39,6 @@ type evaluatorListResource struct {
 func (l *evaluatorListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().BedrockAgentCoreClient(ctx)
 
-	var query listEvaluatorModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input bedrockagentcorecontrol.ListEvaluatorsInput
 
@@ -99,10 +91,6 @@ func (l *evaluatorListResource) List(ctx context.Context, request list.ListReque
 			}
 		}
 	}
-}
-
-type listEvaluatorModel struct {
-	framework.WithRegionModel
 }
 
 func listEvaluators(ctx context.Context, conn *bedrockagentcorecontrol.Client, input *bedrockagentcorecontrol.ListEvaluatorsInput) iter.Seq2[awstypes.EvaluatorSummary, error] {

--- a/internal/service/bedrockagentcore/harness_list.go
+++ b/internal/service/bedrockagentcore/harness_list.go
@@ -38,14 +38,6 @@ type harnessListResource struct {
 func (l *harnessListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().BedrockAgentCoreClient(ctx)
 
-	var query listHarnessModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input bedrockagentcorecontrol.ListHarnessesInput
 		for item, err := range listHarnesses(ctx, conn, &input) {
@@ -93,10 +85,6 @@ func (l *harnessListResource) List(ctx context.Context, request list.ListRequest
 			}
 		}
 	}
-}
-
-type listHarnessModel struct {
-	framework.WithRegionModel
 }
 
 func listHarnesses(ctx context.Context, conn *bedrockagentcorecontrol.Client, input *bedrockagentcorecontrol.ListHarnessesInput) iter.Seq2[awstypes.HarnessSummary, error] {

--- a/internal/service/bedrockagentcore/online_evaluation_config_list.go
+++ b/internal/service/bedrockagentcore/online_evaluation_config_list.go
@@ -38,14 +38,6 @@ type onlineEvaluationConfigListResource struct {
 func (l *onlineEvaluationConfigListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().BedrockAgentCoreClient(ctx)
 
-	var query listOnlineEvaluationConfigModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input bedrockagentcorecontrol.ListOnlineEvaluationConfigsInput
 		for item, err := range listOnlineEvaluationConfigs(ctx, conn, &input) {
@@ -94,10 +86,6 @@ func (l *onlineEvaluationConfigListResource) List(ctx context.Context, request l
 			}
 		}
 	}
-}
-
-type listOnlineEvaluationConfigModel struct {
-	framework.WithRegionModel
 }
 
 func listOnlineEvaluationConfigs(ctx context.Context, conn *bedrockagentcorecontrol.Client, input *bedrockagentcorecontrol.ListOnlineEvaluationConfigsInput) iter.Seq2[awstypes.OnlineEvaluationConfigSummary, error] {

--- a/internal/service/bedrockagentcore/policy_engine_list.go
+++ b/internal/service/bedrockagentcore/policy_engine_list.go
@@ -38,14 +38,6 @@ type policyEngineListResource struct {
 func (l *policyEngineListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().BedrockAgentCoreClient(ctx)
 
-	var query listPolicyEngineModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input bedrockagentcorecontrol.ListPolicyEnginesInput
 		for item, err := range listPolicyEngines(ctx, conn, &input) {
@@ -92,10 +84,6 @@ func (l *policyEngineListResource) List(ctx context.Context, request list.ListRe
 			}
 		}
 	}
-}
-
-type listPolicyEngineModel struct {
-	framework.WithRegionModel
 }
 
 func listPolicyEngines(ctx context.Context, conn *bedrockagentcorecontrol.Client, input *bedrockagentcorecontrol.ListPolicyEnginesInput) iter.Seq2[awstypes.PolicyEngine, error] {

--- a/internal/service/bedrockagentcore/registry_list.go
+++ b/internal/service/bedrockagentcore/registry_list.go
@@ -45,14 +45,6 @@ func (l *registryListResource) ListResourceConfigSchema(ctx context.Context, req
 func (l *registryListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().BedrockAgentCoreClient(ctx)
 
-	var query listRegistryModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input bedrockagentcorecontrol.ListRegistriesInput
 		for item, err := range listRegistries(ctx, conn, &input) {
@@ -99,10 +91,6 @@ func (l *registryListResource) List(ctx context.Context, request list.ListReques
 			}
 		}
 	}
-}
-
-type listRegistryModel struct {
-	framework.WithRegionModel
 }
 
 func listRegistries(ctx context.Context, conn *bedrockagentcorecontrol.Client, input *bedrockagentcorecontrol.ListRegistriesInput) iter.Seq2[awstypes.RegistrySummary, error] {

--- a/internal/service/bedrockagentcore/resource_policy_list.go
+++ b/internal/service/bedrockagentcore/resource_policy_list.go
@@ -38,14 +38,6 @@ type resourcePolicyListResource struct {
 func (l *resourcePolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().BedrockAgentCoreClient(ctx)
 
-	var query listResourcePolicyModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		// Check agent runtimes and their endpoints for resource policies.
 		var runtimesInput bedrockagentcorecontrol.ListAgentRuntimesInput
@@ -126,10 +118,6 @@ func (l *resourcePolicyListResource) yieldResourcePolicy(ctx context.Context, co
 	})
 
 	return yield(result)
-}
-
-type listResourcePolicyModel struct {
-	framework.WithRegionModel
 }
 
 func listAgentRuntimesForPolicies(ctx context.Context, conn *bedrockagentcorecontrol.Client, input *bedrockagentcorecontrol.ListAgentRuntimesInput) iter.Seq2[awstypes.AgentRuntime, error] {

--- a/internal/service/cleanrooms/collaboration_list.go
+++ b/internal/service/cleanrooms/collaboration_list.go
@@ -37,14 +37,6 @@ type listResourceCollaboration struct {
 func (l *listResourceCollaboration) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().CleanRoomsClient(ctx)
 
-	var query listCollaborationModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Clean Rooms Collaboration")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input cleanrooms.ListCollaborationsInput
@@ -92,10 +84,6 @@ func (l *listResourceCollaboration) List(ctx context.Context, request list.ListR
 			}
 		}
 	}
-}
-
-type listCollaborationModel struct {
-	framework.WithRegionModel
 }
 
 func listCollaborations(ctx context.Context, conn *cleanrooms.Client, input *cleanrooms.ListCollaborationsInput) iter.Seq2[awstypes.CollaborationSummary, error] {

--- a/internal/service/cleanrooms/configured_table_list.go
+++ b/internal/service/cleanrooms/configured_table_list.go
@@ -37,14 +37,6 @@ type listResourceConfiguredTable struct {
 func (l *listResourceConfiguredTable) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().CleanRoomsClient(ctx)
 
-	var query listConfiguredTableModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Clean Rooms Configured Table")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input cleanrooms.ListConfiguredTablesInput
@@ -87,10 +79,6 @@ func (l *listResourceConfiguredTable) List(ctx context.Context, request list.Lis
 			}
 		}
 	}
-}
-
-type listConfiguredTableModel struct {
-	framework.WithRegionModel
 }
 
 func listConfiguredTables(ctx context.Context, conn *cleanrooms.Client, input *cleanrooms.ListConfiguredTablesInput) iter.Seq2[awstypes.ConfiguredTableSummary, error] {

--- a/internal/service/cleanrooms/membership_list.go
+++ b/internal/service/cleanrooms/membership_list.go
@@ -37,14 +37,6 @@ type membershipListResource struct {
 func (l *membershipListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().CleanRoomsClient(ctx)
 
-	var query listMembershipModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Clean Rooms Membership")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -98,10 +90,6 @@ func (l *membershipListResource) List(ctx context.Context, request list.ListRequ
 			}
 		}
 	}
-}
-
-type listMembershipModel struct {
-	framework.WithRegionModel
 }
 
 func listMemberships(ctx context.Context, conn *cleanrooms.Client, input *cleanrooms.ListMembershipsInput) iter.Seq2[awstypes.MembershipSummary, error] {

--- a/internal/service/cloudfront/distribution_list.go
+++ b/internal/service/cloudfront/distribution_list.go
@@ -39,14 +39,6 @@ func (l *distributionListResource) List(ctx context.Context, request list.ListRe
 	awsClient := l.Meta()
 	conn := awsClient.CloudFrontClient(ctx)
 
-	var query listDistributionModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing CloudFront Distributions")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input cloudfront.ListDistributionsInput
@@ -104,8 +96,6 @@ func (l *distributionListResource) List(ctx context.Context, request list.ListRe
 		}
 	}
 }
-
-type listDistributionModel struct{}
 
 func listDistributions(ctx context.Context, conn *cloudfront.Client, input *cloudfront.ListDistributionsInput) iter.Seq2[awstypes.DistributionSummary, error] {
 	return func(yield func(awstypes.DistributionSummary, error) bool) {

--- a/internal/service/cloudfront/key_value_store_list.go
+++ b/internal/service/cloudfront/key_value_store_list.go
@@ -34,14 +34,6 @@ type listResourceKeyValueStore struct {
 }
 
 func (r *listResourceKeyValueStore) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query listKeyValueStoreModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	awsClient := r.Meta()
 	conn := awsClient.CloudFrontClient(ctx)
 
@@ -92,8 +84,6 @@ func (r *listResourceKeyValueStore) List(ctx context.Context, request list.ListR
 		}
 	}
 }
-
-type listKeyValueStoreModel struct{}
 
 func listKeyValueStores(ctx context.Context, conn *cloudfront.Client, input *cloudfront.ListKeyValueStoresInput) iter.Seq2[awstypes.KeyValueStore, error] {
 	return func(yield func(awstypes.KeyValueStore, error) bool) {

--- a/internal/service/cloudwatch/alarm_mute_rule_list.go
+++ b/internal/service/cloudwatch/alarm_mute_rule_list.go
@@ -39,14 +39,6 @@ type alarmMuteRuleListResource struct {
 func (l *alarmMuteRuleListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().CloudWatchClient(ctx)
 
-	var query listAlarmMuteRuleModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input cloudwatch.ListAlarmMuteRulesInput
 		for item, err := range listAlarmMuteRules(ctx, conn, &input) {
@@ -95,10 +87,6 @@ func (l *alarmMuteRuleListResource) List(ctx context.Context, request list.ListR
 			}
 		}
 	}
-}
-
-type listAlarmMuteRuleModel struct {
-	framework.WithRegionModel
 }
 
 func listAlarmMuteRules(ctx context.Context, conn *cloudwatch.Client, input *cloudwatch.ListAlarmMuteRulesInput) iter.Seq2[awstypes.AlarmMuteRuleSummary, error] {

--- a/internal/service/cloudwatch/metric_alarm_list.go
+++ b/internal/service/cloudwatch/metric_alarm_list.go
@@ -37,14 +37,6 @@ type listResourceMetricAlarm struct {
 func (l *listResourceMetricAlarm) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().CloudWatchClient(ctx)
 
-	var query listMetricAlarmModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input cloudwatch.DescribeAlarmsInput
 		input.AlarmTypes = []awstypes.AlarmType{awstypes.AlarmTypeMetricAlarm}
@@ -83,10 +75,6 @@ func (l *listResourceMetricAlarm) List(ctx context.Context, request list.ListReq
 			}
 		}
 	}
-}
-
-type listMetricAlarmModel struct {
-	framework.WithRegionModel
 }
 
 func listMetricAlarms(ctx context.Context, conn *cloudwatch.Client, input *cloudwatch.DescribeAlarmsInput) iter.Seq2[awstypes.MetricAlarm, error] {

--- a/internal/service/codebuild/project_list.go
+++ b/internal/service/codebuild/project_list.go
@@ -31,21 +31,9 @@ type projectListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type projectListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *projectListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.CodeBuildClient(ctx)
-
-	var query projectListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	var input codebuild.ListProjectsInput
 

--- a/internal/service/codepipeline/codepipeline_list.go
+++ b/internal/service/codepipeline/codepipeline_list.go
@@ -36,21 +36,9 @@ type pipelineListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type pipelineListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *pipelineListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.CodePipelineClient(ctx)
-
-	var query pipelineListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	var input codepipeline.ListPipelinesInput
 

--- a/internal/service/configservice/config_rule_list.go
+++ b/internal/service/configservice/config_rule_list.go
@@ -36,14 +36,6 @@ type configRuleListResource struct {
 func (l *configRuleListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ConfigServiceClient(ctx)
 
-	var query listConfigRuleModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input configservice.DescribeConfigRulesInput
 		for item, err := range listConfigRules(ctx, conn, &input) {
@@ -84,10 +76,6 @@ func (l *configRuleListResource) List(ctx context.Context, request list.ListRequ
 			}
 		}
 	}
-}
-
-type listConfigRuleModel struct {
-	framework.WithRegionModel
 }
 
 func listConfigRules(ctx context.Context, conn *configservice.Client, input *configservice.DescribeConfigRulesInput) iter.Seq2[awstypes.ConfigRule, error] {

--- a/internal/service/dynamodb/table_list.go
+++ b/internal/service/dynamodb/table_list.go
@@ -30,21 +30,9 @@ type tableListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type tableListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *tableListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.DynamoDBClient(ctx)
-
-	var query tableListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	tflog.Info(ctx, "Listing DynamoDB tables")
 	stream.Results = func(yield func(list.ListResult) bool) {

--- a/internal/service/ec2/ec2_secondary_network_list.go
+++ b/internal/service/ec2/ec2_secondary_network_list.go
@@ -32,14 +32,6 @@ type secondaryNetworkListResource struct {
 func (r *secondaryNetworkListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := r.Meta().EC2Client(ctx)
 
-	var query listSecondaryNetworkModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		result := request.NewListResult(ctx)
 		var input ec2.DescribeSecondaryNetworksInput
@@ -72,10 +64,6 @@ func (r *secondaryNetworkListResource) List(ctx context.Context, request list.Li
 			}
 		}
 	}
-}
-
-type listSecondaryNetworkModel struct {
-	framework.WithRegionModel
 }
 
 func listSecondaryNetworks(ctx context.Context, conn *ec2.Client, input *ec2.DescribeSecondaryNetworksInput) iter.Seq2[awstypes.SecondaryNetwork, error] {

--- a/internal/service/ec2/transitgateway_metering_policy_list.go
+++ b/internal/service/ec2/transitgateway_metering_policy_list.go
@@ -33,14 +33,6 @@ func (l *transitGatewayMeteringPolicyListResource) List(ctx context.Context, req
 	c := l.Meta()
 	conn := c.EC2Client(ctx)
 
-	var query listTransitGatewayMeteringPolicyModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing EC2 Transit Gateway Metering Policies")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -72,8 +64,4 @@ func (l *transitGatewayMeteringPolicyListResource) List(ctx context.Context, req
 			}
 		}
 	}
-}
-
-type listTransitGatewayMeteringPolicyModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/ecr/repository_list.go
+++ b/internal/service/ecr/repository_list.go
@@ -31,17 +31,7 @@ type repositoryListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type repositoryListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *repositoryListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query repositoryListResourceModel
-	if diags := request.Config.Get(ctx, &query); diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
 	awsClient := l.Meta()
 	conn := awsClient.ECRClient(ctx)
 

--- a/internal/service/ecr/repository_policy_list.go
+++ b/internal/service/ecr/repository_policy_list.go
@@ -32,17 +32,7 @@ type repositoryPolicyListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type repositoryPolicyListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *repositoryPolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query repositoryPolicyListResourceModel
-	if diags := request.Config.Get(ctx, &query); diags.HasError() {
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
-		return
-	}
-
 	conn := l.Meta().ECRClient(ctx)
 
 	tflog.Info(ctx, "Listing ECR repository policies")

--- a/internal/service/ecs/cluster_list.go
+++ b/internal/service/ecs/cluster_list.go
@@ -35,14 +35,6 @@ type listResourceCluster struct {
 func (l *listResourceCluster) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ECSClient(ctx)
 
-	var query listClusterModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing ECS (Elastic Container) Cluster")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input ecs.ListClustersInput
@@ -94,10 +86,6 @@ func (l *listResourceCluster) List(ctx context.Context, request list.ListRequest
 			}
 		}
 	}
-}
-
-type listClusterModel struct {
-	framework.WithRegionModel
 }
 
 func listClusterARNs(ctx context.Context, conn *ecs.Client, input *ecs.ListClustersInput) iter.Seq2[string, error] {

--- a/internal/service/ecs/daemon_task_definition_list.go
+++ b/internal/service/ecs/daemon_task_definition_list.go
@@ -39,15 +39,6 @@ func (r *listResourceDaemonTaskDefinition) ListResourceConfigSchema(_ context.Co
 }
 
 func (r *listResourceDaemonTaskDefinition) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query daemonTaskDefinitionListModel
-
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	awsClient := r.Meta()
 	conn := awsClient.ECSClient(ctx)
 
@@ -116,8 +107,4 @@ func listDaemonTaskDefinitionSummaries(ctx context.Context, conn *ecs.Client, in
 			return
 		}
 	}
-}
-
-type daemonTaskDefinitionListModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/ecs/task_definition_list.go
+++ b/internal/service/ecs/task_definition_list.go
@@ -35,14 +35,6 @@ type listResourceTaskDefinition struct {
 func (l *listResourceTaskDefinition) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ECSClient(ctx)
 
-	var query listTaskDefinitionModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing ECS (Elastic Container) Task Definition")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input ecs.ListTaskDefinitionsInput
@@ -96,10 +88,6 @@ func (l *listResourceTaskDefinition) List(ctx context.Context, request list.List
 			}
 		}
 	}
-}
-
-type listTaskDefinitionModel struct {
-	framework.WithRegionModel
 }
 
 func listTaskDefinitions(ctx context.Context, conn *ecs.Client, input *ecs.ListTaskDefinitionsInput) iter.Seq2[string, error] {

--- a/internal/service/eks/cluster_list.go
+++ b/internal/service/eks/cluster_list.go
@@ -34,14 +34,6 @@ type clusterListResource struct {
 func (l *clusterListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().EKSClient(ctx)
 
-	var query listClusterModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input eks.ListClustersInput
 		for item, err := range listClusters(ctx, conn, &input) {
@@ -90,10 +82,6 @@ func (l *clusterListResource) List(ctx context.Context, request list.ListRequest
 			}
 		}
 	}
-}
-
-type listClusterModel struct {
-	framework.WithRegionModel
 }
 
 func listClusters(ctx context.Context, conn *eks.Client, input *eks.ListClustersInput) iter.Seq2[string, error] {

--- a/internal/service/elb/load_balancer_list.go
+++ b/internal/service/elb/load_balancer_list.go
@@ -37,14 +37,6 @@ type listResourceLoadBalancer struct {
 func (l *listResourceLoadBalancer) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ELBClient(ctx)
 
-	var query listLoadBalancerModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing ELB Classic Load Balancer")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input elasticloadbalancing.DescribeLoadBalancersInput
@@ -97,10 +89,6 @@ func (l *listResourceLoadBalancer) List(ctx context.Context, request list.ListRe
 			}
 		}
 	}
-}
-
-type listLoadBalancerModel struct {
-	framework.WithRegionModel
 }
 
 func listLoadBalancers(ctx context.Context, conn *elasticloadbalancing.Client, input *elasticloadbalancing.DescribeLoadBalancersInput) iter.Seq2[awstypes.LoadBalancerDescription, error] {

--- a/internal/service/elbv2/load_balancer_list.go
+++ b/internal/service/elbv2/load_balancer_list.go
@@ -35,14 +35,6 @@ type listResourceLoadBalancer struct {
 func (l *listResourceLoadBalancer) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ELBV2Client(ctx)
 
-	var query listLoadBalancerModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Resources")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -105,8 +97,4 @@ func (l *listResourceLoadBalancer) List(ctx context.Context, request list.ListRe
 			}
 		}
 	}
-}
-
-type listLoadBalancerModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/elbv2/target_group_list.go
+++ b/internal/service/elbv2/target_group_list.go
@@ -35,14 +35,6 @@ type listResourceTargetGroup struct {
 func (l *listResourceTargetGroup) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ELBV2Client(ctx)
 
-	var query listTargetGroupModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "ListingResources")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -104,8 +96,4 @@ func (l *listResourceTargetGroup) List(ctx context.Context, request list.ListReq
 			}
 		}
 	}
-}
-
-type listTargetGroupModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/events/rule_list.go
+++ b/internal/service/events/rule_list.go
@@ -36,14 +36,6 @@ type listResourceRule struct {
 func (l *listResourceRule) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().EventsClient(ctx)
 
-	var query listRuleModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing EventBridge Rule")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input eventbridge.ListRulesInput
@@ -92,10 +84,6 @@ func (l *listResourceRule) List(ctx context.Context, request list.ListRequest, s
 			}
 		}
 	}
-}
-
-type listRuleModel struct {
-	framework.WithRegionModel
 }
 
 func listRules(ctx context.Context, conn *eventbridge.Client, input *eventbridge.ListRulesInput) iter.Seq2[awstypes.Rule, error] {

--- a/internal/service/glue/catalog_list.go
+++ b/internal/service/glue/catalog_list.go
@@ -32,21 +32,9 @@ type catalogListResource struct {
 	framework.WithList
 }
 
-type catalogListModel struct {
-	framework.WithRegionModel
-}
-
 func (r *catalogListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := r.Meta()
 	conn := awsClient.GlueClient(ctx)
-
-	var query catalogListModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	stream.Results = func(yield func(list.ListResult) bool) {
 		result := request.NewListResult(ctx)

--- a/internal/service/glue/job_list.go
+++ b/internal/service/glue/job_list.go
@@ -33,21 +33,9 @@ type jobListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type listJobModel struct {
-	framework.WithRegionModel
-}
-
 func (l *jobListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.GlueClient(ctx)
-
-	var query listJobModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	tflog.Info(ctx, "Listing Glue jobs")
 	stream.Results = func(yield func(list.ListResult) bool) {

--- a/internal/service/iam/group_policy_attachment_list.go
+++ b/internal/service/iam/group_policy_attachment_list.go
@@ -32,19 +32,8 @@ type groupPolicyAttachmentListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type listGroupPolicyAttachmentModel struct {
-}
-
 func (l *groupPolicyAttachmentListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().IAMClient(ctx)
-
-	var query listGroupPolicyAttachmentModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	var input iam.ListGroupsInput
 	tflog.Info(ctx, "Listing Resources")

--- a/internal/service/kafka/cluster_list.go
+++ b/internal/service/kafka/cluster_list.go
@@ -36,14 +36,6 @@ type clusterListResource struct {
 func (l *clusterListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().KafkaClient(ctx)
 
-	var query listClusterModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input kafka.ListClustersInput
 		for item, err := range listClusters(ctx, conn, &input) {
@@ -93,10 +85,6 @@ func (l *clusterListResource) List(ctx context.Context, request list.ListRequest
 			}
 		}
 	}
-}
-
-type listClusterModel struct {
-	framework.WithRegionModel
 }
 
 func listClusters(ctx context.Context, conn *kafka.Client, input *kafka.ListClustersInput) iter.Seq2[awstypes.ClusterInfo, error] {

--- a/internal/service/kafka/serverless_cluster_list.go
+++ b/internal/service/kafka/serverless_cluster_list.go
@@ -37,14 +37,6 @@ type serverlessClusterListResource struct {
 func (l *serverlessClusterListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().KafkaClient(ctx)
 
-	var query listServerlessClusterModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		input := kafka.ListClustersV2Input{
 			ClusterTypeFilter: aws.String("SERVERLESS"),
@@ -101,10 +93,6 @@ func (l *serverlessClusterListResource) List(ctx context.Context, request list.L
 			}
 		}
 	}
-}
-
-type listServerlessClusterModel struct {
-	framework.WithRegionModel
 }
 
 func listServerlessClusters(ctx context.Context, conn *kafka.Client, input *kafka.ListClustersV2Input) iter.Seq2[awstypes.Cluster, error] {

--- a/internal/service/kms/alias_list.go
+++ b/internal/service/kms/alias_list.go
@@ -32,19 +32,7 @@ type aliasListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type aliasListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *aliasListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query aliasListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	awsClient := l.Meta()
 	conn := awsClient.KMSClient(ctx)
 

--- a/internal/service/kms/key_list.go
+++ b/internal/service/kms/key_list.go
@@ -31,19 +31,7 @@ type keyListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type keyListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *keyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query keyListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	awsClient := l.Meta()
 	conn := awsClient.KMSClient(ctx)
 

--- a/internal/service/lambda/capacity_provider_list.go
+++ b/internal/service/lambda/capacity_provider_list.go
@@ -32,15 +32,6 @@ type listResourceCapacityProvider struct {
 
 func (r *listResourceCapacityProvider) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := r.Meta().LambdaClient(ctx)
-	var query capacityProviderListModel
-
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		result := request.NewListResult(ctx)
 		var input lambda.ListCapacityProvidersInput
@@ -85,10 +76,6 @@ func (r *listResourceCapacityProvider) List(ctx context.Context, request list.Li
 			}
 		}
 	}
-}
-
-type capacityProviderListModel struct {
-	framework.WithRegionModel
 }
 
 func listCapacityProviders(ctx context.Context, conn *lambda.Client, input *lambda.ListCapacityProvidersInput) iter.Seq2[awstypes.CapacityProvider, error] {

--- a/internal/service/lambda/event_source_mapping_list.go
+++ b/internal/service/lambda/event_source_mapping_list.go
@@ -36,14 +36,6 @@ type eventSourceMappingListResource struct {
 func (l *eventSourceMappingListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().LambdaClient(ctx)
 
-	var query listEventSourceMappingModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Lambda Event Source Mappings")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -96,10 +88,6 @@ func (l *eventSourceMappingListResource) List(ctx context.Context, request list.
 			}
 		}
 	}
-}
-
-type listEventSourceMappingModel struct {
-	framework.WithRegionModel
 }
 
 func listEventSourceMappings(ctx context.Context, conn *lambda.Client, input *lambda.ListEventSourceMappingsInput) iter.Seq2[awstypes.EventSourceMappingConfiguration, error] {

--- a/internal/service/lambda/function_list.go
+++ b/internal/service/lambda/function_list.go
@@ -38,14 +38,6 @@ type listResourceFunction struct {
 func (l *listResourceFunction) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().LambdaClient(ctx)
 
-	var query listFunctionModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Lambda Functions")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input lambda.ListFunctionsInput
@@ -97,10 +89,6 @@ func (l *listResourceFunction) List(ctx context.Context, request list.ListReques
 			}
 		}
 	}
-}
-
-type listFunctionModel struct {
-	framework.WithRegionModel
 }
 
 func listFunctions(ctx context.Context, conn *lambda.Client, input *lambda.ListFunctionsInput, optFns ...func(*lambda.Options)) iter.Seq2[awstypes.FunctionConfiguration, error] {

--- a/internal/service/lambda/function_scaling_config_list.go
+++ b/internal/service/lambda/function_scaling_config_list.go
@@ -35,14 +35,6 @@ type listResourceFunctionScalingConfig struct {
 func (r *listResourceFunctionScalingConfig) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := r.Meta().LambdaClient(ctx)
 
-	var query functionScalingConfigListModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		// Scaling configurations only apply to functions using a capacity provider,
 		// so enumerate capacity providers, then the function versions attached to
@@ -124,10 +116,6 @@ func (r *listResourceFunctionScalingConfig) List(ctx context.Context, request li
 			}
 		}
 	}
-}
-
-type functionScalingConfigListModel struct {
-	framework.WithRegionModel
 }
 
 func listFunctionVersionsByCapacityProvider(ctx context.Context, conn *lambda.Client, capacityProviderName string) iter.Seq2[awstypes.FunctionVersionsByCapacityProviderListItem, error] {

--- a/internal/service/lambda/layer_version_list.go
+++ b/internal/service/lambda/layer_version_list.go
@@ -34,21 +34,9 @@ type layerVersionListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type layerVersionListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *layerVersionListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.LambdaClient(ctx)
-
-	var query layerVersionListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	tflog.Info(ctx, "Listing Lambda Layer Versions")
 

--- a/internal/service/lambdacore/network_connector_list.go
+++ b/internal/service/lambdacore/network_connector_list.go
@@ -37,14 +37,6 @@ type networkConnectorListResource struct {
 func (l *networkConnectorListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().LambdaCoreClient(ctx)
 
-	var query listNetworkConnectorModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input lambdacore.ListNetworkConnectorsInput
 		for item, err := range listNetworkConnectors(ctx, conn, &input) {
@@ -91,10 +83,6 @@ func (l *networkConnectorListResource) List(ctx context.Context, request list.Li
 			}
 		}
 	}
-}
-
-type listNetworkConnectorModel struct {
-	framework.WithRegionModel
 }
 
 func listNetworkConnectors(ctx context.Context, conn *lambdacore.Client, input *lambdacore.ListNetworkConnectorsInput, optFns ...func(*lambdacore.Options)) iter.Seq2[awstypes.NetworkConnectorSummary, error] {

--- a/internal/service/logs/group_list.go
+++ b/internal/service/logs/group_list.go
@@ -29,21 +29,9 @@ type logGroupListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type logGroupListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *logGroupListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.LogsClient(ctx)
-
-	var query logGroupListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	stream.Results = func(yield func(list.ListResult) bool) {
 		result := request.NewListResult(ctx)

--- a/internal/service/mailmanager/archive_list.go
+++ b/internal/service/mailmanager/archive_list.go
@@ -33,20 +33,8 @@ type archiveListResource struct {
 	framework.WithList
 }
 
-type listArchiveModel struct {
-	framework.WithRegionModel
-}
-
 func (l *archiveListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().MailManagerClient(ctx)
-
-	var query listArchiveModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input mailmanager.ListArchivesInput

--- a/internal/service/mailmanager/ingress_point_list.go
+++ b/internal/service/mailmanager/ingress_point_list.go
@@ -35,20 +35,8 @@ type ingressPointListResource struct {
 	framework.WithList
 }
 
-type listIngressPointModel struct {
-	framework.WithRegionModel
-}
-
 func (l *ingressPointListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().MailManagerClient(ctx)
-
-	var query listIngressPointModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input mailmanager.ListIngressPointsInput

--- a/internal/service/mailmanager/relay_list.go
+++ b/internal/service/mailmanager/relay_list.go
@@ -34,20 +34,8 @@ type relayListResource struct {
 	framework.WithList
 }
 
-type listRelayModel struct {
-	framework.WithRegionModel
-}
-
 func (l *relayListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().MailManagerClient(ctx)
-
-	var query listRelayModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input mailmanager.ListRelaysInput

--- a/internal/service/mailmanager/rule_set_list.go
+++ b/internal/service/mailmanager/rule_set_list.go
@@ -36,20 +36,8 @@ type ruleSetListResource struct {
 	framework.WithList
 }
 
-type listRuleSetModel struct {
-	framework.WithRegionModel
-}
-
 func (l *ruleSetListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().MailManagerClient(ctx)
-
-	var query listRuleSetModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input mailmanager.ListRuleSetsInput

--- a/internal/service/mailmanager/traffic_policy_list.go
+++ b/internal/service/mailmanager/traffic_policy_list.go
@@ -35,20 +35,8 @@ type trafficPolicyListResource struct {
 	framework.WithList
 }
 
-type listTrafficPolicyModel struct {
-	framework.WithRegionModel
-}
-
 func (l *trafficPolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().MailManagerClient(ctx)
-
-	var query listTrafficPolicyModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input mailmanager.ListTrafficPoliciesInput

--- a/internal/service/networkfirewall/container_association_list.go
+++ b/internal/service/networkfirewall/container_association_list.go
@@ -37,14 +37,6 @@ type containerAssociationListResource struct {
 func (l *containerAssociationListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().NetworkFirewallClient(ctx)
 
-	var query listContainerAssociationModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing resources")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -98,10 +90,6 @@ func (l *containerAssociationListResource) List(ctx context.Context, request lis
 			}
 		}
 	}
-}
-
-type listContainerAssociationModel struct {
-	framework.WithRegionModel
 }
 
 func listContainerAssociations(ctx context.Context, conn *networkfirewall.Client, input *networkfirewall.ListContainerAssociationsInput, optFns ...func(*networkfirewall.Options)) iter.Seq2[awstypes.ContainerAssociationSummary, error] {

--- a/internal/service/observabilityadmin/telemetry_rule_for_organization_list.go
+++ b/internal/service/observabilityadmin/telemetry_rule_for_organization_list.go
@@ -35,14 +35,6 @@ type telemetryRuleForOrganizationListResource struct {
 func (l *telemetryRuleForOrganizationListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ObservabilityAdminClient(ctx)
 
-	var query listTelemetryRuleForOrganizationModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input observabilityadmin.ListTelemetryRulesForOrganizationInput
 		for item, err := range listTelemetryRulesForOrganization(ctx, conn, &input) {
@@ -80,10 +72,6 @@ func (l *telemetryRuleForOrganizationListResource) List(ctx context.Context, req
 			}
 		}
 	}
-}
-
-type listTelemetryRuleForOrganizationModel struct {
-	framework.WithRegionModel
 }
 
 func listTelemetryRulesForOrganization(ctx context.Context, conn *observabilityadmin.Client, input *observabilityadmin.ListTelemetryRulesForOrganizationInput) iter.Seq2[awstypes.TelemetryRuleSummary, error] {

--- a/internal/service/observabilityadmin/telemetry_rule_list.go
+++ b/internal/service/observabilityadmin/telemetry_rule_list.go
@@ -35,14 +35,6 @@ type telemetryRuleListResource struct {
 func (l *telemetryRuleListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ObservabilityAdminClient(ctx)
 
-	var query listTelemetryRuleModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input observabilityadmin.ListTelemetryRulesInput
 		for item, err := range listTelemetryRules(ctx, conn, &input) {
@@ -80,10 +72,6 @@ func (l *telemetryRuleListResource) List(ctx context.Context, request list.ListR
 			}
 		}
 	}
-}
-
-type listTelemetryRuleModel struct {
-	framework.WithRegionModel
 }
 
 func listTelemetryRules(ctx context.Context, conn *observabilityadmin.Client, input *observabilityadmin.ListTelemetryRulesInput) iter.Seq2[awstypes.TelemetryRuleSummary, error] {

--- a/internal/service/opensearchserverless/collection_group_list.go
+++ b/internal/service/opensearchserverless/collection_group_list.go
@@ -40,14 +40,6 @@ func (l *collectionGroupListResource) List(ctx context.Context, request list.Lis
 	awsClient := l.Meta()
 	conn := awsClient.OpenSearchServerlessClient(ctx)
 
-	var query listCollectionGroupModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input opensearchserverless.ListCollectionGroupsInput
 
@@ -105,10 +97,6 @@ func (l *collectionGroupListResource) List(ctx context.Context, request list.Lis
 			}
 		}
 	}
-}
-
-type listCollectionGroupModel struct {
-	framework.WithRegionModel
 }
 
 func listCollectionGroups(ctx context.Context, conn *opensearchserverless.Client, input *opensearchserverless.ListCollectionGroupsInput) iter.Seq2[awstypes.CollectionGroupSummary, error] {

--- a/internal/service/opensearchserverless/collection_list.go
+++ b/internal/service/opensearchserverless/collection_list.go
@@ -31,15 +31,6 @@ type collectionListResource struct {
 }
 
 func (r *collectionListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query listCollectionModel
-
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	awsClient := r.Meta()
 	conn := awsClient.OpenSearchServerlessClient(ctx)
 
@@ -84,10 +75,6 @@ func (r *collectionListResource) List(ctx context.Context, request list.ListRequ
 			}
 		}
 	}
-}
-
-type listCollectionModel struct {
-	framework.WithRegionModel
 }
 
 func listCollections(ctx context.Context, conn *opensearchserverless.Client, input *opensearchserverless.ListCollectionsInput) iter.Seq2[awstypes.CollectionSummary, error] {

--- a/internal/service/opensearchserverless/vpc_endpoint_list.go
+++ b/internal/service/opensearchserverless/vpc_endpoint_list.go
@@ -38,14 +38,6 @@ func (l *vpcEndpointListResource) List(ctx context.Context, request list.ListReq
 	awsClient := l.Meta()
 	conn := awsClient.OpenSearchServerlessClient(ctx)
 
-	var query listVPCEndpointModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input opensearchserverless.ListVpcEndpointsInput
 
@@ -98,10 +90,6 @@ func (l *vpcEndpointListResource) List(ctx context.Context, request list.ListReq
 			}
 		}
 	}
-}
-
-type listVPCEndpointModel struct {
-	framework.WithRegionModel
 }
 
 func listVPCEndpoints(ctx context.Context, conn *opensearchserverless.Client, input *opensearchserverless.ListVpcEndpointsInput) iter.Seq2[awstypes.VpcEndpointSummary, error] {

--- a/internal/service/organizations/aws_service_access_list.go
+++ b/internal/service/organizations/aws_service_access_list.go
@@ -30,14 +30,6 @@ type awsServiceAccessListResource struct {
 func (l *awsServiceAccessListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().OrganizationsClient(ctx)
 
-	var query listAWSServiceAccessModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input organizations.ListAWSServiceAccessForOrganizationInput
 		for item, err := range listEnabledServicePrincipals(ctx, conn, &input) {
@@ -68,5 +60,3 @@ func (l *awsServiceAccessListResource) List(ctx context.Context, request list.Li
 		}
 	}
 }
-
-type listAWSServiceAccessModel struct{}

--- a/internal/service/osis/pipeline_endpoint_list.go
+++ b/internal/service/osis/pipeline_endpoint_list.go
@@ -35,14 +35,6 @@ type pipelineEndpointListResource struct {
 func (l *pipelineEndpointListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().OpenSearchIngestionClient(ctx)
 
-	var query listPipelineEndpointModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input osis.ListPipelineEndpointsInput
 		for item, err := range listPipelineEndpoints(ctx, conn, &input) {
@@ -72,10 +64,6 @@ func (l *pipelineEndpointListResource) List(ctx context.Context, request list.Li
 			}
 		}
 	}
-}
-
-type listPipelineEndpointModel struct {
-	framework.WithRegionModel
 }
 
 func listPipelineEndpoints(ctx context.Context, conn *osis.Client, input *osis.ListPipelineEndpointsInput) iter.Seq2[awstypes.PipelineEndpoint, error] {

--- a/internal/service/osis/pipeline_list.go
+++ b/internal/service/osis/pipeline_list.go
@@ -37,14 +37,6 @@ type pipelineListResource struct {
 func (l *pipelineListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().OpenSearchIngestionClient(ctx)
 
-	var query listPipelineModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input osis.ListPipelinesInput
 		for item, err := range listPipelines(ctx, conn, &input) {
@@ -83,10 +75,6 @@ func (l *pipelineListResource) List(ctx context.Context, request list.ListReques
 			}
 		}
 	}
-}
-
-type listPipelineModel struct {
-	framework.WithRegionModel
 }
 
 func listPipelines(ctx context.Context, conn *osis.Client, input *osis.ListPipelinesInput) iter.Seq2[awstypes.PipelineSummary, error] {

--- a/internal/service/osis/resource_policy_list.go
+++ b/internal/service/osis/resource_policy_list.go
@@ -37,14 +37,6 @@ type resourcePolicyListResource struct {
 func (l *resourcePolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().OpenSearchIngestionClient(ctx)
 
-	var query listResourcePolicyModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input osis.ListPipelinesInput
 		for output, err := range listResourcePolicies(ctx, conn, &input) {
@@ -74,10 +66,6 @@ func (l *resourcePolicyListResource) List(ctx context.Context, request list.List
 			}
 		}
 	}
-}
-
-type listResourcePolicyModel struct {
-	framework.WithRegionModel
 }
 
 func listResourcePolicies(ctx context.Context, conn *osis.Client, input *osis.ListPipelinesInput) iter.Seq2[*osis.GetResourcePolicyOutput, error] {

--- a/internal/service/pinpointsmsvoicev2/pool_list.go
+++ b/internal/service/pinpointsmsvoicev2/pool_list.go
@@ -34,14 +34,6 @@ type poolListResource struct {
 func (l *poolListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().PinpointSMSVoiceV2Client(ctx)
 
-	var query listPoolModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing End User Messaging SMS Pools")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -92,8 +84,4 @@ func (l *poolListResource) List(ctx context.Context, request list.ListRequest, s
 			}
 		}
 	}
-}
-
-type listPoolModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/pinpointsmsvoicev2/sender_id_list.go
+++ b/internal/service/pinpointsmsvoicev2/sender_id_list.go
@@ -31,14 +31,6 @@ type senderIDListResource struct {
 func (l *senderIDListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().PinpointSMSVoiceV2Client(ctx)
 
-	var query listSenderIDModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing End User Messaging SMS Sender IDs")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -75,8 +67,4 @@ func (l *senderIDListResource) List(ctx context.Context, request list.ListReques
 			}
 		}
 	}
-}
-
-type listSenderIDModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/rds/subnet_group_list.go
+++ b/internal/service/rds/subnet_group_list.go
@@ -34,21 +34,9 @@ type subnetGroupListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type subnetGroupListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *subnetGroupListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.RDSClient(ctx)
-
-	var query subnetGroupListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	tflog.Info(ctx, "Listing RDS DB Subnet Groups")
 

--- a/internal/service/resiliencehubv2/policy_list.go
+++ b/internal/service/resiliencehubv2/policy_list.go
@@ -38,14 +38,6 @@ type policyListResource struct {
 func (l *policyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ResilienceHubV2Client(ctx)
 
-	var query listPolicyModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input resiliencehubv2.ListPoliciesInput
 		for item, err := range listPolicies(ctx, conn, &input) {
@@ -96,10 +88,6 @@ func (l *policyListResource) List(ctx context.Context, request list.ListRequest,
 			}
 		}
 	}
-}
-
-type listPolicyModel struct {
-	framework.WithRegionModel
 }
 
 func listPolicies(ctx context.Context, conn *resiliencehubv2.Client, input *resiliencehubv2.ListPoliciesInput, optFns ...func(*resiliencehubv2.Options)) iter.Seq2[awstypes.PolicySummary, error] {

--- a/internal/service/resiliencehubv2/service_list.go
+++ b/internal/service/resiliencehubv2/service_list.go
@@ -38,14 +38,6 @@ type serviceListResource struct {
 func (l *serviceListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ResilienceHubV2Client(ctx)
 
-	var query listServiceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input resiliencehubv2.ListServicesInput
 		for item, err := range listServices(ctx, conn, &input) {
@@ -96,10 +88,6 @@ func (l *serviceListResource) List(ctx context.Context, request list.ListRequest
 			}
 		}
 	}
-}
-
-type listServiceModel struct {
-	framework.WithRegionModel
 }
 
 func listServices(ctx context.Context, conn *resiliencehubv2.Client, input *resiliencehubv2.ListServicesInput, optFns ...func(*resiliencehubv2.Options)) iter.Seq2[awstypes.ServiceSummary, error] {

--- a/internal/service/resiliencehubv2/system_list.go
+++ b/internal/service/resiliencehubv2/system_list.go
@@ -38,14 +38,6 @@ type systemListResource struct {
 func (l *systemListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().ResilienceHubV2Client(ctx)
 
-	var query listSystemModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input resiliencehubv2.ListSystemsInput
 		for item, err := range listSystems(ctx, conn, &input) {
@@ -96,10 +88,6 @@ func (l *systemListResource) List(ctx context.Context, request list.ListRequest,
 			}
 		}
 	}
-}
-
-type listSystemModel struct {
-	framework.WithRegionModel
 }
 
 func listSystems(ctx context.Context, conn *resiliencehubv2.Client, input *resiliencehubv2.ListSystemsInput, optFns ...func(*resiliencehubv2.Options)) iter.Seq2[awstypes.SystemSummary, error] {

--- a/internal/service/route53resolver/rule_association_list.go
+++ b/internal/service/route53resolver/rule_association_list.go
@@ -37,14 +37,6 @@ type listResourceRuleAssociation struct {
 func (l *listResourceRuleAssociation) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().Route53ResolverClient(ctx)
 
-	var query listRuleAssociationModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Route 53 Resolver Rule Association")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input route53resolver.ListResolverRuleAssociationsInput
@@ -83,10 +75,6 @@ func (l *listResourceRuleAssociation) List(ctx context.Context, request list.Lis
 			}
 		}
 	}
-}
-
-type listRuleAssociationModel struct {
-	framework.WithRegionModel
 }
 
 func listResolverRuleAssociations(ctx context.Context, conn *route53resolver.Client, input *route53resolver.ListResolverRuleAssociationsInput) iter.Seq2[awstypes.ResolverRuleAssociation, error] {

--- a/internal/service/route53resolver/rule_list.go
+++ b/internal/service/route53resolver/rule_list.go
@@ -33,21 +33,9 @@ type listResourceRule struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type listRuleModel struct {
-	framework.WithRegionModel
-}
-
 func (l *listResourceRule) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.Route53ResolverClient(ctx)
-
-	var query listRuleModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	tflog.Info(ctx, "Listing Route 53 Resolver Rules")
 	stream.Results = func(yield func(list.ListResult) bool) {

--- a/internal/service/s3/bucket_acl_list.go
+++ b/internal/service/s3/bucket_acl_list.go
@@ -35,14 +35,6 @@ type listResourceBucketACL struct {
 func (l *listResourceBucketACL) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().S3Client(ctx)
 
-	var query listBucketACLModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing S3 Bucket ACL")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		input := s3.ListBucketsInput{
@@ -97,8 +89,4 @@ func (l *listResourceBucketACL) List(ctx context.Context, request list.ListReque
 			}
 		}
 	}
-}
-
-type listBucketACLModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/s3/bucket_list.go
+++ b/internal/service/s3/bucket_list.go
@@ -38,14 +38,6 @@ type listResourceBucket struct {
 func (l *listResourceBucket) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().S3Client(ctx)
 
-	var query listBucketModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Resources")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -100,10 +92,6 @@ func (l *listResourceBucket) List(ctx context.Context, request list.ListRequest,
 			}
 		}
 	}
-}
-
-type listBucketModel struct {
-	framework.WithRegionModel
 }
 
 func listBuckets(ctx context.Context, conn *s3.Client, input *s3.ListBucketsInput) iter.Seq2[awstypes.Bucket, error] {

--- a/internal/service/s3/bucket_logging_list.go
+++ b/internal/service/s3/bucket_logging_list.go
@@ -36,14 +36,6 @@ type bucketLoggingListResource struct {
 func (l *bucketLoggingListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().S3Client(ctx)
 
-	var query listBucketLoggingModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing S3 Bucket Logging")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -103,8 +95,4 @@ func (l *bucketLoggingListResource) List(ctx context.Context, request list.ListR
 			}
 		}
 	}
-}
-
-type listBucketLoggingModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/s3/bucket_notification_list.go
+++ b/internal/service/s3/bucket_notification_list.go
@@ -36,14 +36,6 @@ type bucketNotificationListResource struct {
 func (l *bucketNotificationListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().S3Client(ctx)
 
-	var query listBucketNotificationModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing S3 Bucket Notifications")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -109,8 +101,4 @@ func (l *bucketNotificationListResource) List(ctx context.Context, request list.
 			}
 		}
 	}
-}
-
-type listBucketNotificationModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/s3/bucket_public_access_block_list.go
+++ b/internal/service/s3/bucket_public_access_block_list.go
@@ -35,14 +35,6 @@ type listResourceBucketPublicAccessBlock struct {
 func (l *listResourceBucketPublicAccessBlock) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().S3Client(ctx)
 
-	var query listBucketPublicAccessBlockModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Resources")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -99,8 +91,4 @@ func (l *listResourceBucketPublicAccessBlock) List(ctx context.Context, request 
 			}
 		}
 	}
-}
-
-type listBucketPublicAccessBlockModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/s3/directory_bucket_list.go
+++ b/internal/service/s3/directory_bucket_list.go
@@ -35,14 +35,6 @@ type directoryBucketListResource struct {
 func (r *directoryBucketListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := r.Meta().S3ExpressClient(ctx)
 
-	var query listDirectoryBucketModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		result := request.NewListResult(ctx)
 		var input s3.ListDirectoryBucketsInput
@@ -83,10 +75,6 @@ func (r *directoryBucketListResource) List(ctx context.Context, request list.Lis
 			}
 		}
 	}
-}
-
-type listDirectoryBucketModel struct {
-	framework.WithRegionModel
 }
 
 func listDirectoryBuckets(ctx context.Context, conn *s3.Client, input *s3.ListDirectoryBucketsInput) iter.Seq2[awstypes.Bucket, error] {

--- a/internal/service/s3control/multi_region_access_point_list.go
+++ b/internal/service/s3control/multi_region_access_point_list.go
@@ -34,19 +34,7 @@ type multiRegionAccessPointListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type multiRegionAccessPointListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *multiRegionAccessPointListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query multiRegionAccessPointListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	awsClient := l.Meta()
 	conn := awsClient.S3ControlClient(ctx)
 	accountID := awsClient.AccountID(ctx)

--- a/internal/service/s3control/multi_region_access_point_routes_list.go
+++ b/internal/service/s3control/multi_region_access_point_routes_list.go
@@ -29,19 +29,7 @@ type multiRegionAccessPointRoutesListResource struct {
 	framework.WithList
 }
 
-type multiRegionAccessPointRoutesListModel struct {
-	framework.WithRegionModel
-}
-
 func (l *multiRegionAccessPointRoutesListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query multiRegionAccessPointRoutesListModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	awsClient := l.Meta()
 	conn := awsClient.S3ControlClient(ctx)
 	accountID := awsClient.AccountID(ctx)

--- a/internal/service/s3files/file_system_list.go
+++ b/internal/service/s3files/file_system_list.go
@@ -33,14 +33,6 @@ type fileSystemListResource struct {
 func (r *fileSystemListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := r.Meta().S3FilesClient(ctx)
 
-	var query listFileSystemModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		result := request.NewListResult(ctx)
 		input := s3files.ListFileSystemsInput{}
@@ -83,8 +75,4 @@ func (r *fileSystemListResource) List(ctx context.Context, request list.ListRequ
 			}
 		}
 	}
-}
-
-type listFileSystemModel struct {
-	framework.WithRegionModel
 }

--- a/internal/service/sagemaker/algorithm_list.go
+++ b/internal/service/sagemaker/algorithm_list.go
@@ -36,14 +36,6 @@ func (l *algorithmListResource) List(ctx context.Context, request list.ListReque
 	awsClient := l.Meta()
 	conn := awsClient.SageMakerClient(ctx)
 
-	var query listAlgorithmModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing SageMaker Algorithm resources")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -92,10 +84,6 @@ func (l *algorithmListResource) List(ctx context.Context, request list.ListReque
 			}
 		}
 	}
-}
-
-type listAlgorithmModel struct {
-	framework.WithRegionModel
 }
 
 func listAlgorithms(ctx context.Context, conn *sagemaker.Client, input *sagemaker.ListAlgorithmsInput) iter.Seq2[awstypes.AlgorithmSummary, error] {

--- a/internal/service/sagemaker/hyper_parameter_tuning_job_list.go
+++ b/internal/service/sagemaker/hyper_parameter_tuning_job_list.go
@@ -38,14 +38,6 @@ func (l *hyperParameterTuningJobListResource) List(ctx context.Context, request 
 	awsClient := l.Meta()
 	conn := awsClient.SageMakerClient(ctx)
 
-	var query listHyperParameterTuningJobModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing SageMaker Hyper Parameter Tuning Job resources")
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -102,10 +94,6 @@ func (l *hyperParameterTuningJobListResource) List(ctx context.Context, request 
 			}
 		}
 	}
-}
-
-type listHyperParameterTuningJobModel struct {
-	framework.WithRegionModel
 }
 
 func listHyperParameterTuningJobs(ctx context.Context, conn *sagemaker.Client, input *sagemaker.ListHyperParameterTuningJobsInput) iter.Seq2[awstypes.HyperParameterTuningJobSummary, error] {

--- a/internal/service/sagemaker/training_job_list.go
+++ b/internal/service/sagemaker/training_job_list.go
@@ -34,14 +34,6 @@ type trainingJobListResource struct {
 func (l *trainingJobListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().SageMakerClient(ctx)
 
-	var query listTrainingJobModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input sagemaker.ListTrainingJobsInput
 
@@ -92,10 +84,6 @@ func (l *trainingJobListResource) List(ctx context.Context, request list.ListReq
 			}
 		}
 	}
-}
-
-type listTrainingJobModel struct {
-	framework.WithRegionModel
 }
 
 func listTrainingJobs(ctx context.Context, conn *sagemaker.Client, input *sagemaker.ListTrainingJobsInput) iter.Seq2[awstypes.TrainingJobSummary, error] {

--- a/internal/service/scheduler/schedule_list.go
+++ b/internal/service/scheduler/schedule_list.go
@@ -38,14 +38,6 @@ type scheduleListResource struct {
 func (l *scheduleListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().SchedulerClient(ctx)
 
-	var query listScheduleModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Resources", map[string]any{})
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -100,10 +92,6 @@ func (l *scheduleListResource) List(ctx context.Context, request list.ListReques
 			}
 		}
 	}
-}
-
-type listScheduleModel struct {
-	framework.WithRegionModel
 }
 
 func listSchedules(ctx context.Context, conn *scheduler.Client, input *scheduler.ListSchedulesInput) iter.Seq2[awstypes.ScheduleSummary, error] {

--- a/internal/service/secretsmanager/secret_list.go
+++ b/internal/service/secretsmanager/secret_list.go
@@ -37,14 +37,6 @@ type listResourceSecret struct {
 func (l *listResourceSecret) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().SecretsManagerClient(ctx)
 
-	var query listSecretModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Secrets Manager Secret")
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input secretsmanager.ListSecretsInput
@@ -94,10 +86,6 @@ func (l *listResourceSecret) List(ctx context.Context, request list.ListRequest,
 			}
 		}
 	}
-}
-
-type listSecretModel struct {
-	framework.WithRegionModel
 }
 
 func listSecrets(ctx context.Context, conn *secretsmanager.Client, input *secretsmanager.ListSecretsInput) iter.Seq2[awstypes.SecretListEntry, error] {

--- a/internal/service/securityhub/automation_rule_v2_list.go
+++ b/internal/service/securityhub/automation_rule_v2_list.go
@@ -35,14 +35,6 @@ type automationRuleV2ListResource struct {
 func (l *automationRuleV2ListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().SecurityHubClient(ctx)
 
-	var query listAutomationRuleV2Model
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input securityhub.ListAutomationRulesV2Input
 		for item, err := range listAutomationRuleV2s(ctx, conn, &input) {
@@ -79,10 +71,6 @@ func (l *automationRuleV2ListResource) List(ctx context.Context, request list.Li
 			}
 		}
 	}
-}
-
-type listAutomationRuleV2Model struct {
-	framework.WithRegionModel
 }
 
 func listAutomationRuleV2s(ctx context.Context, conn *securityhub.Client, input *securityhub.ListAutomationRulesV2Input) iter.Seq2[awstypes.AutomationRulesMetadataV2, error] {

--- a/internal/service/securityhub/connector_v2_list.go
+++ b/internal/service/securityhub/connector_v2_list.go
@@ -35,14 +35,6 @@ type connectorV2ListResource struct {
 func (l *connectorV2ListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().SecurityHubClient(ctx)
 
-	var query listConnectorV2Model
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input securityhub.ListConnectorsV2Input
 		for item, err := range listConnectorV2s(ctx, conn, &input) {
@@ -80,10 +72,6 @@ func (l *connectorV2ListResource) List(ctx context.Context, request list.ListReq
 			}
 		}
 	}
-}
-
-type listConnectorV2Model struct {
-	framework.WithRegionModel
 }
 
 func listConnectorV2s(ctx context.Context, conn *securityhub.Client, input *securityhub.ListConnectorsV2Input) iter.Seq2[awstypes.ConnectorSummary, error] {

--- a/internal/service/securityhub/insight_list.go
+++ b/internal/service/securityhub/insight_list.go
@@ -36,14 +36,6 @@ type insightListResource struct {
 func (l *insightListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().SecurityHubClient(ctx)
 
-	var query listInsightModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		var input securityhub.GetInsightsInput
 		for item, err := range listInsights(ctx, conn, &input) {
@@ -84,10 +76,6 @@ func (l *insightListResource) List(ctx context.Context, request list.ListRequest
 			}
 		}
 	}
-}
-
-type listInsightModel struct {
-	framework.WithRegionModel
 }
 
 func listInsights(ctx context.Context, conn *securityhub.Client, input *securityhub.GetInsightsInput) iter.Seq2[awstypes.Insight, error] {

--- a/internal/service/sns/topic_list.go
+++ b/internal/service/sns/topic_list.go
@@ -34,20 +34,8 @@ type topicListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type listTopicModel struct {
-	framework.WithRegionModel
-}
-
 func (l *topicListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().SNSClient(ctx)
-
-	var query listTopicModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	tflog.Info(ctx, "Listing SNS Topics")
 	stream.Results = func(yield func(list.ListResult) bool) {

--- a/internal/service/sns/topic_policy_list.go
+++ b/internal/service/sns/topic_policy_list.go
@@ -31,20 +31,8 @@ type topicPolicyListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type listTopicPolicyModel struct {
-	framework.WithRegionModel
-}
-
 func (l *topicPolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().SNSClient(ctx)
-
-	var query listTopicPolicyModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	tflog.Info(ctx, "Listing SNS Topic Policies")
 	stream.Results = func(yield func(list.ListResult) bool) {

--- a/internal/service/sqs/queue_list.go
+++ b/internal/service/sqs/queue_list.go
@@ -30,19 +30,7 @@ type queueListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type queueListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *queueListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
-	var query queueListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	awsClient := l.Meta()
 	conn := awsClient.SQSClient(ctx)
 

--- a/internal/service/sqs/queue_policy_list.go
+++ b/internal/service/sqs/queue_policy_list.go
@@ -36,21 +36,9 @@ type queuePolicyListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type listQueuePolicyModel struct {
-	framework.WithRegionModel
-}
-
 func (l *queuePolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.SQSClient(ctx)
-
-	var query listQueuePolicyModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	h := &queueAttributeHandler{
 		AttributeName: sqstypes.QueueAttributeNamePolicy,

--- a/internal/service/ssm/association_list.go
+++ b/internal/service/ssm/association_list.go
@@ -37,14 +37,6 @@ type associationListResource struct {
 func (l *associationListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().SSMClient(ctx)
 
-	var query listAssociationModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	tflog.Info(ctx, "Listing Resources", map[string]any{})
 
 	stream.Results = func(yield func(list.ListResult) bool) {
@@ -97,10 +89,6 @@ func (l *associationListResource) List(ctx context.Context, request list.ListReq
 			}
 		}
 	}
-}
-
-type listAssociationModel struct {
-	framework.WithRegionModel
 }
 
 func listAssociations(ctx context.Context, conn *ssm.Client, input *ssm.ListAssociationsInput) iter.Seq2[awstypes.Association, error] {

--- a/internal/service/ssm/parameter_list.go
+++ b/internal/service/ssm/parameter_list.go
@@ -31,21 +31,9 @@ type parameterListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type parameterListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *parameterListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.SSMClient(ctx)
-
-	var query parameterListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	var input ssm.DescribeParametersInput
 

--- a/internal/service/ssm/patch_baseline_list.go
+++ b/internal/service/ssm/patch_baseline_list.go
@@ -34,21 +34,9 @@ type patchBaselineListResource struct {
 	framework.ListResourceWithSDKv2Resource
 }
 
-type patchBaselineListResourceModel struct {
-	framework.WithRegionModel
-}
-
 func (l *patchBaselineListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	awsClient := l.Meta()
 	conn := awsClient.SSMClient(ctx)
-
-	var query patchBaselineListResourceModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
 
 	var input ssm.DescribePatchBaselinesInput
 

--- a/internal/service/ssm/patch_group_list.go
+++ b/internal/service/ssm/patch_group_list.go
@@ -36,14 +36,6 @@ type patchGroupListResource struct {
 func (l *patchGroupListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := l.Meta().SSMClient(ctx)
 
-	var query listPatchGroupModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		input := ssm.DescribePatchGroupsInput{}
 		for item, err := range listPatchGroups(ctx, conn, &input) {
@@ -91,10 +83,6 @@ func (l *patchGroupListResource) List(ctx context.Context, request list.ListRequ
 			}
 		}
 	}
-}
-
-type listPatchGroupModel struct {
-	framework.WithRegionModel
 }
 
 func listPatchGroups(ctx context.Context, conn *ssm.Client, input *ssm.DescribePatchGroupsInput) iter.Seq2[awstypes.PatchGroupPatchBaselineMapping, error] {

--- a/internal/service/workmail/organization_list.go
+++ b/internal/service/workmail/organization_list.go
@@ -33,14 +33,6 @@ type organizationListResource struct {
 func (r *organizationListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream) {
 	conn := r.Meta().WorkMailClient(ctx)
 
-	var query listOrganizationModel
-	if request.Config.Raw.IsKnown() && !request.Config.Raw.IsNull() {
-		if diags := request.Config.Get(ctx, &query); diags.HasError() {
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-	}
-
 	stream.Results = func(yield func(list.ListResult) bool) {
 		result := request.NewListResult(ctx)
 		var input workmail.ListOrganizationsInput
@@ -87,10 +79,6 @@ func (r *organizationListResource) List(ctx context.Context, request list.ListRe
 			}
 		}
 	}
-}
-
-type listOrganizationModel struct {
-	framework.WithRegionModel
 }
 
 func listOrganizations(ctx context.Context, conn *workmail.Client, input *workmail.ListOrganizationsInput) iter.Seq2[awstypes.OrganizationSummary, error] {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This rule will capture cases where the list configuration is decoded into a resource model struct that is never used.

Also fixes instances of this pattern in existing list resources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/49549#discussion_r3958797723



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t K=sqs T='TestAccSQSQueue_List_'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-unused-config-model 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/sqs/... -v -count 1 -parallel 20 -run='TestAccSQSQueue_List_'  -timeout 360m -vet=off -buildvcs=false
2026/09/09 16:22:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/09 16:22:28 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccSQSQueue_List_regionOverride (85.24s)
--- PASS: TestAccSQSQueue_List_includeResource (89.49s)
--- PASS: TestAccSQSQueue_List_basic (139.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sqs        148.056s
```

```console
% make t K=ssm T='TestAccSSMParameter_List_' && make t K=ecr T='TestAccECRRepository_List_' && make t K=ecs T='TestAccECSDaemonTaskDefinition_List_' && make t K=cloudfront T='TestAccCloudFrontKeyValueStore_List_basic'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-unused-config-model 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMParameter_List_'  -timeout 360m -vet=off -buildvcs=false
2026/09/09 16:26:45 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/09 16:26:45 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccSSMParameter_List_regionOverride (18.35s)
--- PASS: TestAccSSMParameter_List_basic (21.33s)
--- PASS: TestAccSSMParameter_List_IncludeResource_writeOnly (22.32s)
--- PASS: TestAccSSMParameter_List_IncludeResource_basic (22.43s)
--- PASS: TestAccSSMParameter_List_IncludeResource_insecure (22.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        30.819s
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-unused-config-model 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepository_List_'  -timeout 360m -vet=off -buildvcs=false
2026/09/09 16:27:38 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/09 16:27:38 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccECRRepository_List_regionOverride (17.57s)
--- PASS: TestAccECRRepository_List_basic (18.93s)
--- PASS: TestAccECRRepository_List_includeResource (19.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        27.208s
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-unused-config-model 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSDaemonTaskDefinition_List_'  -timeout 360m -vet=off -buildvcs=false
2026/09/09 16:28:29 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/09 16:28:29 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccECSDaemonTaskDefinition_List_regionOverride (18.78s)
--- PASS: TestAccECSDaemonTaskDefinition_List_basic (20.13s)
--- PASS: TestAccECSDaemonTaskDefinition_List_includeResource (20.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        28.421s
?       github.com/hashicorp/terraform-provider-aws/internal/service/ecs/test-fixtures  [no test files]
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 td-unused-config-model 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontKeyValueStore_List_basic'  -timeout 360m -vet=off -buildvcs=false
2026/09/09 16:29:28 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/09 16:29:28 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccCloudFrontKeyValueStore_List_basic (32.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 40.806s
```
