### PR TITLE
Makefile: Fixes `PHONY` target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -909,8 +909,9 @@ smoke-identity: prereq-go ## Run Resource Identity smoke tests
 	GO_BIN=$(GO_VER) PACKAGE_PARALLELISM=$$((cores / 2)) sh -c "'$(CURDIR)/.ci/scripts/smoke-tests-identity.sh'"
 
 SMOKE_LOGGING_LEVELS := DEBUG WARN
+SMOKE_LOGGING_TARGETS := $(addprefix smoke-logging-,$(SMOKE_LOGGING_LEVELS))
 
-smoke-logging: $(addprefix smoke-logging-,$(SMOKE_LOGGING_LEVELS)) ## Run logging smoke tests at all log levels
+smoke-logging: $(SMOKE_LOGGING_TARGETS) ## Run logging smoke tests at all log levels
 
 smoke-logging-%: prereq-go ## Run logging smoke tests at a specific log level (e.g. make smoke-logging-DEBUG)
 	GO_BIN=$(GO_VER) TF_LOG=$* sh -c "'$(CURDIR)/.ci/scripts/smoke-tests-logging.sh'"
@@ -1385,7 +1386,7 @@ yamllint: ## [CI] YAML Linting / yamllint
 	smoke-core-services \
 	smoke-identity \
 	smoke-logging \
-	smoke-logging-% \
+	$(SMOKE_LOGGING_TARGETS) \
 	sweep \
 	sweeper \
 	sweeper-check \


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes `PHONY` target in makefile by removing `%` and correctly adding `smoke-logging-<level>` matrix
