### PR TITLE
fix(bedrockagent): resolve perpetual diff on deletion_protection_threshold

### DIFF
--- a/internal/service/bedrockagent/data_source.go
+++ b/internal/service/bedrockagent/data_source.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -279,8 +280,12 @@ func (r *dataSourceResource) Schema(ctx context.Context, request resource.Schema
 												},
 												"deletion_protection_threshold": schema.Int32Attribute{
 													Optional: true,
+													Computed: true,
 													Validators: []validator.Int32{
 														int32validator.Between(0, 100),
+													},
+													PlanModifiers: []planmodifier.Int32{
+														int32planmodifier.UseStateForUnknown(),
 													},
 												},
 											},
@@ -1009,6 +1014,14 @@ func (r *dataSourceResource) Create(ctx context.Context, request resource.Create
 
 	data.DataDeletionPolicy = fwtypes.StringEnumValue(ds.DataDeletionPolicy)
 
+	// Server-side defaults (e.g. deletion_protection_threshold) are only
+	// present on the post-create API response, so re-flatten the nested
+	// configuration to resolve any Computed values left unknown by config.
+	response.Diagnostics.Append(fwflex.Flatten(ctx, ds.DataSourceConfiguration, &data.DataSourceConfiguration)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
 
@@ -1081,9 +1094,18 @@ func (r *dataSourceResource) Update(ctx context.Context, request resource.Update
 		return
 	}
 
-	if _, err := waitDataSourceUpdated(ctx, conn, dataSourceID, knowledgeBaseID, r.DeleteTimeout(ctx, new.Timeouts)); err != nil {
+	ds, err := waitDataSourceUpdated(ctx, conn, dataSourceID, knowledgeBaseID, r.DeleteTimeout(ctx, new.Timeouts))
+	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("waiting for Bedrock Agent Data Source (%s,%s) update", dataSourceID, knowledgeBaseID), err.Error())
 
+		return
+	}
+
+	// Server-side defaults (e.g. deletion_protection_threshold) are only
+	// present on the post-update API response, so re-flatten the nested
+	// configuration to resolve any Computed values left unknown by config.
+	response.Diagnostics.Append(fwflex.Flatten(ctx, ds.DataSourceConfiguration, &new.DataSourceConfiguration)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/service/bedrockagent/data_source_test.go
+++ b/internal/service/bedrockagent/data_source_test.go
@@ -636,6 +636,17 @@ func testAccDataSource_managedKBConnector_mediaExtraction(t *testing.T) {
 				),
 			},
 			{
+				// Forces an Update call (not just Create) while deletion_protection_threshold
+				// stays unset, to guard against the same perpetual-diff regression on the
+				// update path.
+				Config: testAccDataSourceConfig_managedKBConnector_mediaExtraction_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceExists(ctx, t, resourceName, &dataSource),
+					resource.TestCheckResourceAttr(resourceName, "data_source_configuration.0.managed_knowledge_base_connector_configuration.0.media_extraction_configuration.0.audio_extraction_configuration.0.audio_extraction_status", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "data_source_configuration.0.managed_knowledge_base_connector_configuration.0.media_extraction_configuration.0.image_extraction_configuration.0.image_extraction_status", "ENABLED"),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1179,6 +1190,51 @@ resource "aws_bedrockagent_data_source" "test" {
         }
         image_extraction_configuration {
           image_extraction_status = "DISABLED"
+        }
+      }
+
+      deletion_protection_configuration {
+        deletion_protection_status = "DISABLED"
+      }
+    }
+  }
+}
+`, rName))
+}
+
+// testAccDataSourceConfig_managedKBConnector_mediaExtraction_update is identical to
+// testAccDataSourceConfig_managedKBConnector_mediaExtraction except it toggles the
+// extraction statuses, forcing an Update call while deletion_protection_threshold
+// remains unset in both configs.
+func testAccDataSourceConfig_managedKBConnector_mediaExtraction_update(rName string) string {
+	return acctest.ConfigCompose(testAccDataSourceConfig_managedKBConnector_base(rName), fmt.Sprintf(`
+resource "aws_bedrockagent_data_source" "test" {
+  name              = %[1]q
+  knowledge_base_id = aws_bedrockagent_knowledge_base.test.id
+
+  data_source_configuration {
+    type = "MANAGED_KNOWLEDGE_BASE_CONNECTOR"
+
+    managed_knowledge_base_connector_configuration {
+      connector_parameters = jsonencode({
+        type    = "S3"
+        version = "1"
+        connectionConfiguration = {
+          bucketName           = aws_s3_bucket.test.bucket
+          bucketOwnerAccountId = data.aws_caller_identity.current.account_id
+        }
+        aclEnabled = false
+        filterConfiguration = {
+          maxFileSizeInMegaBytes = "500"
+        }
+      })
+
+      media_extraction_configuration {
+        audio_extraction_configuration {
+          audio_extraction_status = "DISABLED"
+        }
+        image_extraction_configuration {
+          image_extraction_status = "ENABLED"
         }
       }
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to access controls, encryption, or logging.

### Description

`aws_bedrockagent_data_source`'s `managed_knowledge_base_connector_configuration.deletion_protection_configuration.deletion_protection_threshold` was declared `Optional` only. When left unset, AWS returns a server-side default of `15`, but the provider had no way to reconcile that against the unset config, so every `terraform plan` after apply showed a perpetual `15 -> null` diff.

Marked the attribute `Computed` with a `UseStateForUnknown` plan modifier, the pattern already used elsewhere in this provider for server-side defaults.

While reviewing, found the same issue in `Update`: it discarded the post-update API response instead of re-flattening it into state, so the same perpetual diff could reappear after any update. Fixed identically.

Added an update-path regression step alongside the existing create-path `ImportStateVerify` coverage in `testAccDataSource_managedKBConnector_mediaExtraction`.

### Relations

Closes #49959

### References

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccBedrockAgent_serial/DataSource/managedKBConnectorMediaExtraction PKG=bedrockagent

Not run locally due to environment constraints (Windows toolchain/network limitations). Verified the fix compiles cleanly (go build, go vet, gofmt) and follows the same Computed + UseStateForUnknown pattern already used elsewhere in this provider. Happy for a maintainer to trigger /test to confirm.