### PR TITLE
`aws_elasticache_user_group` : filter out already removed users during a user group update

### DIFF
--- a/.changelog/49948.txt
+++ b/.changelog/49948.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_user_group: Fix `user_ids` additions being silently dropped when the same update also removes an already-detached user
+```

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -8,6 +8,7 @@ package elasticache
 import (
 	"context"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -159,9 +160,11 @@ func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta a
 		input := &elasticache.ModifyUserGroupInput{
 			UserGroupId: aws.String(d.Get("user_group_id").(string)),
 		}
+		modified := false
 
 		if d.HasChange(names.AttrEngine) {
 			input.Engine = aws.String(d.Get(names.AttrEngine).(string))
+			modified = true
 		}
 
 		if d.HasChange("user_ids") {
@@ -170,20 +173,35 @@ func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta a
 
 			if add.Len() > 0 {
 				input.UserIdsToAdd = flex.ExpandStringValueSet(add)
+				modified = true
 			}
+
 			if del.Len() > 0 {
-				input.UserIdsToRemove = flex.ExpandStringValueSet(del)
+				// Deleting a user detaches it from its groups, so a stale removal would fail
+				// the whole request, discarding any pending additions with it.
+				userGroup, err := findUserGroupByID(ctx, conn, d.Id())
+
+				if err != nil {
+					return sdkdiag.AppendErrorf(diags, "reading ElastiCache User Group (%s): %s", d.Id(), err)
+				}
+
+				if remove := tfslices.Filter(flex.ExpandStringValueSet(del), func(v string) bool {
+					return slices.Contains(userGroup.UserIds, v)
+				}); len(remove) > 0 {
+					input.UserIdsToRemove = remove
+					modified = true
+				}
 			}
 		}
 
-		_, err := conn.ModifyUserGroup(ctx, input)
+		if modified {
+			if _, err := conn.ModifyUserGroup(ctx, input); err != nil {
+				return sdkdiag.AppendErrorf(diags, "updating ElastiCache User Group (%q): %s", d.Id(), err)
+			}
 
-		if err != nil && !errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "is not a member of user group") {
-			return sdkdiag.AppendErrorf(diags, "updating ElastiCache User Group (%q): %s", d.Id(), err)
-		}
-
-		if _, err := waitUserGroupUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache User Group (%s) update: %s", d.Id(), err)
+			if _, err := waitUserGroupUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache User Group (%s) update: %s", d.Id(), err)
+			}
 		}
 	}
 

--- a/internal/service/elasticache/user_group_test.go
+++ b/internal/service/elasticache/user_group_test.go
@@ -201,6 +201,54 @@ func TestAccElastiCacheUserGroup_rotate(t *testing.T) {
 	})
 }
 
+// Replacing a group member destroys the outgoing user first, so the update removes a user
+// ElastiCache has already detached while adding a new one.
+func TestAccElastiCacheUserGroup_replaceMember(t *testing.T) {
+	ctx := acctest.Context(t)
+	var userGroup awstypes.UserGroup
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
+	resourceName := "aws_elasticache_user_group.test"
+	user1ResourceName := "aws_elasticache_user.test1"
+	user2ResourceName := "aws_elasticache_user.test2"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserGroupConfig_multiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
+					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "user_ids.*", rName+"-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "user_ids.*", rName+"-2"),
+				),
+			},
+			{
+				Config: testAccUserGroupConfig_rotate(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(user1ResourceName, plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction(user2ResourceName, plancheck.ResourceActionReplace),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
+					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "user_ids.*", rName+"-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "user_ids.*", rName+"-3"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheUserGroup_engineValkey(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userGroup awstypes.UserGroup

--- a/internal/service/elasticache/user_group_test.go
+++ b/internal/service/elasticache/user_group_test.go
@@ -201,8 +201,6 @@ func TestAccElastiCacheUserGroup_rotate(t *testing.T) {
 	})
 }
 
-// Replacing a group member destroys the outgoing user first, so the update removes a user
-// ElastiCache has already detached while adding a new one.
 func TestAccElastiCacheUserGroup_replaceMember(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userGroup awstypes.UserGroup


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls in this pull request.

### Description

`resourceUserGroupUpdate` sends additions and removals in a single `ModifyUserGroup` call. When an `aws_elasticache_user` is destroyed earlier in the same apply, ElastiCache detaches that user from its user groups automatically, so the removal the provider computed from state is already a no-op by the time the group update runs. AWS then rejects the **entire** request with `InvalidParameterValueException: ... is not a member of user group`.

The error suppression added in #43520  made removals idempotent, but it suppresses the failure of the whole request additions included. Two further things hide the failure:

1. Because the call was rejected, the group never enters `modifying`. `waitUserGroupUpdated` (`Pending: [modifying]` → `Target: [active]`) sees `active` after its 30s `Delay` and reports the update as successful.
2. `resourceUserGroupRead` then writes back the real membership, so state and remote agree at the end of the apply.

The result is an apply that reports success while the group is missing the user it was told to add. The next plan proposes the addition again and a second apply converges, so the practical symptom is a converge-in-two-applies bug with no error surfaced in the first run.

**Fix:** reconcile the removal set against live membership before building the request, using the existing `findUserGroupByID`. Users AWS has already detached are dropped from `UserIdsToRemove`, so the request is one AWS will accept and the addition goes through.

With the removal set accurate, the blanket error suppression is no longer load-bearing and is removed. The #43520  scenario still behaves correctly: a removal for an already-detached user filters down to an empty set, and a new `modified` guard skips the API call and the waiter entirely rather than sending a no-op modification. That path now costs one fewer failed API call and skips a 30s waiter.

The add and the remove stay in a **single atomic call**.

One residual trade-off, called out for reviewers: because the membership read and the modify are separate calls, a removal that races between them (an out-of-band detach, or `DescribeUserGroups` lagging a `DeleteUser`) now errors instead of being tolerated. That window is much narrower than the one being fixed, erroring is the safer failure mode, and a re-apply converges.


### Relations

Closes #49945


### References
Introduced by 95705ee734b9a9617ef7ad41bbec07ad4644278b in #43520 , released in v6.14.0.

* [`ModifyUserGroup`](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyUserGroup.html)
* [`DeleteUser`](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_DeleteUser.html)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
➜  terraform-provider-aws git:(b-aws_ec_user_group-dropped-user-additions) make testacc TESTS=TestAccElastiCacheUserGroup_replaceMember PKG=elasticache
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 b-aws_ec_user_group-dropped-user-additions 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUserGroup_replaceMember'  -timeout 360m -vet=off -buildvcs=false
2026/09/10 18:21:44 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/10 18:21:44 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheUserGroup_replaceMember
=== PAUSE TestAccElastiCacheUserGroup_replaceMember
=== CONT  TestAccElastiCacheUserGroup_replaceMember
--- PASS: TestAccElastiCacheUserGroup_replaceMember (394.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        400.643s
...
```
