### PR TITLE
r/aws_glue_catalog_database: fix explicitly-empty create_table_default_permission

### DIFF
--- a/.changelog/49940.txt
+++ b/.changelog/49940.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_database: fix `create_table_default_permission` so an explicitly empty block is sent to AWS as an empty list, rather than being treated as unconfigured
+```

--- a/internal/service/glue/catalog_database.go
+++ b/internal/service/glue/catalog_database.go
@@ -168,6 +168,12 @@ func resourceCatalogDatabaseCreate(ctx context.Context, d *schema.ResourceData, 
 
 	if v, ok := d.GetOk("create_table_default_permission"); ok && len(v.([]any)) > 0 {
 		dbInput.CreateTableDefaultPermissions = expandPrincipalPermissionses(v.([]any))
+	} else if raw := d.GetRawConfig().GetAttr("create_table_default_permission"); !raw.IsNull() && raw.LengthInt() > 0 {
+		// The block is explicitly configured as empty (`create_table_default_permission {}`),
+		// which means "Lake Formation manages new-table permissions" (no automatic
+		// IAM_ALLOWED_PRINCIPALS grant). Send an explicit empty list rather than leaving the
+		// field unset, which would let AWS apply its own default instead.
+		dbInput.CreateTableDefaultPermissions = []awstypes.PrincipalPermissions{}
 	}
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
@@ -228,7 +234,21 @@ func resourceCatalogDatabaseRead(ctx context.Context, d *schema.ResourceData, me
 
 	d.Set(names.AttrARN, databaseARN(ctx, c, name))
 	d.Set(names.AttrCatalogID, database.CatalogId)
-	if err := d.Set("create_table_default_permission", flattenPrincipalPermissionses(database.CreateTableDefaultPermissions)); err != nil {
+	createTableDefaultPermission := flattenPrincipalPermissionses(database.CreateTableDefaultPermissions)
+	if len(createTableDefaultPermission) == 0 {
+		// AWS returned no default permissions. If the config explicitly set an empty
+		// `create_table_default_permission {}` block (rather than omitting the argument),
+		// echo that back so the plan doesn't perpetually want to re-apply it.
+		if raw := d.GetRawConfig().GetAttr("create_table_default_permission"); !raw.IsNull() && raw.LengthInt() > 0 {
+			createTableDefaultPermission = []any{
+				map[string]any{
+					names.AttrPermissions: []any{},
+					names.AttrPrincipal:   []any{},
+				},
+			}
+		}
+	}
+	if err := d.Set("create_table_default_permission", createTableDefaultPermission); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting create_table_default_permission: %s", err)
 	}
 	d.Set(names.AttrDescription, database.Description)
@@ -269,6 +289,12 @@ func resourceCatalogDatabaseUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		if v, ok := d.GetOk("create_table_default_permission"); ok && len(v.([]any)) > 0 {
 			dbInput.CreateTableDefaultPermissions = expandPrincipalPermissionses(v.([]any))
+		} else if raw := d.GetRawConfig().GetAttr("create_table_default_permission"); !raw.IsNull() && raw.LengthInt() > 0 {
+			// The block is explicitly configured as empty (`create_table_default_permission {}`),
+			// which means "Lake Formation manages new-table permissions" (no automatic
+			// IAM_ALLOWED_PRINCIPALS grant). Send an explicit empty list rather than leaving the
+			// field unset, which would leave AWS's existing default in place.
+			dbInput.CreateTableDefaultPermissions = []awstypes.PrincipalPermissions{}
 		}
 
 		if v, ok := d.GetOk(names.AttrDescription); ok {

--- a/internal/service/glue/catalog_database.go
+++ b/internal/service/glue/catalog_database.go
@@ -168,12 +168,6 @@ func resourceCatalogDatabaseCreate(ctx context.Context, d *schema.ResourceData, 
 
 	if v, ok := d.GetOk("create_table_default_permission"); ok && len(v.([]any)) > 0 {
 		dbInput.CreateTableDefaultPermissions = expandPrincipalPermissionses(v.([]any))
-	} else if raw := d.GetRawConfig().GetAttr("create_table_default_permission"); !raw.IsNull() && raw.LengthInt() > 0 {
-		// The block is explicitly configured as empty (`create_table_default_permission {}`),
-		// which means "Lake Formation manages new-table permissions" (no automatic
-		// IAM_ALLOWED_PRINCIPALS grant). Send an explicit empty list rather than leaving the
-		// field unset, which would let AWS apply its own default instead.
-		dbInput.CreateTableDefaultPermissions = []awstypes.PrincipalPermissions{}
 	}
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
@@ -289,12 +283,6 @@ func resourceCatalogDatabaseUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		if v, ok := d.GetOk("create_table_default_permission"); ok && len(v.([]any)) > 0 {
 			dbInput.CreateTableDefaultPermissions = expandPrincipalPermissionses(v.([]any))
-		} else if raw := d.GetRawConfig().GetAttr("create_table_default_permission"); !raw.IsNull() && raw.LengthInt() > 0 {
-			// The block is explicitly configured as empty (`create_table_default_permission {}`),
-			// which means "Lake Formation manages new-table permissions" (no automatic
-			// IAM_ALLOWED_PRINCIPALS grant). Send an explicit empty list rather than leaving the
-			// field unset, which would leave AWS's existing default in place.
-			dbInput.CreateTableDefaultPermissions = []awstypes.PrincipalPermissions{}
 		}
 
 		if v, ok := d.GetOk(names.AttrDescription); ok {
@@ -496,7 +484,7 @@ func expandPrincipalPermissionses(tfList []any) []awstypes.PrincipalPermissions 
 		return nil
 	}
 
-	var apiObjects []awstypes.PrincipalPermissions
+	apiObjects := make([]awstypes.PrincipalPermissions, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]any)
@@ -504,10 +492,33 @@ func expandPrincipalPermissionses(tfList []any) []awstypes.PrincipalPermissions 
 			continue
 		}
 
+		// A block with neither permissions nor a principal represents an explicitly
+		// empty `create_table_default_permission {}`, meaning Lake Formation should
+		// manage default permissions (no automatic IAM_ALLOWED_PRINCIPALS grant). It
+		// must be sent to AWS as a genuinely empty list, not a single entry with a
+		// null Principal, which AWS rejects with "Principal in PrincipalPrivileges
+		// cannot be null". Skipping it here — while still returning the non-nil
+		// (possibly zero-length) apiObjects slice above — achieves that.
+		if isEmptyPrincipalPermissionsBlock(tfMap) {
+			continue
+		}
+
 		apiObjects = append(apiObjects, expandPrincipalPermissions(tfMap))
 	}
 
 	return apiObjects
+}
+
+func isEmptyPrincipalPermissionsBlock(tfMap map[string]any) bool {
+	if v, ok := tfMap[names.AttrPermissions].(*schema.Set); ok && v.Len() > 0 {
+		return false
+	}
+
+	if v, ok := tfMap[names.AttrPrincipal].([]any); ok && len(v) > 0 && v[0] != nil {
+		return false
+	}
+
+	return true
 }
 
 func expandPrincipalPermissions(tfMap map[string]any) awstypes.PrincipalPermissions {

--- a/internal/service/glue/catalog_database_test.go
+++ b/internal/service/glue/catalog_database_test.go
@@ -116,6 +116,51 @@ func TestAccGlueCatalogDatabase_createTablePermission(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "create_table_default_permission.0.principal.0.data_lake_principal_identifier", "IAM_ALLOWED_PRINCIPALS"),
 				),
 			},
+			{
+				// Transition to an explicitly empty block: AWS should switch to
+				// Lake Formation-managed default permissions (no IAM_ALLOWED_PRINCIPALS
+				// entry), not reject the update.
+				Config:  testAccCatalogDatabaseConfig_createTablePermissionEmpty(rName),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogDatabaseExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "create_table_default_permission.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "create_table_default_permission.0.permissions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "create_table_default_permission.0.principal.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGlueCatalogDatabase_createTablePermissionEmpty(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_glue_catalog_database.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogDatabaseDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				// Creating with an explicitly empty block should succeed and result
+				// in Lake Formation-managed default permissions, not a
+				// "Principal ... cannot be null" error.
+				Config: testAccCatalogDatabaseConfig_createTablePermissionEmpty(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogDatabaseExists(ctx, t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "create_table_default_permission.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "create_table_default_permission.0.permissions.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "create_table_default_permission.0.principal.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -531,6 +576,16 @@ resource "aws_glue_catalog_database" "test" {
   }
 }
 `, rName, permission)
+}
+
+func testAccCatalogDatabaseConfig_createTablePermissionEmpty(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+
+  create_table_default_permission {}
+}
+`, rName)
 }
 
 func testAccCatalogDatabaseConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/internal/service/glue/catalog_database_test.go
+++ b/internal/service/glue/catalog_database_test.go
@@ -156,11 +156,12 @@ func TestAccGlueCatalogDatabase_createTablePermissionEmpty(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "create_table_default_permission.0.principal.#", "0"),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			// No ImportState/ImportStateVerify step here: an explicitly-empty
+			// create_table_default_permission block is indistinguishable from an
+			// omitted one once there's no config to consult (as during import), so
+			// the imported state's block count won't match the pre-import state's.
+			// This is an inherent limitation of the Optional+Computed attribute,
+			// not something this fix can resolve.
 		},
 	})
 }


### PR DESCRIPTION
## Description

Rebased/reworked take on #43226 against current `main` (that PR predates the SDKv2 migration of this resource and no longer applies cleanly).

An explicitly configured empty block:

```hcl
resource "aws_glue_catalog_database" "example" {
  name = "example"

  create_table_default_permission {}
}
```

is a valid AWS Lake Formation state — it means new tables in this database get no automatic `IAM_ALLOWED_PRINCIPALS`/`ALL` grant and are Lake Formation-managed instead. AWS's own "change default settings" guidance documents `CreateTableDefaultPermissions: []` as a supported value for this.

Today, an empty block causes `expandPrincipalPermissionses` to produce a single `PrincipalPermissions{}` entry (no `Permissions`, no `Principal`) instead of a genuinely empty list. `GetOk("create_table_default_permission")` returns `ok=true, len=1` whenever the block is present at all — even with empty inner fields — since the outer list always has one element for one configured block. AWS rejects that single null-`Principal` entry with `InvalidInputException: Principal in PrincipalPrivileges cannot be null`. There's no way to configure this attribute as empty today.

## Fix

- `expandPrincipalPermissionses`: skip entries with neither `permissions` nor a `principal` set, so a lone empty block collapses to a genuinely empty (non-nil) slice rather than one null-`Principal` entry. This applies transparently in both `Create` and `Update`, which already call this function.
- `Read`: when AWS returns no default permissions, echo back an explicitly-empty configured block (via `GetRawConfig`) rather than `nil`, so the plan doesn't show a perpetual diff for a resource configured with an empty block.
- Known limitation: an explicitly-empty block is indistinguishable from an omitted one during `import` (no config exists yet, so `GetRawConfig` returns null) — the imported state will show 0 blocks either way. This is inherent to the attribute being Optional+Computed, not something this PR resolves; the added acceptance test intentionally skips `ImportStateVerify` for that case.

## Relations

Closes #27295
Supersedes #43226

## Testing

Added `TestAccGlueCatalogDatabase_createTablePermissionEmpty` and a transition step in `TestAccGlueCatalogDatabase_createTablePermission` covering non-empty → explicitly-empty. Ran `go build`/`go vet`/`gofmt` on the package locally (clean); full acceptance suite requires an AWS account this contribution doesn't have — happy to iterate based on CI/maintainer feedback.

<!-- markdownlint-disable-next-line MD041 -->
```release-note:bug
resource/aws_glue_catalog_database: fix `create_table_default_permission` so an explicitly empty block is sent to AWS as an empty list, rather than as an entry with a null `Principal`
```