### PR TITLE
fix(route53): create new traffic policy version on document change (supersedes #42365)

### DIFF
--- a/.changelog/42365.txt
+++ b/.changelog/42365.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_traffic_policy: Update in-place and create a new version when the `document` argument changes, preserving previous versions, instead of forcing resource replacement
+```

--- a/internal/service/route53/traffic_policy.go
+++ b/internal/service/route53/traffic_policy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -70,7 +71,6 @@ func resourceTrafficPolicy() *schema.Resource {
 				"document": {
 					Type:         schema.TypeString,
 					Required:     true,
-					ForceNew:     true,
 					ValidateFunc: validation.StringLenBetween(0, 102400),
 				},
 				names.AttrName: {
@@ -89,6 +89,7 @@ func resourceTrafficPolicy() *schema.Resource {
 				},
 			}
 		},
+		CustomizeDiff: updateComputedAttributesOnPublish,
 	}
 }
 
@@ -145,23 +146,43 @@ func resourceTrafficPolicyRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
+func updateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff, meta any) error {
+	if hasConfigChanges(d) {
+		d.SetNewComputed(names.AttrVersion)
+	}
+
+	return nil
+}
+
+func hasConfigChanges(d sdkv2.ResourceDiffer) bool {
+	return d.HasChange("document")
+}
+
 func resourceTrafficPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53Client(ctx)
+	var err error
 
-	input := &route53.UpdateTrafficPolicyCommentInput{
-		Id:      aws.String(d.Id()),
-		Version: aws.Int32(int32(d.Get(names.AttrVersion).(int))),
+	if d.HasChange("document") {
+		input := &route53.CreateTrafficPolicyVersionInput{
+			Id:       aws.String(d.Id()),
+			Document: aws.String(d.Get("document").(string)),
+			Comment:  aws.String(d.Get(names.AttrComment).(string)),
+		}
+
+		_, err = conn.CreateTrafficPolicyVersion(ctx, input)
+	} else if d.HasChange(names.AttrComment) {
+		input := &route53.UpdateTrafficPolicyCommentInput{
+			Id:      aws.String(d.Id()),
+			Version: aws.Int32(int32(d.Get(names.AttrVersion).(int))),
+			Comment: aws.String(d.Get(names.AttrComment).(string)),
+		}
+
+		_, err = conn.UpdateTrafficPolicyComment(ctx, input)
 	}
-
-	if d.HasChange(names.AttrComment) {
-		input.Comment = aws.String(d.Get(names.AttrComment).(string))
-	}
-
-	_, err := conn.UpdateTrafficPolicyComment(ctx, input)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating Route53 Traffic Policy (%s) comment: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Route53 Traffic Policy (%s): %s", d.Id(), err)
 	}
 
 	return append(diags, resourceTrafficPolicyRead(ctx, d, meta)...)

--- a/internal/service/route53/traffic_policy_test.go
+++ b/internal/service/route53/traffic_policy_test.go
@@ -121,6 +121,60 @@ func TestAccRoute53TrafficPolicy_update(t *testing.T) {
 	})
 }
 
+func TestAccRoute53TrafficPolicy_updateDocument(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.TrafficPolicy
+	resourceName := "aws_route53_traffic_policy.test"
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	initialDocument := `{
+		"AWSPolicyFormatVersion":"2015-10-01",
+		"RecordType":"A",
+		"Endpoints":{
+			"endpoint-start-NkPh":{
+				"Type":"value",
+				"Value":"10.0.0.1"
+			}
+		},
+		"StartEndpoint":"endpoint-start-NkPh"
+	}`
+	updatedDocument := `{
+		"AWSPolicyFormatVersion":"2015-10-01",
+		"RecordType":"A",
+		"Endpoints":{
+			"endpoint-start-NkPh":{
+				"Type":"value",
+				"Value":"10.0.0.2"
+			}
+		},
+		"StartEndpoint":"endpoint-start-NkPh"
+	}`
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckTrafficPolicy(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTrafficPolicyDestroy(ctx, t),
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrafficPolicyConfig_document(rName, initialDocument),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrafficPolicyExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "document", initialDocument),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, "1"),
+				),
+			},
+			{
+				Config: testAccTrafficPolicyConfig_document(rName, updatedDocument),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTrafficPolicyExists(ctx, t, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "document", updatedDocument),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckTrafficPolicyExists(ctx context.Context, t *testing.T, n string, v *awstypes.TrafficPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -220,4 +274,13 @@ resource "aws_route53_traffic_policy" "test" {
 EOT
 }
 `, rName, comment)
+}
+
+func testAccTrafficPolicyConfig_document(rName, document string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_traffic_policy" "test" {
+  name     = %[1]q
+  document = %[2]q
+}
+`, rName, document)
 }


### PR DESCRIPTION
### Description

This revives and rebases #42365 (which is stale by ~41k commits and has unresolvable merge conflicts) so it can be merged cleanly against current `main`.

It enhances the `aws_route53_traffic_policy` resource to properly support versioning when the `document` argument changes.
Previously, changing `document` forced resource replacement. With this change, updating the document creates a new traffic policy version while preserving previous versions, aligning with the Route 53 API behavior (`CreateTrafficPolicyVersion`).

### Relations

- Supersedes #42365
- Closes #27767

### Changes vs. the original #42365

The original PR was authored against the April 2025 tree and no longer applies. In rebasing onto current `main`, the following adaptations were made:

- Moved the changelog entry out of `CHANGELOG.md` and into `.changelog/42365.txt` (the direct `CHANGELOG.md` edit was the root cause of the permanent merge conflict).
- Migrated the resource to `SchemaFunc` (from `Schema`).
- Updated to the current `tfresource.RetryWhenIsA[any, *T](ctx, …, func(ctx) …)` signature and `internal/retry` helpers.
- Updated acceptance-test helper signatures (`testAccCheckTrafficPolicyExists(ctx, t, …)`, `testAccCheckTrafficPolicyDestroy(ctx, t)`, `acctest.RandomWithPrefix(t, …)`).
- Cleaned up lint issues: `meta interface{}` → `meta any`, removed leftover debug `log.Printf`, dropped the redundant `ForceNew: false`.

### Output from Acceptance Testing

Local verification: `go build`, `go vet`, and `gofmt` all pass; the test package compiles. Acceptance testing (`TestAccRoute53TrafficPolicy_updateDocument`) requires AWS credentials.

```console
$ make testacc TESTS=TestAccRoute53TrafficPolicy_updateDocument PKG=route53
```

### Credits

Full credit to @Dhruvin1 (Dhruvin Shah) for the original implementation in #42365, and to @IamEnTm for the original fork the fix was based on. This PR only rebases and adapts that work to current `main`.