### PR TITLE
[bugfix] aws_elasticache_user modify race condition fix

### DIFF
--- a/.changelog/49976.txt
+++ b/.changelog/49976.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_user: Retry `ModifyUser` on `InvalidUserState` errors so updates succeed when a concurrent operation has briefly put the user in the `modifying` state
+```

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -297,9 +297,10 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 			}
 		}
 
-		_, err := conn.ModifyUser(ctx, input)
-
-		if err != nil {
+		// Retry ModifyUser while the user is transiently "modifying" (InvalidUserState): https://github.com/hashicorp/terraform-provider-aws/issues/49726.
+		if _, err := tfresource.RetryWhenIsA[any, *awstypes.InvalidUserStateFault](ctx, d.Timeout(schema.TimeoutUpdate), func(ctx context.Context) (any, error) {
+			return conn.ModifyUser(ctx, input)
+		}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating ElastiCache User (%s): %s", d.Id(), err)
 		}
 


### PR DESCRIPTION
<!-- Copyright IBM Corp. 2014, 2026 -->
<!-- SPDX-License-Identifier: MPL-2.0 -->

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updating an `aws_elasticache_user` in the same apply as related resources (a user group membership change and a serverless cache update) can fail intermittently. A concurrent operation briefly puts the user in the `modifying` state, and `ModifyUser` then returns `InvalidUserState: ... Only active users can be modified.`

Before this change, `resourceUserUpdate` called `ModifyUser` with no retry, so it failed right away on that transient error. This wraps the call in `tfresource.RetryWhenIsA[any, *awstypes.InvalidUserStateFault]` using the update timeout, so it retries with backoff until the user is modifiable. This matches the existing pattern in `user_group_association.go`, which wraps `ModifyUserGroup` the same way for `InvalidUserGroupStateFault`. Retrying also handles the case where the user re-enters `modifying` right before the call, which a plain wait-for-active would miss.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #49726

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccElastiCacheUser PKG=elasticache ACCTEST_PARALLELISM=1 ACCTEST_TIMEOUT=4880m
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
xargs: gofmt: No such file or directory
make: Validating schemas
go: downloading github.com/hashicorp/terraform-plugin-log v0.11.0
go: downloading github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.20.0
go: downloading github.com/aws/aws-sdk-go-v2 v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/config v1.33.4
go: downloading github.com/aws/aws-sdk-go-v2/service/sts v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/account v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.56.0
go: downloading github.com/aws/aws-sdk-go-v2/service/accountaccess v1.6.0
go: downloading github.com/aws/aws-sdk-go-v2/service/acm v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/acmpca v1.56.0
go: downloading github.com/aws/aws-sdk-go-v2/service/amplify v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/agentregistrycontrol v1.6.0
go: downloading github.com/aws/aws-sdk-go-v2/service/apigateway v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/amp v1.54.0
go: downloading github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appconfig v1.53.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appfabric v1.24.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appintegrations v1.46.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appflow v1.61.0
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationinsights v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.30.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appmesh v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/apprunner v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appstream v1.70.0
go: downloading github.com/aws/aws-sdk-go-v2/service/arcregionswitch v1.19.0
go: downloading github.com/aws/aws-sdk-go-v2/service/arczonalshift v1.30.0
go: downloading github.com/aws/aws-sdk-go-v2/service/appsync v1.61.0
go: downloading github.com/aws/aws-sdk-go-v2/service/athena v1.66.0
go: downloading github.com/aws/aws-sdk-go-v2/service/auditmanager v1.54.0
go: downloading github.com/aws/aws-sdk-go-v2/service/autoscaling v1.78.0
go: downloading github.com/aws/aws-sdk-go-v2/service/autoscalingplans v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/backup v1.65.0
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrock v1.72.0
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.65.0
go: downloading github.com/aws/aws-sdk-go-v2/service/batch v1.75.0
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.66.0
go: downloading github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.24.0
go: downloading github.com/aws/aws-sdk-go-v2/service/billing v1.19.0
go: downloading github.com/aws/aws-sdk-go-v2/service/budgets v1.51.0
go: downloading github.com/aws/aws-sdk-go-v2/service/chatbot v1.22.0
go: downloading github.com/aws/aws-sdk-go-v2/service/chime v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.57.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloud9 v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudformation v1.81.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudfront v1.73.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.20.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.65.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.72.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.87.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codeartifact v1.46.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codebuild v1.78.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.28.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codecommit v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codeconnections v1.18.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codedeploy v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codepipeline v1.55.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.74.0
go: downloading golang.org/x/crypto v0.57.0
go: downloading github.com/aws/aws-sdk-go-v2/service/comprehend v1.49.0
go: downloading github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.62.0
go: downloading github.com/aws/aws-sdk-go-v2/service/configservice v1.74.0
go: downloading github.com/aws/aws-sdk-go-v2/service/connect v1.198.0
go: downloading github.com/aws/aws-sdk-go-v2/service/connectcases v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/controltower v1.37.0
go: downloading github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/costexplorer v1.72.0
go: downloading github.com/aws/aws-sdk-go-v2/service/costoptimizationhub v1.31.0
go: downloading github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.71.0
go: downloading github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.71.0
go: downloading github.com/aws/aws-sdk-go-v2/service/databrew v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dataexchange v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/datapipeline v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/datasync v1.67.0
go: downloading github.com/aws/aws-sdk-go-v2/service/datazone v1.74.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dax v1.38.1
go: downloading github.com/aws/aws-sdk-go-v2/service/detective v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/devicefarm v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/devopsagent v1.17.0
go: downloading github.com/aws/aws-sdk-go-v2/service/devopsguru v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/directconnect v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/directoryservice v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/directoryservicedata v1.15.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dlm v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/docdb v1.56.0
go: downloading github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.28.0
go: downloading github.com/aws/aws-sdk-go-v2/service/drs v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dsql v1.22.0
go: downloading github.com/aws/aws-sdk-go-v2/service/dynamodb v1.68.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ec2 v1.332.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ecr v1.65.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ecs v1.97.0
go: downloading github.com/aws/aws-sdk-go-v2/service/efs v1.49.0
go: downloading github.com/aws/aws-sdk-go-v2/service/eks v1.99.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticache v1.61.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.63.0
go: downloading github.com/aws/aws-sdk-go-v2/service/elasticsearchservice v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/emr v1.70.0
go: downloading github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.51.0
go: downloading github.com/aws/aws-sdk-go-v2/service/emrserverless v1.49.0
go: downloading github.com/aws/aws-sdk-go-v2/service/eventbridge v1.54.0
go: downloading github.com/aws/aws-sdk-go-v2/service/evs v1.20.0
go: downloading github.com/aws/aws-sdk-go-v2/service/finspace v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/firehose v1.51.0
go: downloading github.com/aws/aws-sdk-go-v2/service/fis v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/fms v1.53.0
go: downloading github.com/aws/aws-sdk-go-v2/service/fsx v1.74.0
go: downloading github.com/aws/aws-sdk-go-v2/service/gamelift v1.66.0
go: downloading github.com/aws/aws-sdk-go-v2/service/glacier v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/glue v1.158.0
go: downloading github.com/aws/aws-sdk-go-v2/service/grafana v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/greengrass v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/groundstation v1.51.0
go: downloading github.com/aws/aws-sdk-go-v2/service/guardduty v1.92.0
go: downloading github.com/aws/aws-sdk-go-v2/service/healthlake v1.49.0
go: downloading github.com/aws/aws-sdk-go-v2/service/iam v1.64.0
go: downloading github.com/aws/aws-sdk-go-v2/service/identitystore v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.63.0
go: downloading github.com/aws/aws-sdk-go-v2/service/inspector v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/inspector2 v1.59.0
go: downloading github.com/aws/aws-sdk-go-v2/service/interconnect v1.9.0
go: downloading github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/invoicing v1.18.0
go: downloading github.com/aws/aws-sdk-go-v2/service/iot v1.84.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ivs v1.61.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ivschat v1.29.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kafka v1.64.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kendra v1.69.0
go: downloading github.com/aws/aws-sdk-go-v2/service/keyspaces v1.33.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesis v1.54.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/kms v1.60.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lakeformation v1.55.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lambda v1.108.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lambdacore v1.7.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lambdamicrovms v1.7.0
go: downloading github.com/aws/aws-sdk-go-v2/service/launchwizard v1.23.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.70.0
go: downloading github.com/aws/aws-sdk-go-v2/service/lightsail v1.65.0
go: downloading github.com/aws/aws-sdk-go-v2/service/licensemanager v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/location v1.59.0
go: downloading github.com/aws/aws-sdk-go-v2/service/m2 v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/macie2 v1.59.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mailmanager v1.27.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.59.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.103.0
go: downloading github.com/aws/aws-sdk-go-v2/service/medialive v1.110.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackage v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.49.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mediastore v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mgn v1.56.0
go: downloading github.com/aws/aws-sdk-go-v2/service/memorydb v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mpa v1.15.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mq v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mwaa v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/mwaaserverless v1.9.0
go: downloading github.com/aws/aws-sdk-go-v2/service/neptune v1.53.0
go: downloading github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.30.0
go: downloading github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.72.0
go: downloading github.com/aws/aws-sdk-go-v2/service/networkflowmonitor v1.19.0
go: downloading github.com/aws/aws-sdk-go-v2/service/networkmanager v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.21.0
go: downloading github.com/aws/aws-sdk-go-v2/service/notifications v1.16.0
go: downloading github.com/aws/aws-sdk-go-v2/service/notificationscontacts v1.14.0
go: downloading github.com/aws/aws-sdk-go-v2/service/oam v1.31.0
go: downloading github.com/aws/aws-sdk-go-v2/service/observabilityadmin v1.28.0
go: downloading github.com/aws/aws-sdk-go-v2/service/odb v1.22.0
go: downloading github.com/aws/aws-sdk-go-v2/service/opensearch v1.80.0
go: downloading github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/organizations v1.60.0
go: downloading github.com/aws/aws-sdk-go-v2/service/osis v1.29.0
go: downloading github.com/aws/aws-sdk-go-v2/service/outposts v1.74.0
go: downloading github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.23.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pcs v1.29.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pinpoint v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pipes v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/polly v1.65.0
go: downloading github.com/aws/aws-sdk-go-v2/service/pricing v1.49.0
go: downloading github.com/aws/aws-sdk-go-v2/service/qbusiness v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/quicksight v1.130.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ram v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rbin v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rds v1.129.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rdsdata v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/redshift v1.71.0
go: downloading github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rekognition v1.59.0
go: downloading github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/resiliencehubv2 v1.10.0
go: downloading github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.33.0
go: downloading github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.31.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53 v1.70.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53domains v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53profiles v1.17.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.34.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53resolver v1.54.0
go: downloading github.com/aws/aws-sdk-go-v2/service/rum v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3 v1.113.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3control v1.79.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3files v1.8.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3outposts v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3tables v1.23.0
go: downloading github.com/aws/aws-sdk-go-v2/service/s3vectors v1.15.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sagemaker v1.277.0
go: downloading github.com/aws/aws-sdk-go-v2/service/savingsplans v1.40.0
go: downloading github.com/aws/aws-sdk-go-v2/service/scheduler v1.25.0
go: downloading github.com/aws/aws-sdk-go-v2/service/schemas v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.49.0
go: downloading github.com/aws/aws-sdk-go-v2/service/securityhub v1.81.0
go: downloading github.com/aws/aws-sdk-go-v2/service/securitylake v1.34.0
go: downloading github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.49.0
go: downloading github.com/aws/aws-sdk-go-v2/service/servicequotas v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ses v1.42.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sesv2 v1.73.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sfn v1.50.0
go: downloading github.com/aws/aws-sdk-go-v2/service/shield v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/signer v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sns v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sqs v1.52.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssm v1.78.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.39.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.17.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmsap v1.35.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sso v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.48.0
go: downloading github.com/aws/aws-sdk-go-v2/service/storagegateway v1.52.0
go: downloading github.com/aws/aws-sdk-go-v2/service/swf v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/synthetics v1.52.0
go: downloading github.com/aws/aws-sdk-go-v2/service/taxsettings v1.27.0
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.29.0
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.44.0
go: downloading github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/transcribe v1.65.0
go: downloading github.com/aws/aws-sdk-go-v2/service/transfer v1.82.0
go: downloading github.com/aws/aws-sdk-go-v2/service/uxc v1.8.0
go: downloading github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.41.0
go: downloading github.com/aws/aws-sdk-go-v2/service/vpclattice v1.32.0
go: downloading github.com/aws/aws-sdk-go-v2/service/waf v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/wafregional v1.38.0
go: downloading github.com/aws/aws-sdk-go-v2/service/wafv2 v1.83.0
go: downloading github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.49.0
go: downloading github.com/aws/aws-sdk-go-v2/service/workmail v1.45.0
go: downloading github.com/aws/aws-sdk-go-v2/service/workspaces v1.80.0
go: downloading github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.47.0
go: downloading github.com/aws/aws-sdk-go-v2/service/xray v1.45.0
go: downloading golang.org/x/text v0.42.0
go: downloading github.com/aws/aws-sdk-go-v2/credentials v1.20.4
go: downloading github.com/beevik/etree v1.8.0
go: downloading github.com/hashicorp/terraform-exec v0.25.3
go: downloading github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.23.5
go: downloading github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.3
go: downloading github.com/aws/aws-sdk-go-v2/internal/v4a v1.5.3
go: downloading github.com/aws/aws-sdk-go-v2/service/signin v1.10.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssooidc v1.43.0
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.14.3
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.13.3
go: downloading golang.org/x/net v0.59.0
go: downloading golang.org/x/exp v0.0.0-20260908205506-85c1c2202aba
go: downloading github.com/zclconf/go-cty v1.19.0
go: downloading github.com/hashicorp/go-plugin v1.8.0
go: downloading github.com/fatih/color v1.19.0
go: downloading github.com/hashicorp/hc-install v0.9.5
go: downloading github.com/mattn/go-isatty v0.0.24
go: downloading github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.3
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.20.3
go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20260908043556-f8649ddbbfe6
go: downloading github.com/cloudflare/circl v1.6.5
go: downloading golang.org/x/sys v0.48.0
go: downloading github.com/hashicorp/terraform-registry-address v0.5.0
go: downloading google.golang.org/protobuf v1.36.12
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.11.3
go: downloading github.com/mattn/go-colorable v0.1.15
go: downloading golang.org/x/mod v0.41.0
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/sdkv2	0.286s
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider/framework	0.265s
make: Running acceptance tests on branch: 🌿 f-elasticache-servless-user-modify-race 🌿...
TF_ACC=1 go1.26.6 test ./internal/service/elasticache/... -v -count 1 -parallel 1 -run='TestAccElastiCacheUser'  -timeout 4880m -vet=off -buildvcs=false
2026/09/12 04:17:10 Creating Terraform AWS Provider (SDKv2-style)...
2026/09/12 04:17:10 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccElastiCacheUserDataSource_basic
=== PAUSE TestAccElastiCacheUserDataSource_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_basic
=== PAUSE TestAccElastiCacheUserGroupAssociation_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_update
=== PAUSE TestAccElastiCacheUserGroupAssociation_update
=== RUN   TestAccElastiCacheUserGroupAssociation_disappears
=== PAUSE TestAccElastiCacheUserGroupAssociation_disappears
=== RUN   TestAccElastiCacheUserGroupAssociation_multiple
=== PAUSE TestAccElastiCacheUserGroupAssociation_multiple
=== RUN   TestAccElastiCacheUserGroup_basic
=== PAUSE TestAccElastiCacheUserGroup_basic
=== RUN   TestAccElastiCacheUserGroup_mixedCase
=== PAUSE TestAccElastiCacheUserGroup_mixedCase
=== RUN   TestAccElastiCacheUserGroup_update
=== PAUSE TestAccElastiCacheUserGroup_update
=== RUN   TestAccElastiCacheUserGroup_rotate
=== PAUSE TestAccElastiCacheUserGroup_rotate
=== RUN   TestAccElastiCacheUserGroup_engineValkey
=== PAUSE TestAccElastiCacheUserGroup_engineValkey
=== RUN   TestAccElastiCacheUserGroup_tags
=== PAUSE TestAccElastiCacheUserGroup_tags
=== RUN   TestAccElastiCacheUserGroup_disappears
=== PAUSE TestAccElastiCacheUserGroup_disappears
=== RUN   TestAccElastiCacheUser_basic
=== PAUSE TestAccElastiCacheUser_basic
=== RUN   TestAccElastiCacheUser_mixedCase
=== PAUSE TestAccElastiCacheUser_mixedCase
=== RUN   TestAccElastiCacheUser_passwordAuthMode
=== PAUSE TestAccElastiCacheUser_passwordAuthMode
=== RUN   TestAccElastiCacheUser_iamAuthMode
=== PAUSE TestAccElastiCacheUser_iamAuthMode
=== RUN   TestAccElastiCacheUser_update
=== PAUSE TestAccElastiCacheUser_update
=== RUN   TestAccElastiCacheUser_updateEngine
=== PAUSE TestAccElastiCacheUser_updateEngine
=== RUN   TestAccElastiCacheUser_updatePasswordAuthMode
=== PAUSE TestAccElastiCacheUser_updatePasswordAuthMode
=== RUN   TestAccElastiCacheUser_tags
=== PAUSE TestAccElastiCacheUser_tags
=== RUN   TestAccElastiCacheUser_disappears
=== PAUSE TestAccElastiCacheUser_disappears
=== RUN   TestAccElastiCacheUser_oobModify
=== PAUSE TestAccElastiCacheUser_oobModify
=== RUN   TestAccElastiCacheUser_passwordsWriteOnly
=== PAUSE TestAccElastiCacheUser_passwordsWriteOnly
=== CONT  TestAccElastiCacheUserDataSource_basic
--- PASS: TestAccElastiCacheUserDataSource_basic (70.39s)
=== CONT  TestAccElastiCacheUser_oobModify
--- PASS: TestAccElastiCacheUser_oobModify (182.23s)
=== CONT  TestAccElastiCacheUser_passwordsWriteOnly
--- PASS: TestAccElastiCacheUser_passwordsWriteOnly (120.30s)
=== CONT  TestAccElastiCacheUserGroup_disappears
--- PASS: TestAccElastiCacheUserGroup_disappears (183.83s)
=== CONT  TestAccElastiCacheUser_disappears
--- PASS: TestAccElastiCacheUser_disappears (226.66s)
=== CONT  TestAccElastiCacheUser_tags
--- PASS: TestAccElastiCacheUser_tags (85.38s)
=== CONT  TestAccElastiCacheUser_updatePasswordAuthMode
--- PASS: TestAccElastiCacheUser_updatePasswordAuthMode (174.77s)
=== CONT  TestAccElastiCacheUser_updateEngine
--- PASS: TestAccElastiCacheUser_updateEngine (130.30s)
=== CONT  TestAccElastiCacheUser_update
--- PASS: TestAccElastiCacheUser_update (120.31s)
=== CONT  TestAccElastiCacheUser_iamAuthMode
--- PASS: TestAccElastiCacheUser_iamAuthMode (64.89s)
=== CONT  TestAccElastiCacheUser_passwordAuthMode
--- PASS: TestAccElastiCacheUser_passwordAuthMode (54.42s)
=== CONT  TestAccElastiCacheUser_mixedCase
--- PASS: TestAccElastiCacheUser_mixedCase (64.57s)
=== CONT  TestAccElastiCacheUser_basic
--- PASS: TestAccElastiCacheUser_basic (64.62s)
=== CONT  TestAccElastiCacheUserGroup_mixedCase
=== CONT  TestAccElastiCacheUserGroup_engineValkey
--- PASS: TestAccElastiCacheUserGroup_mixedCase (175.21s)
--- PASS: TestAccElastiCacheUserGroup_engineValkey (246.54s)
=== CONT  TestAccElastiCacheUserGroup_tags
--- PASS: TestAccElastiCacheUserGroup_tags (186.41s)
=== CONT  TestAccElastiCacheUserGroup_rotate
--- PASS: TestAccElastiCacheUserGroup_rotate (486.62s)
=== CONT  TestAccElastiCacheUserGroup_update
--- PASS: TestAccElastiCacheUserGroup_update (309.63s)
=== CONT  TestAccElastiCacheUserGroupAssociation_disappears
--- PASS: TestAccElastiCacheUserGroupAssociation_disappears (304.81s)
=== CONT  TestAccElastiCacheUserGroup_basic
--- PASS: TestAccElastiCacheUserGroup_basic (195.38s)
=== CONT  TestAccElastiCacheUserGroupAssociation_multiple
--- PASS: TestAccElastiCacheUserGroupAssociation_multiple (435.49s)
=== CONT  TestAccElastiCacheUserGroupAssociation_basic
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (306.30s)
=== CONT  TestAccElastiCacheUserGroupAssociation_update
--- PASS: TestAccElastiCacheUserGroupAssociation_update (424.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	4614.020s
```
