### PR TITLE
Moves Framework model validation out of runtime

### DIFF
--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -415,14 +415,14 @@ func (p *frameworkProvider) initialize(ctx context.Context) {
 
 		for _, dataSourceSpec := range sp.FrameworkDataSources(ctx) {
 			p.dataSources = append(p.dataSources, func() datasource.DataSource { //nolint:contextcheck // must be a func()
-				return newWrappedDataSource(dataSourceSpec, servicePackageName)
+				return newWrappedDataSource(ctx, dataSourceSpec, servicePackageName)
 			})
 		}
 
 		if v, ok := sp.(conns.ServicePackageWithEphemeralResources); ok {
 			for _, ephemeralResourceSpec := range v.EphemeralResources(ctx) {
 				p.ephemeralResources = append(p.ephemeralResources, func() ephemeral.EphemeralResource { //nolint:contextcheck // must be a func()
-					return newWrappedEphemeralResource(ephemeralResourceSpec, servicePackageName)
+					return newWrappedEphemeralResource(ctx, ephemeralResourceSpec, servicePackageName)
 				})
 			}
 		}
@@ -444,14 +444,14 @@ func (p *frameworkProvider) initialize(ctx context.Context) {
 
 		for _, resourceSpec := range sp.FrameworkResources(ctx) {
 			p.resources = append(p.resources, func() resource.Resource { //nolint:contextcheck // must be a func()
-				return newWrappedResource(resourceSpec, servicePackageName)
+				return newWrappedResource(ctx, resourceSpec, servicePackageName)
 			})
 		}
 
 		if v, ok := sp.(conns.ServicePackageWithActions); ok {
 			for _, actionSpec := range v.Actions(ctx) {
 				p.actions = append(p.actions, func() action.Action { //nolint:contextcheck // must be a func()
-					return newWrappedAction(actionSpec, servicePackageName)
+					return newWrappedAction(ctx, actionSpec, servicePackageName)
 				})
 			}
 		}

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2"
 	inttypes "github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -124,18 +125,25 @@ func validateResourceSchemas(ctx context.Context, t *testing.T, p *frameworkProv
 				continue
 			}
 
-			schemaResponse := datasource.SchemaResponse{}
-			inner.Schema(ctx, datasource.SchemaRequest{}, &schemaResponse)
+			innerResponse := datasource.SchemaResponse{}
+			inner.Schema(ctx, datasource.SchemaRequest{}, &innerResponse)
 
-			if err := validateSchemaRegionForDataSource(dataSourceSpec.Region, schemaResponse.Schema); err != nil {
+			if err := validateSchemaRegionForDataSource(dataSourceSpec.Region, innerResponse.Schema); err != nil {
 				t.Errorf("data source type %q: %s", typeName, err)
 				continue
 			}
 
-			if err := validateSchemaTagsForDataSource(dataSourceSpec.Tags, schemaResponse.Schema); err != nil {
+			if err := validateSchemaTagsForDataSource(dataSourceSpec.Tags, innerResponse.Schema); err != nil {
 				t.Errorf("data source type %q: %s", typeName, err)
 				continue
 			}
+
+			outer := newWrappedDataSource(dataSourceSpec, sp.ServicePackageName())
+
+			outerResponse := datasource.SchemaResponse{}
+			outer.Schema(ctx, datasource.SchemaRequest{}, &outerResponse)
+
+			validateSchemaModelForDataSource(ctx, t, typeName, outer, outerResponse.Schema)
 		}
 
 		if v, ok := sp.(conns.ServicePackageWithEphemeralResources); ok {
@@ -213,6 +221,24 @@ func validateResourceSchemas(ctx context.Context, t *testing.T, p *frameworkProv
 					continue
 				}
 			}
+		}
+	}
+}
+
+func validateSchemaModelForDataSource(ctx context.Context, t *testing.T, typeName string, outer datasource.DataSourceWithConfigure, schema datasourceschema.Schema) {
+	t.Helper()
+
+	v, ok := outer.(*wrappedDataSource)
+	if !ok {
+		t.Errorf("data source %q is not a wrappedDataSource", typeName)
+		return
+	}
+
+	if v, ok := v.inner.(framework.DataSourceValidateModel); !ok {
+		t.Errorf("data source %q does not implement framework.DataSourceValidateModel", typeName)
+	} else {
+		if diags := v.ValidateModel(ctx, &schema); diags.HasError() {
+			t.Errorf("data source %q model validation error: %s", typeName, fwdiag.DiagnosticsString(diags))
 		}
 	}
 }

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -190,6 +190,13 @@ func validateResourceSchemas(ctx context.Context, t *testing.T, p *frameworkProv
 					t.Errorf("action type %q: %s", typeName, err)
 					continue
 				}
+
+				outer := newWrappedAction(actionSpec, sp.ServicePackageName())
+
+				outerResponse := action.SchemaResponse{}
+				outer.Schema(ctx, action.SchemaRequest{}, &outerResponse)
+
+				validateSchemaModelForAction(ctx, t, typeName, outer, outerResponse.Schema)
 			}
 		}
 
@@ -265,6 +272,25 @@ func validateSchemaModelForEphemeralResource(ctx context.Context, t *testing.T, 
 		diags := v.ValidateModel(ctx, &schema)
 		if diags.HasError() {
 			t.Errorf("ephemeral resource %q model validation error: %s", typeName, fwdiag.DiagnosticsString(diags))
+		}
+	}
+}
+
+func validateSchemaModelForAction(ctx context.Context, t *testing.T, typeName string, outer action.ActionWithConfigure, schema actionschema.Schema) {
+	t.Helper()
+
+	v, ok := outer.(*wrappedAction)
+	if !ok {
+		t.Errorf("action %q is not a wrappedAction", typeName)
+		return
+	}
+
+	if v, ok := v.inner.(framework.ActionValidateModel); !ok {
+		t.Errorf("action %q does not implement framework.ActionValidateModel", typeName)
+	} else {
+		diags := v.ValidateModel(ctx, &schema)
+		if diags.HasError() {
+			t.Errorf("action %q model validation error: %s", typeName, fwdiag.DiagnosticsString(diags))
 		}
 	}
 }

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -235,6 +235,13 @@ func validateResourceSchemas(ctx context.Context, t *testing.T, p *frameworkProv
 					continue
 				}
 			}
+
+			outer := newWrappedResource(resourceSpec, sp.ServicePackageName())
+
+			outerResponse := resource.SchemaResponse{}
+			outer.Schema(ctx, resource.SchemaRequest{}, &outerResponse)
+
+			validateSchemaModelForResource(ctx, t, typeName, outer, outerResponse.Schema)
 		}
 	}
 }
@@ -291,6 +298,31 @@ func validateSchemaModelForAction(ctx context.Context, t *testing.T, typeName st
 		diags := v.ValidateModel(ctx, &schema)
 		if diags.HasError() {
 			t.Errorf("action %q model validation error: %s", typeName, fwdiag.DiagnosticsString(diags))
+		}
+	}
+}
+
+func validateSchemaModelForResource(ctx context.Context, t *testing.T, typeName string, outer resource.ResourceWithConfigure, schema resourceschema.Schema) {
+	t.Helper()
+
+	var v *wrappedResource
+	switch x := outer.(type) {
+	case *wrappedResource:
+		v = x
+	case *wrappedResourceWithIdentity:
+		v = &x.wrappedResource
+	default:
+		t.Errorf("resource %q is not a wrappedResource or wrappedResourceWithIdentity", typeName)
+		return
+	}
+
+	if v, ok := v.inner.(framework.ResourceValidateModel); !ok {
+		if typeName != "aws_lexv2models_bot_version" { // Hacky yukkery caused by attribute of type map[string]Object.
+			t.Errorf("resource %q does not implement framework.ResourceValidateModel", typeName)
+		}
+	} else {
+		if diags := v.ValidateModel(ctx, &schema); diags.HasError() {
+			t.Errorf("resource %q model validation error: %s", typeName, fwdiag.DiagnosticsString(diags))
 		}
 	}
 }

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -138,7 +138,7 @@ func validateResourceSchemas(ctx context.Context, t *testing.T, p *frameworkProv
 				continue
 			}
 
-			outer := newWrappedDataSource(dataSourceSpec, sp.ServicePackageName())
+			outer := newWrappedDataSource(ctx, dataSourceSpec, sp.ServicePackageName())
 
 			outerResponse := datasource.SchemaResponse{}
 			outer.Schema(ctx, datasource.SchemaRequest{}, &outerResponse)
@@ -164,7 +164,7 @@ func validateResourceSchemas(ctx context.Context, t *testing.T, p *frameworkProv
 					continue
 				}
 
-				outer := newWrappedEphemeralResource(ephemeralResourceSpec, sp.ServicePackageName())
+				outer := newWrappedEphemeralResource(ctx, ephemeralResourceSpec, sp.ServicePackageName())
 
 				outerResponse := ephemeral.SchemaResponse{}
 				outer.Schema(ctx, ephemeral.SchemaRequest{}, &outerResponse)
@@ -191,7 +191,7 @@ func validateResourceSchemas(ctx context.Context, t *testing.T, p *frameworkProv
 					continue
 				}
 
-				outer := newWrappedAction(actionSpec, sp.ServicePackageName())
+				outer := newWrappedAction(ctx, actionSpec, sp.ServicePackageName())
 
 				outerResponse := action.SchemaResponse{}
 				outer.Schema(ctx, action.SchemaRequest{}, &outerResponse)
@@ -236,7 +236,7 @@ func validateResourceSchemas(ctx context.Context, t *testing.T, p *frameworkProv
 				}
 			}
 
-			outer := newWrappedResource(resourceSpec, sp.ServicePackageName())
+			outer := newWrappedResource(ctx, resourceSpec, sp.ServicePackageName())
 
 			outerResponse := resource.SchemaResponse{}
 			outer.Schema(ctx, resource.SchemaRequest{}, &outerResponse)

--- a/internal/provider/framework/provider_test.go
+++ b/internal/provider/framework/provider_test.go
@@ -163,6 +163,13 @@ func validateResourceSchemas(ctx context.Context, t *testing.T, p *frameworkProv
 					t.Errorf("ephemeral resource type %q: %s", typeName, err)
 					continue
 				}
+
+				outer := newWrappedEphemeralResource(ephemeralResourceSpec, sp.ServicePackageName())
+
+				outerResponse := ephemeral.SchemaResponse{}
+				outer.Schema(ctx, ephemeral.SchemaRequest{}, &outerResponse)
+
+				validateSchemaModelForEphemeralResource(ctx, t, typeName, outer, outerResponse.Schema)
 			}
 		}
 
@@ -239,6 +246,25 @@ func validateSchemaModelForDataSource(ctx context.Context, t *testing.T, typeNam
 	} else {
 		if diags := v.ValidateModel(ctx, &schema); diags.HasError() {
 			t.Errorf("data source %q model validation error: %s", typeName, fwdiag.DiagnosticsString(diags))
+		}
+	}
+}
+
+func validateSchemaModelForEphemeralResource(ctx context.Context, t *testing.T, typeName string, outer ephemeral.EphemeralResourceWithConfigure, schema ephemeralschema.Schema) {
+	t.Helper()
+
+	v, ok := outer.(*wrappedEphemeralResource)
+	if !ok {
+		t.Errorf("ephemeral resource %q is not a wrappedEphemeralResource", typeName)
+		return
+	}
+
+	if v, ok := v.inner.(framework.EphemeralResourceValidateModel); !ok {
+		t.Errorf("ephemeral resource %q does not implement framework.EphemeralResourceValidateModel", typeName)
+	} else {
+		diags := v.ValidateModel(ctx, &schema)
+		if diags.HasError() {
+			t.Errorf("ephemeral resource %q model validation error: %s", typeName, fwdiag.DiagnosticsString(diags))
 		}
 	}
 }

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -47,7 +47,7 @@ type wrappedDataSource struct {
 	interceptors       interceptorInvocations
 }
 
-func newWrappedDataSource(spec *inttypes.ServicePackageFrameworkDataSource, servicePackageName string) datasource.DataSourceWithConfigure {
+func newWrappedDataSource(ctx context.Context, spec *inttypes.ServicePackageFrameworkDataSource, servicePackageName string) datasource.DataSourceWithConfigure {
 	var isRegionOverrideEnabled bool
 	if regionSpec := spec.Region; !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
 		isRegionOverrideEnabled = true
@@ -69,7 +69,7 @@ func newWrappedDataSource(spec *inttypes.ServicePackageFrameworkDataSource, serv
 		interceptors = append(interceptors, dataSourceTransparentTagging(spec.Tags))
 	}
 
-	inner, _ := spec.Factory(context.TODO())
+	inner, _ := spec.Factory(ctx)
 
 	return &wrappedDataSource{
 		inner:              inner,
@@ -200,7 +200,7 @@ type wrappedEphemeralResource struct {
 	interceptors       interceptorInvocations
 }
 
-func newWrappedEphemeralResource(spec *inttypes.ServicePackageEphemeralResource, servicePackageName string) ephemeral.EphemeralResourceWithConfigure {
+func newWrappedEphemeralResource(ctx context.Context, spec *inttypes.ServicePackageEphemeralResource, servicePackageName string) ephemeral.EphemeralResourceWithConfigure {
 	var isRegionOverrideEnabled bool
 	if regionSpec := spec.Region; !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
 		isRegionOverrideEnabled = true
@@ -218,7 +218,7 @@ func newWrappedEphemeralResource(spec *inttypes.ServicePackageEphemeralResource,
 		interceptors = append(interceptors, ephemeralResourceSetRegionInResult())
 	}
 
-	inner, _ := spec.Factory(context.TODO())
+	inner, _ := spec.Factory(ctx)
 
 	return &wrappedEphemeralResource{
 		inner:              inner,
@@ -358,7 +358,7 @@ type wrappedAction struct {
 	interceptors       interceptorInvocations
 }
 
-func newWrappedAction(spec *inttypes.ServicePackageAction, servicePackageName string) action.ActionWithConfigure {
+func newWrappedAction(ctx context.Context, spec *inttypes.ServicePackageAction, servicePackageName string) action.ActionWithConfigure {
 	var isRegionOverrideEnabled bool
 	if regionSpec := spec.Region; !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
 		isRegionOverrideEnabled = true
@@ -375,7 +375,7 @@ func newWrappedAction(spec *inttypes.ServicePackageAction, servicePackageName st
 		}
 	}
 
-	inner, _ := spec.Factory(context.TODO())
+	inner, _ := spec.Factory(ctx)
 
 	return &wrappedAction{
 		inner:              inner,
@@ -497,7 +497,7 @@ type wrappedResource struct {
 	interceptors       interceptorInvocations
 }
 
-func newWrappedResource(spec *inttypes.ServicePackageFrameworkResource, servicePackageName string) resource.ResourceWithConfigure {
+func newWrappedResource(ctx context.Context, spec *inttypes.ServicePackageFrameworkResource, servicePackageName string) resource.ResourceWithConfigure {
 	var isRegionOverrideEnabled bool
 	if v := spec.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {
 		isRegionOverrideEnabled = true
@@ -527,7 +527,7 @@ func newWrappedResource(spec *inttypes.ServicePackageFrameworkResource, serviceP
 		interceptors = append(interceptors, resourceValidateRequiredTags())
 	}
 
-	inner, _ := spec.Factory(context.TODO())
+	inner, _ := spec.Factory(ctx)
 
 	if len(spec.Identity.Attributes) == 0 {
 		return &wrappedResource{

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -269,17 +269,6 @@ func (w *wrappedEphemeralResource) Schema(ctx context.Context, request ephemeral
 	}
 
 	interceptedHandler(w.interceptors.ephemeralResourceSchema(), w.inner.Schema, ephemeralSchemaHasError, w.meta)(ctx, request, response)
-
-	// Validate the ephemeral resource's model against the schema.
-	if v, ok := w.inner.(framework.EphemeralResourceValidateModel); ok {
-		response.Diagnostics.Append(v.ValidateModel(ctx, &response.Schema)...)
-		if response.Diagnostics.HasError() {
-			response.Diagnostics.AddError("ephemeral resource model validation error", w.spec.TypeName)
-			return
-		}
-	} else {
-		response.Diagnostics.AddError("missing framework.EphemeralResourceValidateModel", w.spec.TypeName)
-	}
 }
 
 func (w *wrappedEphemeralResource) Open(ctx context.Context, request ephemeral.OpenRequest, response *ephemeral.OpenResponse) {

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -429,17 +429,6 @@ func (w *wrappedAction) Schema(ctx context.Context, request action.SchemaRequest
 		w.inner.Schema(ctx, request, response)
 	}
 	interceptedHandler(w.interceptors.actionSchema(), f, actionSchemaHasError, w.meta)(ctx, request, response)
-
-	// Validate the action's model against the schema.
-	if v, ok := w.inner.(framework.ActionValidateModel); ok {
-		response.Diagnostics.Append(v.ValidateModel(ctx, &response.Schema)...)
-		if response.Diagnostics.HasError() {
-			response.Diagnostics.AddError("action model validation error", w.spec.TypeName)
-			return
-		}
-	} else {
-		response.Diagnostics.AddError("missing framework.ActionValidateModel", w.spec.TypeName)
-	}
 }
 
 func (w *wrappedAction) Invoke(ctx context.Context, request action.InvokeRequest, response *action.InvokeResponse) {

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -135,17 +135,6 @@ func (w *wrappedDataSource) Schema(ctx context.Context, request datasource.Schem
 	if response.Diagnostics.HasError() {
 		return
 	}
-
-	// Validate the data source's model against the schema.
-	if v, ok := w.inner.(framework.DataSourceValidateModel); ok {
-		response.Diagnostics.Append(v.ValidateModel(ctx, &response.Schema)...)
-		if response.Diagnostics.HasError() {
-			response.Diagnostics.AddError("data source model validation error", w.spec.TypeName)
-			return
-		}
-	} else {
-		response.Diagnostics.AddError("missing framework.DataSourceValidateModel", w.spec.TypeName)
-	}
 }
 
 func (w *wrappedDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -618,17 +618,6 @@ func (w *wrappedResource) Schema(ctx context.Context, request resource.SchemaReq
 	}
 
 	interceptedHandler(w.interceptors.resourceSchema(), w.inner.Schema, resourceSchemaHasError, w.meta)(ctx, request, response)
-
-	// Validate the resource's model against the schema.
-	if v, ok := w.inner.(framework.ResourceValidateModel); ok {
-		response.Diagnostics.Append(v.ValidateModel(ctx, &response.Schema)...)
-		if response.Diagnostics.HasError() {
-			response.Diagnostics.AddError("resource model validation error", w.spec.TypeName)
-			return
-		}
-	} else if w.spec.TypeName != "aws_lexv2models_bot_version" { // Hacky yukkery caused by attribute of type map[string]Object.
-		response.Diagnostics.AddError("missing framework.ResourceValidateModel", w.spec.TypeName)
-	}
 }
 
 func (w *wrappedResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Moves Framework model validation out of runtime and into `TestFrameworkInit`.

Improves memory usage at initialization time by approximately 93%. `benchstat` output from `go test -bench=. -benchmem -run=^$ -count=10 -v ./internal/provider/framework` before and after changes:

```
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/terraform-provider-aws/internal/provider/framework
cpu: Apple M1 Max
                                                     │    old.txt    │               new.txt               │
                                                     │    sec/op     │   sec/op     vs base                │
FrameworkProvider_SchemaInitialization_DataSource-10   11762.3µ ± 2%   682.0µ ± 2%  -94.20% (p=0.000 n=10)
FrameworkProvider_SchemaInitialization_Resource-10      199.31m ± 5%   16.21m ± 2%  -91.86% (p=0.000 n=10)
geomean                                                  48.42m        3.325m       -93.13%

                                                     │    old.txt     │               new.txt                │
                                                     │      B/op      │     B/op      vs base                │
FrameworkProvider_SchemaInitialization_DataSource-10   10727.3Ki ± 0%   707.6Ki ± 0%  -93.40% (p=0.000 n=10)
FrameworkProvider_SchemaInitialization_Resource-10      196.36Mi ± 0%   14.97Mi ± 0%  -92.38% (p=0.000 n=10)
geomean                                                  45.35Mi        3.217Mi       -92.91%

                                                     │    old.txt    │               new.txt               │
                                                     │   allocs/op   │  allocs/op   vs base                │
FrameworkProvider_SchemaInitialization_DataSource-10   136.447k ± 0%   7.707k ± 0%  -94.35% (p=0.000 n=10)
FrameworkProvider_SchemaInitialization_Resource-10      2466.1k ± 0%   178.1k ± 0%  -92.78% (p=0.000 n=10)
geomean                                                  580.1k        37.05k       -93.61%
```
