### PR TITLE
docs: replace invalid value in example

### DIFF
--- a/website/docs/r/bedrockagentcore_gateway.html.markdown
+++ b/website/docs/r/bedrockagentcore_gateway.html.markdown
@@ -69,7 +69,7 @@ resource "aws_bedrockagentcore_gateway" "example" {
   protocol_configuration {
     mcp {
       instructions       = "Gateway for handling MCP requests"
-      search_type        = "HYBRID"
+      search_type        = "SEMANTIC"
       supported_versions = ["2025-03-26", "2025-06-18"]
     }
   }


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls.

### Description

The example code in section [Gateway with advanced JWT Authorization and MCP Configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_gateway#gateway-with-advanced-jwt-authorization-and-mcp-configuration) for resource [`aws_bedrockagentcore_gateway`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_gateway) is updated to no longer use the invalid value `HYBRID`. Only `SEMANTIC` is supported for [`search_type`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagentcore_gateway#search_type-1)

### Relations

Closes #49944

### References

- [Resource code in provider](https://github.com/hashicorp/terraform-provider-aws/blob/9c81245db08e51cdb3267e3a69c359bf68c50542/internal/service/bedrockagentcore/gateway.go#L225) showing usage of `awstypes.SearchType`
- [AWS SDK Go V2- SearchType definition](https://github.com/aws/aws-sdk-go-v2/blob/a7eaa1049236d17c89832b88edea1378b54e95d7/service/bedrockagentcorecontrol/types/enums.go#L2204)
### Output from Acceptance Testing

Not applicable. Only documentation is updated.