### PR TITLE
[Enhancement] aws_lb_target_group: Add Gateway Load Balancer TCP reset attributes

### DIFF
--- a/.changelog/49969.txt
+++ b/.changelog/49969.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lb_target_group: Add `send_tcp_reset` configuration block for Gateway Load Balancer target groups
+```

--- a/internal/service/elbv2/const.go
+++ b/internal/service/elbv2/const.go
@@ -126,8 +126,10 @@ const (
 	targetGroupAttributeTargetHealthStateUnhealthyDrainingIntervalSeconds      = "target_health_state.unhealthy.draining_interval_seconds"
 
 	// The following attributes are supported only by Gateway Load Balancers:
-	targetGroupAttributeTargetFailoverOnDeregistration = "target_failover.on_deregistration"
-	targetGroupAttributeTargetFailoverOnUnhealthy      = "target_failover.on_unhealthy"
+	targetGroupAttributeSendTCPResetOnDeregistrationEnabled = "send_tcp_reset.on_deregistration.enabled"
+	targetGroupAttributeSendTCPResetOnUnhealthyEnabled      = "send_tcp_reset.on_unhealthy.enabled"
+	targetGroupAttributeTargetFailoverOnDeregistration      = "target_failover.on_deregistration"
+	targetGroupAttributeTargetFailoverOnUnhealthy           = "target_failover.on_unhealthy"
 )
 
 const (

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -262,11 +262,13 @@ func resourceTargetGroup() *schema.Resource {
 						Schema: map[string]*schema.Schema{
 							"on_deregistration": {
 								Type:     schema.TypeBool,
-								Required: true,
+								Optional: true,
+								Computed: true,
 							},
 							"on_unhealthy": {
 								Type:     schema.TypeBool,
-								Required: true,
+								Optional: true,
+								Computed: true,
 							},
 						},
 					},

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -254,6 +254,23 @@ func resourceTargetGroup() *schema.Resource {
 					Optional: true,
 					Default:  false,
 				},
+				"send_tcp_reset": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"on_deregistration": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+							"on_unhealthy": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+						},
+					},
+				},
 				"slow_start": {
 					Type:     schema.TypeInt,
 					Optional: true,
@@ -549,6 +566,10 @@ func resourceTargetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	switch targetType {
 	case awstypes.TargetTypeEnumInstance, awstypes.TargetTypeEnumIp:
+		if v, ok := d.GetOk("send_tcp_reset"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			attributes = append(attributes, expandTargetGroupSendTCPResetAttributes(v.([]any)[0].(map[string]any), protocol)...)
+		}
+
 		if v, ok := d.GetOk("stickiness"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 			attributes = append(attributes, expandTargetGroupStickinessAttributes(v.([]any)[0].(map[string]any), protocol)...)
 		}
@@ -660,6 +681,10 @@ func resourceTargetGroupFlatten(ctx context.Context, awsClient *conns.AWSClient,
 		return fmt.Errorf("reading ELBv2 Target Group (%s) attributes: %w", d.Id(), err)
 	}
 
+	if err := d.Set("send_tcp_reset", []any{flattenTargetGroupSendTCPResetAttributes(attributes, protocol)}); err != nil {
+		return fmt.Errorf("setting send_tcp_reset: %w", err)
+	}
+
 	if err := d.Set("stickiness", []any{flattenTargetGroupStickinessAttributes(attributes, protocol)}); err != nil {
 		return fmt.Errorf("setting stickiness: %w", err)
 	}
@@ -752,6 +777,12 @@ func resourceTargetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 					Key:   aws.String(targetGroupAttributeStickinessEnabled),
 					Value: flex.BoolValueToString(false),
 				})
+			}
+		}
+
+		if d.HasChange("send_tcp_reset") {
+			if v, ok := d.GetOk("send_tcp_reset"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				attributes = append(attributes, expandTargetGroupSendTCPResetAttributes(v.([]any)[0].(map[string]any), protocol)...)
 			}
 		}
 
@@ -1300,6 +1331,51 @@ func flattenTargetGroupStickinessAttributes(apiObjects []awstypes.TargetGroupAtt
 				tfMap["cookie_name"] = aws.ToString(v)
 			case k == targetGroupAttributeStickinessAppCookieDurationSeconds && stickinessType == stickinessTypeAppCookie:
 				tfMap["cookie_duration"] = flex.StringToIntValue(v)
+			}
+		}
+	}
+
+	return tfMap
+}
+
+func expandTargetGroupSendTCPResetAttributes(tfMap map[string]any, protocol awstypes.ProtocolEnum) []awstypes.TargetGroupAttribute {
+	if tfMap == nil {
+		return nil
+	}
+
+	var apiObjects []awstypes.TargetGroupAttribute
+
+	switch protocol {
+	case awstypes.ProtocolEnumGeneve:
+		apiObjects = append(apiObjects,
+			awstypes.TargetGroupAttribute{
+				Key:   aws.String(targetGroupAttributeSendTCPResetOnDeregistrationEnabled),
+				Value: flex.BoolValueToString(tfMap["on_deregistration"].(bool)),
+			},
+			awstypes.TargetGroupAttribute{
+				Key:   aws.String(targetGroupAttributeSendTCPResetOnUnhealthyEnabled),
+				Value: flex.BoolValueToString(tfMap["on_unhealthy"].(bool)),
+			})
+	}
+
+	return apiObjects
+}
+
+func flattenTargetGroupSendTCPResetAttributes(apiObjects []awstypes.TargetGroupAttribute, protocol awstypes.ProtocolEnum) map[string]any {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	switch protocol {
+	case awstypes.ProtocolEnumGeneve:
+		for _, apiObject := range apiObjects {
+			switch k, v := aws.ToString(apiObject.Key), apiObject.Value; k {
+			case targetGroupAttributeSendTCPResetOnDeregistrationEnabled:
+				tfMap["on_deregistration"] = flex.StringToBoolValue(v)
+			case targetGroupAttributeSendTCPResetOnUnhealthyEnabled:
+				tfMap["on_unhealthy"] = flex.StringToBoolValue(v)
 			}
 		}
 	}

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -1182,6 +1182,64 @@ func TestAccELBV2TargetGroup_Geneve_Sticky(t *testing.T) {
 	})
 }
 
+func TestAccELBV2TargetGroup_Geneve_sendTCPReset(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.TargetGroup
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	resourceName := "aws_lb_target_group.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGatewayLoadBalancer(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTargetGroupDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTargetGroupConfig_protocolGeneveSendTCPReset(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTargetGroupExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPort, "6081"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrProtocol, string(awstypes.ProtocolEnumGeneve)),
+					resource.TestCheckResourceAttr(resourceName, "send_tcp_reset.0.on_deregistration", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "send_tcp_reset.0.on_unhealthy", acctest.CtFalse),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"connection_termination",
+					"lambda_multi_value_headers_enabled",
+					"proxy_protocol_v2",
+					"slow_start",
+				},
+			},
+			{
+				Config: testAccTargetGroupConfig_protocolGeneveSendTCPReset(rName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTargetGroupExists(ctx, t, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPort, "6081"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrProtocol, string(awstypes.ProtocolEnumGeneve)),
+					resource.TestCheckResourceAttr(resourceName, "send_tcp_reset.0.on_deregistration", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "send_tcp_reset.0.on_unhealthy", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"connection_termination",
+					"lambda_multi_value_headers_enabled",
+					"proxy_protocol_v2",
+					"slow_start",
+				},
+			},
+		},
+	})
+}
+
 func TestAccELBV2TargetGroup_Geneve_targetFailover(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.TargetGroup
@@ -4855,6 +4913,33 @@ resource "aws_lb_target_group" "test" {
   }
 }
 `, rName)
+}
+
+func testAccTargetGroupConfig_protocolGeneveSendTCPReset(rName string, sendTCPReset bool) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.10.10.0/25"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 6081
+  protocol = "GENEVE"
+  vpc_id   = aws_vpc.test.id
+  send_tcp_reset {
+    on_deregistration = %[2]t
+    on_unhealthy      = %[2]t
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, sendTCPReset)
 }
 
 func testAccTargetGroupConfig_protocolGeneveSticky(rName, stickinessType string) string {

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -126,6 +126,7 @@ This resource supports the following arguments:
   Required when `target_type` is `instance`, `ip`, or `alb`.
   Does not apply when `target_type` is `lambda`.
 * `proxy_protocol_v2` - (Optional) Whether to enable support for proxy protocol v2 on Network Load Balancers. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#proxy-protocol) for more information. Default is `false`.
+* `send_tcp_reset` - (Optional) Send TCP reset configuration block. Only applicable for Gateway Load Balancer target groups. See [send_tcp_reset](#send_tcp_reset) for more information.
 * `slow_start` - (Optional) Amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds.
 * `stickiness` - (Optional, Maximum of 1) Stickiness configuration block. Detailed below.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
@@ -185,6 +186,13 @@ This resource supports the following arguments:
 * `cookie_name` - (Optional) Name of the application based cookie. AWSALB, AWSALBAPP, and AWSALBTG prefixes are reserved and cannot be used. Only needed when type is `app_cookie`.
 * `enabled` - (Optional) Boolean to enable / disable `stickiness`. Default is `true`.
 * `type` - (Required) The type of sticky sessions. The only current possible values are `lb_cookie`, `app_cookie` for ALBs, `source_ip` for NLBs, and `source_ip_dest_ip`, `source_ip_dest_ip_proto` for GWLBs.
+
+### send_tcp_reset
+
+~> **NOTE:** This block is only applicable for a Gateway Load Balancer (GWLB). This feature requires 5-tuple flow stickiness, which the target group uses by default when `stickiness` is not enabled.
+
+* `on_deregistration` - (Optional) Whether the GWLB sends a TCP reset (RST) to the sender of traffic when a target is deregistered. The reset occurs after the connection drain time has elapsed. Possible values are `true` or `false`. Default: `false`. This attribute does not apply when `target_failover.on_deregistration` is set to `rebalance`.
+* `on_unhealthy` - (Optional) Whether the GWLB sends a TCP reset (RST) to the sender of traffic when a target becomes unhealthy. Possible values are `true` or `false`. Default: `false`. This attribute does not apply when `target_failover.on_unhealthy` is set to `rebalance`.
 
 ### target_failover
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds new attribute `send_tcp_reset` to add support for TCP Reset with Gateway Load Balancer. Supports TCP reset when a target is unhealthy (`on_unhealthy.enabled`) and deregistered (`on_deregistration.enabled`). 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49852

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
SDK for Go v2: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2#Client.ModifyTargetGroupAttributes
ModifyTargetGroupAttributes API: https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_ModifyTargetGroupAttributes.html

### Output from Acceptance Testing
```console
$ make testacc PKG=elbv2 TESTS=TestAccELBV2TargetGroup_Geneve_sendTCPReset   
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Validating schemas
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2     (cached)
ok      github.com/hashicorp/terraform-provider-aws/internal/provider/framework (cached)
make: Running acceptance tests on branch: 🌿 f-aws_lb_target_group-send_tcp_reset 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TargetGroup_Geneve_sendTCPReset'  -timeout 360m -vet=off -buildvcs=false
2026/09/11 19:19:30 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/11 19:19:30 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccELBV2TargetGroup_Geneve_sendTCPReset
=== PAUSE TestAccELBV2TargetGroup_Geneve_sendTCPReset
=== CONT  TestAccELBV2TargetGroup_Geneve_sendTCPReset
--- PASS: TestAccELBV2TargetGroup_Geneve_sendTCPReset (51.81s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      52.013s
```

