### PR TITLE
r/aws_efs_access_point: List tags with ListTagsForResource

### DIFF
--- a/.changelog/49938.txt
+++ b/.changelog/49938.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_efs_access_point: Fix tag read-back by listing tags with `ListTagsForResource` instead of the deprecated `DescribeTags` API
+```

--- a/internal/service/efs/generate.go
+++ b/internal/service/efs/generate.go
@@ -1,7 +1,7 @@
 // Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=DescribeTags -ListTagsOpPaginated -ListTagsInIDElem=FileSystemId -ServiceTagsSlice -TagInIDElem=ResourceId -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForResource -ListTagsOpPaginated -ListTagsInIDElem=ResourceId -ServiceTagsSlice -TagInIDElem=ResourceId -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 //go:generate go run ../../generate/identitytests/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.

--- a/internal/service/efs/tags_gen.go
+++ b/internal/service/efs/tags_gen.go
@@ -23,13 +23,13 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *efs.Client, identifier string, optFns ...func(*efs.Options)) (tftags.KeyValueTags, error) {
-	input := efs.DescribeTagsInput{
-		FileSystemId: aws.String(identifier),
+	input := efs.ListTagsForResourceInput{
+		ResourceId: aws.String(identifier),
 	}
 
 	var output []awstypes.Tag
 
-	pages := efs.NewDescribeTagsPaginator(conn, &input)
+	pages := efs.NewListTagsForResourcePaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx, optFns...)
 


### PR DESCRIPTION
### Description

Closes #49937.

The EFS service's generated `listTags` read tags through the legacy `DescribeTags` API, which only accepts a file system ID (`fs-...`). For `aws_efs_access_point` the resource identifier is an access point ID (`fsap-...`), so any tag read-back against an access point failed with:

```
ValidationException: Value 'fsap-...' at 'fileSystemId' failed to satisfy constraint
```

The tag *write* path already uses `TagResource` / `UntagResource`, which take a generic `ResourceId` and work for both file systems and access points. This change makes the read path symmetric by switching the EFS tag list operation to `ListTagsForResource`, which accepts the same generic `ResourceId`. `DescribeTags` is itself deprecated in the EFS API reference in favour of `ListTagsForResource`.

### Relations

This is the root cause behind #49937. The read-back only fires when the planned `tags_all` is not wholly known (e.g. when a tag has an empty-string value), which is why the failure looked intermittent.

### References

- Issue: #49937
- EFS API — `ListTagsForResource`: https://docs.aws.amazon.com/efs/latest/ug/API_ListTagsForResource.html
- EFS API — `DescribeTags` (deprecated): https://docs.aws.amazon.com/efs/latest/ug/API_DescribeTags.html
