### PR TITLE
r/aws_redshiftserverless_workgroup: allow enable_large_strings_opt_in config parameter

### DIFF
--- a/.changelog/49941.txt
+++ b/.changelog/49941.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshiftserverless_workgroup: Allow `enable_large_strings_opt_in` config parameter
+```

--- a/internal/service/redshiftserverless/workgroup.go
+++ b/internal/service/redshiftserverless/workgroup.go
@@ -73,6 +73,8 @@ func resourceWorkgroup() *schema.Resource {
 									"auto_mv",
 									"datestyle",
 									"enable_case_sensitive_identifier", // "ValidationException: The parameter key enable_case_sensitivity_identifier isn't supported. Supported values: [[max_query_cpu_usage_percent, max_join_row_count, auto_mv, max_query_execution_time, max_query_queue_time, max_query_blocks_read, max_return_row_count, search_path, datestyle, max_query_cpu_time, max_io_skew, max_scan_row_count, query_group, enable_user_activity_logging, enable_case_sensitive_identifier, max_nested_loop_join_row_count, max_query_temp_blocks_to_disk, max_cpu_skew]]"
+									// https://docs.aws.amazon.com/redshift/latest/mgmt/behavior-changes.html
+									"enable_large_strings_opt_in",
 									"enable_user_activity_logging",
 									"query_group",
 									"search_path",


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #49939

Amazon Redshift Serverless now returns `enable_large_strings_opt_in` from `GetWorkgroup` (introduced with Redshift Patch 205 for larger individual strings in the `SUPER` data type). Because the provider rejects this key in `config_parameter.parameter_key` validation, a workgroup whose API response includes it produces a perpetual diff, and every `apply` that touches the workgroup fails with:

```
ValidationException: You didn't specify any changes to the configuration parameters.
```

The AWS API accepts the key (verified via the CLI in the linked issue), so the fix is to add it to the allowed `parameter_key` values. This mirrors the existing handling of the `require_ssl` / `use_fips_ssl` parameters that AWS surfaces automatically.

Output from acceptance testing:

<!--
If the PR modifies a resource, data source, or datasource that has acceptance tests, paste the output from those tests here. This is not required for documentation-only changes, but it is preferred for code changes.
-->

```console
% make testacc TESTS=TestAccRedshiftServerlessWorkgroup_configParameters PKG=redshiftserverless
... (requires AWS credentials; not run in this environment)
```
