### PR TITLE
[bugfix] aws_elasticache_replication_group : Fix log_delivery_configuration modification with apply_immediately = false

### DIFF
--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -1161,14 +1161,14 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 		if d.HasChange("log_delivery_configuration") {
 			o, n := d.GetChange("log_delivery_configuration")
 
-			input.LogDeliveryConfigurations = []awstypes.LogDeliveryConfigurationRequest{}
+			logDeliveryConfigurations := []awstypes.LogDeliveryConfigurationRequest{}
 			logTypesToSubmit := make(map[awstypes.LogType]bool)
 
 			currentLogDeliveryConfig := n.(*schema.Set).List()
 			for _, current := range currentLogDeliveryConfig {
 				logDeliveryConfigurationRequest := expandLogDeliveryConfigurationRequests(current.(map[string]any))
 				logTypesToSubmit[logDeliveryConfigurationRequest.LogType] = true
-				input.LogDeliveryConfigurations = append(input.LogDeliveryConfigurations, logDeliveryConfigurationRequest)
+				logDeliveryConfigurations = append(logDeliveryConfigurations, logDeliveryConfigurationRequest)
 			}
 
 			previousLogDeliveryConfig := o.(*schema.Set).List()
@@ -1176,11 +1176,34 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 				logDeliveryConfigurationRequest := expandEmptyLogDeliveryConfigurationRequest(previous.(map[string]any))
 				//if something was removed, send an empty request
 				if !logTypesToSubmit[logDeliveryConfigurationRequest.LogType] {
-					input.LogDeliveryConfigurations = append(input.LogDeliveryConfigurations, logDeliveryConfigurationRequest)
+					logDeliveryConfigurations = append(logDeliveryConfigurations, logDeliveryConfigurationRequest)
 				}
 			}
 
-			requestUpdate = true
+			if d.Get(names.AttrApplyImmediately).(bool) {
+				input.LogDeliveryConfigurations = logDeliveryConfigurations
+				requestUpdate = true
+			} else {
+				// ElastiCache requires apply-immediately for all log delivery modifications, so with
+				// apply_immediately = false they use a separate ApplyImmediately=true call; requestUpdate stays unset to avoid an empty combined call.
+				logDeliveryInput := elasticache.ModifyReplicationGroupInput{
+					ApplyImmediately:          aws.Bool(true),
+					LogDeliveryConfigurations: logDeliveryConfigurations,
+					ReplicationGroupId:        aws.String(d.Id()),
+				}
+				updateFuncs = append(updateFuncs, func() error {
+					_, err := conn.ModifyReplicationGroup(ctx, &logDeliveryInput)
+					// modifying to match out of band operations may result in this error
+					if errs.IsAErrorMessageContains[*awstypes.InvalidParameterCombinationException](err, "No modifications were requested") {
+						return nil
+					}
+
+					if err != nil {
+						return fmt.Errorf("modifying ElastiCache Replication Group (%s) log delivery configuration: %w", d.Id(), err)
+					}
+					return nil
+				})
+			}
 		}
 
 		if d.HasChange("maintenance_window") {

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -4557,6 +4557,136 @@ func TestAccElastiCacheReplicationGroup_SlowLog_Redis5ToValkey7(t *testing.T) {
 	})
 }
 
+func TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration_applyImmediatelyFalse_Redis(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var rg awstypes.ReplicationGroup
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_replication_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationGroupConfig_logDeliveryApplyImmediately(rName, "redis", "7.1", "text", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_delivery_configuration.*", map[string]string{
+						names.AttrDestination: rName,
+						"destination_type":    "cloudwatch-logs",
+						"log_format":          "text",
+						"log_type":            "slow-log",
+					}),
+				),
+			},
+			{
+				// Applied immediately even with apply_immediately = false; the empty plan confirms no perpetual diff.
+				Config: testAccReplicationGroupConfig_logDeliveryApplyImmediately(rName, "redis", "7.1", names.AttrJSON, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_delivery_configuration.*", map[string]string{
+						names.AttrDestination: rName,
+						"destination_type":    "cloudwatch-logs",
+						"log_format":          names.AttrJSON,
+						"log_type":            "slow-log",
+					}),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				// Removing the block is also a log delivery modification, so it too applies immediately.
+				Config: testAccReplicationGroupConfig_logDeliveryApplyImmediatelyRemoved(rName, "redis", "7.1", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration_applyImmediatelyFalse_Valkey(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var rg awstypes.ReplicationGroup
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_replication_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationGroupConfig_logDeliveryApplyImmediately(rName, "valkey", "7.2", "text", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_delivery_configuration.*", map[string]string{
+						names.AttrDestination: rName,
+						"destination_type":    "cloudwatch-logs",
+						"log_format":          "text",
+						"log_type":            "slow-log",
+					}),
+				),
+			},
+			{
+				// Applied immediately even with apply_immediately = false; the empty plan confirms no perpetual diff.
+				Config: testAccReplicationGroupConfig_logDeliveryApplyImmediately(rName, "valkey", "7.2", names.AttrJSON, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_delivery_configuration.*", map[string]string{
+						names.AttrDestination: rName,
+						"destination_type":    "cloudwatch-logs",
+						"log_format":          names.AttrJSON,
+						"log_type":            "slow-log",
+					}),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				// Removing the block is also a log delivery modification, so it too applies immediately.
+				Config: testAccReplicationGroupConfig_logDeliveryApplyImmediatelyRemoved(rName, "valkey", "7.2", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckReplicationGroupExists(ctx context.Context, t *testing.T, n string, v *awstypes.ReplicationGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -5083,6 +5213,55 @@ resource "aws_elasticache_replication_group" "test" {
   }
 }
 `, rName, engine, engineVersion)
+}
+
+func testAccReplicationGroupConfig_logDeliveryApplyImmediately(rName, engine, engineVersion, logFormat string, applyImmediately bool) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+  name              = "%[1]s"
+  retention_in_days = 7
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t3.small"
+  port                       = 6379
+  apply_immediately          = %[5]t
+  engine                     = %[2]q
+  engine_version             = %[3]q
+  cluster_mode               = "disabled"
+  transit_encryption_enabled = true
+
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.test.name
+    destination_type = "cloudwatch-logs"
+    log_format       = %[4]q
+    log_type         = "slow-log"
+  }
+}
+`, rName, engine, engineVersion, logFormat, applyImmediately)
+}
+
+func testAccReplicationGroupConfig_logDeliveryApplyImmediatelyRemoved(rName, engine, engineVersion string, applyImmediately bool) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+  name              = "%[1]s"
+  retention_in_days = 7
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t3.small"
+  port                       = 6379
+  apply_immediately          = %[4]t
+  engine                     = %[2]q
+  engine_version             = %[3]q
+  cluster_mode               = "disabled"
+  transit_encryption_enabled = true
+}
+`, rName, engine, engineVersion, applyImmediately)
 }
 
 func testAccReplicationGroupConfig_clusterModeWithNumNodeGroups(rName string, engine string, engineVersion string, numNodeGroups int) string {

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -304,6 +304,8 @@ The following arguments are optional:
 
 The `log_delivery_configuration` block allows the streaming of Redis OSS/Valkey [SLOWLOG](https://redis.io/commands/slowlog) or Redis OSS/Valkey [Engine Log](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html#Log_contents-engine-log) to CloudWatch Logs or Kinesis Data Firehose. Max of 2 blocks.
 
+~> **Note:** Changes to `log_delivery_configuration` are always applied immediately, regardless of the value of `apply_immediately`, because ElastiCache requires apply-immediately for all log delivery modifications.
+
 * `destination` - Name of either the CloudWatch Logs LogGroup or Kinesis Data Firehose resource.
 * `destination_type` - For CloudWatch Logs use `cloudwatch-logs` or for Kinesis Data Firehose use `kinesis-firehose`.
 * `log_format` - Valid values are `json` or `text`


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
ElastiCache requires apply-immediately for all log delivery modifications. The provider was sending `log_delivery_configuration` changes with the resource's `apply_immediately` value, so with `apply_immediately = false` the modify was rejected with `InvalidParameterValue`. This sends `log_delivery_configuration` changes in their own `ModifyReplicationGroup` call with apply-immediately forced to `true`, while leaving every other attribute deferred as the user intended — mirroring the existing engine-version carve-out in the same resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49842
Closes #49270

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS='TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration' PKG=elasticache ACCTEST_PARALLELISM=2 ACCTEST_TIMEOUT=4880m 

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
xargs: gofmt: No such file or directory
make: Validating schemas
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	(cached)
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	(cached)
make: Running acceptance tests on branch: 🌿 rg-log-delivery-apply-immediately 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/elasticache/... -v -count 1 -parallel 2 -run='TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration'  -timeout 4880m -vet=off -buildvcs=false
2026/09/14 15:05:52 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/14 15:05:52 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration_applyImmediatelyFalse_Redis
=== PAUSE TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration_applyImmediatelyFalse_Redis
=== RUN   TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration_applyImmediatelyFalse_Valkey
=== PAUSE TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration_applyImmediatelyFalse_Valkey
=== CONT  TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration_applyImmediatelyFalse_Redis
=== CONT  TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration_applyImmediatelyFalse_Valkey
--- PASS: TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration_applyImmediatelyFalse_Valkey (715.13s)
--- PASS: TestAccElastiCacheReplicationGroup_LogDeliveryConfiguration_applyImmediatelyFalse_Redis (724.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	724.513s
```
