### PR TITLE
CI: Reads current machine's architecture when downloading tools

### DIFF
--- a/.teamcity/scripts/install_terraform.sh
+++ b/.teamcity/scripts/install_terraform.sh
@@ -15,7 +15,14 @@ if [[ -z "${version}" ]]; then
         grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4)
 fi
 
-echo "Downloading Terraform ${version}..."
+machine=$(uname -m)
+case "${machine}" in
+  x86_64)        arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+  *)             echo "ERROR: unsupported architecture: ${machine}" >&2; exit 1 ;;
+esac
+
+echo "Downloading Terraform ${version} (${arch})..."
 
 tools_dir="%TOOLS_DIR%"
 mkdir -p "${tools_dir}"
@@ -24,6 +31,6 @@ zip_file=$(mktemp --suffix=.zip)
 trap 'rm -f "${zip_file}"' EXIT
 
 wget --no-verbose -O "${zip_file}" \
-    "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip"
+    "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_${arch}.zip"
 
 unzip -o -d "${tools_dir}" "${zip_file}" terraform

--- a/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
+++ b/.teamcity/scripts/pullrequest_tests/install_gh_cli.sh
@@ -14,7 +14,14 @@ if [[ -z "${version}" ]]; then
   echo "WARN: failed to resolve gh CLI version from GitHub API, falling back to ${version}" >&2
 fi
 
-echo "Downloading gh ${version}..."
+machine=$(uname -m)
+case "${machine}" in
+  x86_64)        arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+  *)             echo "ERROR: unsupported architecture: ${machine}" >&2; exit 1 ;;
+esac
+
+echo "Downloading gh ${version} (${arch})..."
 
 tools_dir="%TOOLS_DIR%"
 mkdir -p "${tools_dir}"
@@ -23,5 +30,5 @@ tar_file=$(mktemp --suffix=.tar.gz)
 trap 'rm -f "${tar_file}"' EXIT
 
 wget --no-verbose -O "${tar_file}" \
-  "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz"
-tar -xzf "${tar_file}" --strip-components=2 -C "${tools_dir}" "gh_${version}_linux_amd64/bin/gh"
+  "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_${arch}.tar.gz"
+tar -xzf "${tar_file}" --strip-components=2 -C "${tools_dir}" "gh_${version}_linux_${arch}/bin/gh"


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Reads current machine's architecture when downloading tools

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>